### PR TITLE
Fix params picker when zero params exist

### DIFF
--- a/src/components/parameters-picker.tsx
+++ b/src/components/parameters-picker.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent } from 'react';
 
 import { addIcon, closeIcon, LabIcon } from '@jupyterlab/ui-components';
 
@@ -21,68 +21,27 @@ export type ParametersPickerProps = {
   formPrefix: string;
 };
 
-export function parameterNameMatch(elementName: string): number | null {
-  const parameterNameMatch = elementName.match(/^parameter-(\d+)-name$/);
-
-  if (parameterNameMatch === null) {
-    return null;
-  }
-
-  return parseInt(parameterNameMatch[1]);
-}
-
-export function parameterValueMatch(elementName: string): number | null {
-  const parameterValueMatch = elementName.match(/^parameter-(\d+)-value$/);
-
-  if (parameterValueMatch === null) {
-    return null;
-  }
-
-  return parseInt(parameterValueMatch[1]);
-}
-
 export function ParametersPicker(props: ParametersPickerProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
-
-  // Keep an internal state of parameters to prevent the cursor from jumping to the end
-  // of text boxes after the model updates.
-  const [parameters, setParameters] = useState<IJobParameter[]>(props.value);
-
-  const changeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const target = event.target;
-
-    // Update the local state.
-    const newParams = parameters || [];
-    const parameterNameIdx = parameterNameMatch(target.name);
-    const parameterValueIdx = parameterValueMatch(target.name);
-    if (parameterNameIdx !== null) {
-      newParams[parameterNameIdx].name = target.value;
-    } else if (parameterValueIdx !== null) {
-      newParams[parameterValueIdx].value = target.value;
-    }
-    setParameters(newParams);
-
-    props.onChange(event);
-  };
 
   return (
     <Stack spacing={2}>
       <InputLabel>{props.label}</InputLabel>
-      {parameters.map((param, paramIdx) => (
+      {props.value.map((param, paramIdx) => (
         <Cluster key={paramIdx} justifyContent="flex-start">
           <TextField
             name={`parameter-${paramIdx}-name`}
             value={param.name}
             type="text"
             placeholder={trans.__('Name')}
-            onChange={changeHandler}
+            onChange={props.onChange}
           />
           <TextField
             name={`parameter-${paramIdx}-value`}
             value={param.value}
             type="text"
             placeholder={trans.__('Value')}
-            onChange={changeHandler}
+            onChange={props.onChange}
           />
           <IconButton
             aria-label="delete"

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -3,7 +3,7 @@ import React, { ChangeEvent } from 'react';
 import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
 import { OutputFormatPicker, outputFormatsForEnvironment } from '../components/output-format-picker';
-import { parameterNameMatch, ParametersPicker, parameterValueMatch } from '../components/parameters-picker';
+import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
 import { ICreateJobModel, IOutputFormat } from '../model';
@@ -21,6 +21,26 @@ export interface ICreateJobProps {
   toggleView: () => unknown;
   // Extension point: optional additional component
   advancedOptions: React.ElementType;
+}
+
+function parameterNameMatch(elementName: string): number | null {
+  const parameterNameMatch = elementName.match(/^parameter-(\d+)-name$/);
+
+  if (parameterNameMatch === null) {
+    return null;
+  }
+
+  return parseInt(parameterNameMatch[1]);
+}
+
+function parameterValueMatch(elementName: string): number | null {
+  const parameterValueMatch = elementName.match(/^parameter-(\d+)-value$/);
+
+  if (parameterValueMatch === null) {
+    return null;
+  }
+
+  return parseInt(parameterValueMatch[1]);
 }
 
 export function CreateJob(props: ICreateJobProps): JSX.Element {


### PR DESCRIPTION
Remove the locally-cached parameters (intended to fix #34) from parameters picker. Fixes "add" button when zero params exist.

Verified by testing add/remove buttons, submitting job