### PR TITLE
Automated Changelog Entry for 0.1.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,21 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter-scheduler/compare/4dab98695d7251ae61bd224c18609efe9b6daf44...40d15d9fc3a4e7ea5d6e594c662a61a1ac4a43f7))
+
+### Merged PRs
+
+- Fix for tbump [#8](https://github.com/jupyter-server/jupyter-scheduler/pull/8) ([@3coins](https://github.com/3coins))
+- Fix for CI [#7](https://github.com/jupyter-server/jupyter-scheduler/pull/7) ([@3coins](https://github.com/3coins))
+- Added UI extension code, updated name for npm dist [#6](https://github.com/jupyter-server/jupyter-scheduler/pull/6) ([@3coins](https://github.com/3coins))
+- Added API tests, updated namespace [#2](https://github.com/jupyter-server/jupyter-scheduler/pull/2) ([@3coins](https://github.com/3coins))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter-scheduler/graphs/contributors?from=2022-09-10&to=2022-09-15&type=c))
+
+[@3coins](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3A3coins+updated%3A2022-09-10..2022-09-15&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Awelcome+updated%3A2022-09-10..2022-09-15&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyter-server/jupyter-scheduler/releases/tag/untagged-848e97c72a1e67430bda  |
