### PR TITLE
Add full-widget-sized job detail view

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -42,6 +42,22 @@ export class SchedulerService {
     return data as Scheduler.IDescribeJobDefinition;
   }
 
+  async getJob(job_id: string): Promise<Scheduler.IDescribeJob> {
+    let data;
+    let query = '';
+
+    query = `/${job_id}`;
+
+    try {
+      data = await requestAPI(this.serverSettings, `jobs${query}`, {
+        method: 'GET'
+      });
+    } catch (e: any) {
+      console.error(e);
+    }
+    return data as Scheduler.IDescribeJob;
+  }
+
   async getJobs(
     jobQuery: Scheduler.IListJobsQuery,
     job_id?: string

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -1,13 +1,219 @@
-import React from 'react';
-
-import { IJobDetailModel, JobsView } from '../model';
+import React, { useState } from 'react';
+import {
+  ICreateJobModel,
+  IJobDetailModel,
+  IJobParameter,
+  JobsView
+} from '../model';
+import Box from '@mui/material/Box';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import Accordion from '@mui/material/Accordion';
+import {
+  AccordionDetails,
+  AccordionSummary,
+  CircularProgress,
+  OutlinedInputProps,
+  TextField,
+  Typography
+} from '@mui/material';
+import { caretDownIcon } from '@jupyterlab/ui-components';
+import { useTranslator } from '../hooks';
+import { Heading } from '../components/heading';
 
 export interface IJobDetailProps {
   model: IJobDetailModel;
   modelChanged: (model: IJobDetailModel) => void;
+  //remove optional below in setCreateModel
+  setCreateModel?: (createModel: ICreateJobModel) => void;
   setView: (view: JobsView) => void;
 }
 
+interface ITextFieldStyledProps {
+  label: string;
+  defaultValue?: string;
+  InputProps?: Partial<OutlinedInputProps> | undefined;
+}
+
 export function JobDetail(props: IJobDetailProps): JSX.Element {
-  return <h1>Hi there!</h1>;
+  const [loading, setLoading] = useState(false);
+  const [running, setRunning] = useState(true);
+
+  const trans = useTranslator('jupyterlab');
+
+  //const ss = new SchedulerService({});
+  //const job = ss.getJobDefinitions(props.model.jobId):
+  // Take props.jobId, make REST API request to get IJobDetailsModel with all of the job information
+  // To rerun job:
+  // 1) Call props.setCreateModel(<current model for this job>)
+  // 2) Call props.setView('CreateJob')
+
+  const prop = {
+    jobId: 'job-12'
+  };
+
+  const advancedOptions: IJobParameter[] = [
+    { name: 'option 1', value: 'hello' },
+    { name: 'option 2', value: 'value 2' }
+  ];
+
+  const basicOptions: ICreateJobModel = {
+    jobName: 'my job',
+    inputFile: 'foobar',
+    outputPath: 'foobar.jptr',
+    environment: 'conda3',
+    parameters: advancedOptions,
+    outputFormats: [{ name: 'hello', label: 'label' }]
+  };
+
+  function TextFieldStyled(props: ITextFieldStyledProps) {
+    return (
+      <TextField
+        {...props}
+        label={props.label}
+        defaultValue={props.defaultValue}
+        size="small"
+        variant="outlined"
+      />
+    );
+  }
+
+  function MainArea() {
+    if (loading) {
+      return (
+        <Stack direction="row" justifyContent="center">
+          <CircularProgress />
+        </Stack>
+      );
+    } else {
+      return (
+        <>
+          <Stack direction="row" spacing={1} justifyContent="flex-end">
+            {running && (
+              <Button
+                variant="contained"
+                size="small"
+                onClick={_ => setRunning(!running)}
+              >
+                {trans.__('Stop Job')}
+              </Button>
+            )}
+            <Button
+              variant="contained"
+              size="small"
+              onClick={_ => setRunning(!running)}
+            >
+              {trans.__('Rerun Job')}
+            </Button>
+            <Button variant="contained" size="small">
+              {trans.__('Delete Job')}
+            </Button>
+          </Stack>
+          <Stack spacing={4}>
+            <TextFieldStyled
+              label={trans.__('Job name')}
+              defaultValue={basicOptions.jobName}
+              InputProps={{
+                readOnly: true
+              }}
+            />
+            <TextFieldStyled
+              label={trans.__('Input file')}
+              defaultValue={basicOptions.inputFile}
+              InputProps={{
+                readOnly: true
+              }}
+            />
+            <TextFieldStyled
+              label={trans.__('Output path')}
+              defaultValue={basicOptions.outputPath}
+              InputProps={{
+                readOnly: true
+              }}
+            />
+            <TextFieldStyled
+              label={trans.__('Environment')}
+              defaultValue={basicOptions.environment}
+              InputProps={{
+                readOnly: true
+              }}
+            />
+            <TextFieldStyled
+              label={trans.__('Job name')}
+              defaultValue={basicOptions.jobName}
+              InputProps={{
+                readOnly: true
+              }}
+            />
+          </Stack>
+
+          <Accordion
+            defaultExpanded={advancedOptions.length > 0}
+            disabled={advancedOptions.length === 0}
+          >
+            <AccordionSummary
+              expandIcon={<caretDownIcon.react />}
+              aria-controls="panel-content"
+              id="panel-header"
+            >
+              Advanced options
+            </AccordionSummary>
+            <AccordionDetails id="panel-content">
+              <Stack component="form" spacing={4}>
+                {advancedOptions.length > 0 &&
+                  advancedOptions.map((option, idx) => (
+                    <Stack key={idx} direction="row" spacing={1}>
+                      <TextFieldStyled
+                        label={trans.__('Name')}
+                        defaultValue={option.name}
+                        InputProps={{
+                          readOnly: true
+                        }}
+                      />
+                      <TextFieldStyled
+                        label={trans.__('Value')}
+                        defaultValue={option.value}
+                        InputProps={{
+                          readOnly: true
+                        }}
+                      />
+                    </Stack>
+                  ))}
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
+        </>
+      );
+    }
+  }
+
+  return (
+    <>
+      <Button onClick={_ => setLoading(!loading)}> Toggle loading </Button>
+      <Box sx={{ maxWidth: '500px', p: 4 }}>
+        <Stack spacing={4}>
+          <div role="presentation">
+            <Breadcrumbs aria-label="breadcrumb">
+              <Link
+                underline="hover"
+                color="inherit"
+                onClick={(
+                  _:
+                    | React.MouseEvent<HTMLAnchorElement, MouseEvent>
+                    | React.MouseEvent<HTMLSpanElement, MouseEvent>
+                ): void => props.setView('ListJobs')}
+              >
+                {trans.__('Notebook Jobs')}
+              </Link>
+              <Typography color="text.primary">{prop.jobId}</Typography>
+            </Breadcrumbs>
+          </div>
+          <Heading level={1}>{trans.__('Job Detail')}</Heading>
+          <MainArea />
+        </Stack>
+      </Box>
+    </>
+  );
 }

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -27,12 +27,12 @@ import {
 import { caretDownIcon } from '@jupyterlab/ui-components';
 import { useTranslator } from '../hooks';
 import { Heading } from '../components/heading';
+import { SchedulerService } from '../handler';
 
 export interface IJobDetailProps {
   model: IJobDetailModel;
   modelChanged: (model: IJobDetailModel) => void;
-  //remove optional below in setCreateModel
-  setCreateModel?: (createModel: ICreateJobModel) => void;
+  setCreateJobModel: (createModel: ICreateJobModel) => void;
   setView: (view: JobsView) => void;
 }
 
@@ -48,7 +48,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   const trans = useTranslator('jupyterlab');
 
-  //const ss = new SchedulerService({});
+  const ss = new SchedulerService({});
   //const job = ss.getJobDefinitions(props.model.jobId):
   // Take props.jobId, make REST API request to get IJobDetailsModel with all of the job information
   // To rerun job:

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -152,7 +152,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 <FormLabel component="legend">
                   {trans.__('Output formats')}
                 </FormLabel>
-                <FormGroup>
+                <FormGroup style={{ display: 'flex', flexDirection: 'row' }}>
                   {job?.output_formats.map((format, idx) => (
                     <FormControlLabel
                       key={idx}

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -43,15 +43,12 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   const [loading, setLoading] = useState(true);
   const [job, setJob] = useState<Scheduler.IDescribeJob | undefined>(undefined);
 
-  //TO DELETE
-  const prop = { model: { jobId: '3f062962-1e3e-442b-8454-e76af250da39' } };
-
   const trans = useTranslator('jupyterlab');
 
   const ss = new SchedulerService({});
 
   const getJobDefinion = async () => {
-    const jobDefinition = await ss.getJob(prop.model.jobId);
+    const jobDefinition = await ss.getJob(props.model.jobId);
     setJob(jobDefinition);
     setLoading(false);
   };
@@ -107,6 +104,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
         label={props.label}
         defaultValue={props.defaultValue}
         variant="outlined"
+        disabled
       />
     );
   }
@@ -138,37 +136,22 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             <TextFieldStyled
               label={trans.__('Job name')}
               defaultValue={job?.name ?? ''}
-              InputProps={{
-                readOnly: true
-              }}
             />
             <TextFieldStyled
               label={trans.__('Input file')}
               defaultValue={job?.input_uri ?? ''}
-              InputProps={{
-                readOnly: true
-              }}
             />
             <TextFieldStyled
               label={trans.__('Output path')}
               defaultValue={job?.output_uri ?? ''}
-              InputProps={{
-                readOnly: true
-              }}
             />
             <TextFieldStyled
               label={trans.__('Environment')}
               defaultValue={job?.runtime_environment_name ?? ''}
-              InputProps={{
-                readOnly: true
-              }}
             />
             <TextFieldStyled
               label={trans.__('status')}
               defaultValue={job?.status ?? ''}
-              InputProps={{
-                readOnly: true
-              }}
             />
 
             <FormControl component="fieldset">
@@ -212,9 +195,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                         <TextFieldStyled
                           label={trans.__('Value')}
                           defaultValue={value}
-                          InputProps={{
-                            readOnly: true
-                          }}
                         />
                       </Stack>
                     )
@@ -239,23 +219,14 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 <TextFieldStyled
                   label={trans.__('Output Prefix')}
                   defaultValue={job?.output_prefix ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('Idempotency Token')}
                   defaultValue={job?.idempotency_token ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('Job Definition Id')}
                   defaultValue={job?.job_definition_id ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <FormLabel component="legend">{trans.__('Tags')}</FormLabel>
                 {job?.tags &&
@@ -274,75 +245,45 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 <TextFieldStyled
                   label={trans.__('Job Definition Id')}
                   defaultValue={job?.timeout_seconds?.toString() ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('max_retries')}
                   defaultValue={job?.max_retries?.toString() ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('min_retry_interval_millis')}
                   defaultValue={
                     job?.min_retry_interval_millis?.toString() ?? ''
                   }
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('retry_on_timeout')}
                   defaultValue={job?.retry_on_timeout?.toString() ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('start_time')}
                   defaultValue={job?.start_time?.toString() ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('output_filename_template')}
                   defaultValue={job?.output_filename_template ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
 
                 <TextFieldStyled
                   label={trans.__('url')}
                   defaultValue={job?.url ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('status_message')}
                   defaultValue={job?.status_message ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('start_time')}
                   defaultValue={job?.start_time?.toString() ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
                 <TextFieldStyled
                   label={trans.__('end_time')}
                   defaultValue={job?.end_time?.toString() ?? ''}
-                  InputProps={{
-                    readOnly: true
-                  }}
                 />
               </Stack>
             </AccordionDetails>
@@ -386,7 +327,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               >
                 {trans.__('Notebook Jobs')}
               </Link>
-              <Typography color="text.primary">{prop.model.jobId}</Typography>
+              <Typography color="text.primary">{props.model.jobId}</Typography>
             </Breadcrumbs>
           </div>
           <Heading level={1}>{trans.__('Job Detail')}</Heading>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -27,7 +27,7 @@ import {
 import { caretDownIcon } from '@jupyterlab/ui-components';
 import { useTranslator } from '../hooks';
 import { Heading } from '../components/heading';
-import { Scheduler, SchedulerService } from '../handler'; 
+import { Scheduler, SchedulerService } from '../handler';
 
 export interface IJobDetailProps {
   model: IJobDetailModel;
@@ -48,7 +48,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   const [job, setJob] = useState<Scheduler.IDescribeJob | undefined>(undefined);
 
   //TO DELETE
-  const prop = { model: { jobId: 'd5bb0c08-d000-4be8-ba0f-25623f9effbd' } };
+  const prop = { model: { jobId: '3f062962-1e3e-442b-8454-e76af250da39' } };
 
   const trans = useTranslator('jupyterlab');
 
@@ -82,18 +82,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     { name: 'option 2', value: 'value 2' }
   ];
 
-  const basicOptions: ICreateJobModel = {
-    jobName: 'my job',
-    inputFile: 'foobar',
-    outputPath: 'foobar.jptr',
-    environment: 'conda3',
-    parameters: advancedOptions,
-    outputFormats: [
-      { name: 'hello', label: 'label' },
-      { name: 'hello 2', label: 'label 2' }
-    ]
-  };
-
   function TextFieldStyled(props: ITextFieldStyledProps) {
     return (
       <TextField
@@ -109,10 +97,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     if (loading) {
       return (
         <Stack direction="row" justifyContent="center">
-          <Stack alignItems="center">
-            <span>{trans.__('Loading')}...</span>
-            <CircularProgress />
-          </Stack>
+          <CircularProgress title={trans.__('Loading')} />
         </Stack>
       );
     } else {
@@ -134,44 +119,44 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
           <Stack spacing={4}>
             <TextFieldStyled
               label={trans.__('Job name')}
-              defaultValue={basicOptions.jobName}
+              defaultValue={job?.name ?? ''}
               InputProps={{
                 readOnly: true
               }}
             />
             <TextFieldStyled
               label={trans.__('Input file')}
-              defaultValue={basicOptions.inputFile}
+              defaultValue={job?.input_uri ?? ''}
               InputProps={{
                 readOnly: true
               }}
             />
             <TextFieldStyled
               label={trans.__('Output path')}
-              defaultValue={basicOptions.outputPath}
+              defaultValue={job?.output_uri ?? ''}
               InputProps={{
                 readOnly: true
               }}
             />
             <TextFieldStyled
               label={trans.__('Environment')}
-              defaultValue={basicOptions.environment}
+              defaultValue={job?.runtime_environment_name ?? ''}
               InputProps={{
                 readOnly: true
               }}
             />
 
-            {basicOptions.outputFormats && (
+            {job?.output_formats && (
               <FormControl component="fieldset">
                 <FormLabel component="legend">
-                  {trans.__('Output format')}
+                  {trans.__('Output formats')}
                 </FormLabel>
                 <FormGroup>
-                  {basicOptions.outputFormats.map((option, idx) => (
+                  {job?.output_formats.map((format, idx) => (
                     <FormControlLabel
                       key={idx}
                       control={<Checkbox checked={true} defaultChecked />}
-                      label={option.label}
+                      label={format}
                     />
                   ))}
                 </FormGroup>
@@ -220,8 +205,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   return (
     <>
-      <Button onClick={_ => setLoading(!loading)}> Toggle loading </Button>
-      <Button onClick={_ => getJobDefinion()}>Fetch job definition</Button>
       <Box sx={{ maxWidth: '500px', p: 4 }}>
         <Stack spacing={4}>
           <div role="presentation">

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -93,6 +93,18 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     getJobDefinion();
   };
 
+  const timestampLocalize = (time: number | '') => {
+    if (time === '') {
+      return '';
+    } else {
+      const display_date = new Date(time);
+      const local_display_date = display_date
+        ? display_date.toLocaleString()
+        : '';
+      return local_display_date;
+    }
+  };
+
   useEffect(() => {
     getJobDefinion();
   }, []);
@@ -275,11 +287,11 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 />
                 <TextFieldStyled
                   label={trans.__('Start time')}
-                  defaultValue={job?.start_time?.toString() ?? ''}
+                  defaultValue={timestampLocalize(job?.start_time ?? '')}
                 />
                 <TextFieldStyled
                   label={trans.__('End time')}
-                  defaultValue={job?.end_time?.toString() ?? ''}
+                  defaultValue={timestampLocalize(job?.end_time ?? '')}
                 />
               </Stack>
             </AccordionDetails>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -23,8 +23,10 @@ import { caretDownIcon } from '@jupyterlab/ui-components';
 import { useTranslator } from '../hooks';
 import { Heading } from '../components/heading';
 import { Scheduler, SchedulerService } from '../handler';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 
 export interface IJobDetailProps {
+  app: JupyterFrontEnd;
   model: IJobDetailModel;
   modelChanged: (model: IJobDetailModel) => void;
   setCreateJobModel: (createModel: ICreateJobModel) => void;
@@ -87,6 +89,13 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     props.setView('ListJobs');
   };
 
+  const handleStopJob = async () => {
+    props.app.commands.execute('scheduling:stop-job', {
+      id: job?.job_id
+    });
+    getJobDefinion();
+  };
+
   useEffect(() => {
     getJobDefinion();
   }, []);
@@ -115,6 +124,11 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       return (
         <>
           <Stack direction="row" spacing={1} justifyContent="flex-end">
+            {job?.status === 'IN_PROGRESS' && (
+              <Button variant="outlined" onClick={handleStopJob}>
+                {trans.__('Stop Job')}
+              </Button>
+            )}
             <Button variant="outlined" onClick={rerunJob}>
               {trans.__('Rerun Job')}
             </Button>
@@ -152,8 +166,8 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               }}
             />
             <TextFieldStyled
-              label={trans.__('status_message')}
-              defaultValue={job?.status_message ?? ''}
+              label={trans.__('status')}
+              defaultValue={job?.status ?? ''}
               InputProps={{
                 readOnly: true
               }}
@@ -312,8 +326,8 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   }}
                 />
                 <TextFieldStyled
-                  label={trans.__('status')}
-                  defaultValue={job?.status ?? ''}
+                  label={trans.__('status_message')}
+                  defaultValue={job?.status_message ?? ''}
                   InputProps={{
                     readOnly: true
                   }}

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  ICreateJobModel,
-  IJobDetailModel,
-  IJobParameter,
-  JobsView
-} from '../model';
+import { ICreateJobModel, IJobDetailModel, JobsView } from '../model';
 import Box from '@mui/material/Box';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Link from '@mui/material/Link';
@@ -43,8 +38,7 @@ interface ITextFieldStyledProps {
 }
 
 export function JobDetail(props: IJobDetailProps): JSX.Element {
-  const [loading, setLoading] = useState(false);
-  const [running, setRunning] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [job, setJob] = useState<Scheduler.IDescribeJob | undefined>(undefined);
 
   //TO DELETE
@@ -56,11 +50,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   const getJobDefinion = async () => {
     const jobDefinition = await ss.getJob(prop.model.jobId);
-    console.log('fetched job');
-    console.log(jobDefinition);
     setJob(jobDefinition);
-    console.log('state job');
-    console.log(job);
     setLoading(false);
   };
 
@@ -68,19 +58,12 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     getJobDefinion();
   }, []);
 
-  //const job = ss.getJobDefinitions(props.model.jobId);
-
   console.log(`jobId from props: ${props.model.jobId}`);
   //console.log(`jobDefinition in the body: ${jobDefinition}`);
   // Take props.jobId, make REST API request to get IJobDetailsModel with all of the job information
   // To rerun job:
   // 1) Call props.setCreateModel(<current model for this job>)
   // 2) Call props.setView('CreateJob')
-
-  const advancedOptions: IJobParameter[] = [
-    { name: 'option 1', value: 'hello' },
-    { name: 'option 2', value: 'value 2' }
-  ];
 
   function TextFieldStyled(props: ITextFieldStyledProps) {
     return (
@@ -104,14 +87,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       return (
         <>
           <Stack direction="row" spacing={1} justifyContent="flex-end">
-            {running && (
-              <Button variant="outlined" onClick={_ => setRunning(!running)}>
-                {trans.__('Stop Job')}
-              </Button>
-            )}
-            <Button variant="outlined" onClick={_ => setRunning(!running)}>
-              {trans.__('Rerun Job')}
-            </Button>
+            <Button variant="outlined">{trans.__('Rerun Job')}</Button>
             <Button variant="contained" color="error">
               {trans.__('Delete Job')}
             </Button>
@@ -193,10 +169,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             )}
           </Stack>
 
-          <Accordion
-            defaultExpanded={advancedOptions.length > 0}
-            disabled={advancedOptions.length === 0}
-          >
+          <Accordion defaultExpanded={true}>
             <AccordionSummary
               expandIcon={<caretDownIcon.react />}
               aria-controls="panel-content"
@@ -206,7 +179,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             </AccordionSummary>
             <AccordionDetails id="panel-content">
               <Stack component="form" spacing={4}>
-                "Placeholder"
+                Placeholder
               </Stack>
             </AccordionDetails>
           </Accordion>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -150,7 +150,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               defaultValue={job?.runtime_environment_name ?? ''}
             />
             <TextFieldStyled
-              label={trans.__('status')}
+              label={trans.__('Status')}
               defaultValue={job?.status ?? ''}
             />
 

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -181,26 +181,28 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 </FormLabel>
               </AccordionSummary>
               <AccordionDetails id="panel-content">
-                {Object.entries(job?.parameters ?? {}).map(
-                  ([parameter, value]) => (
-                    <Stack key={parameter} direction="row" spacing={1}>
-                      <TextFieldStyled
-                        label={trans.__('Parameter')}
-                        defaultValue={parameter}
-                        InputProps={{
-                          readOnly: true
-                        }}
-                      />
-                      <TextFieldStyled
-                        label={trans.__('Value')}
-                        defaultValue={value}
-                        InputProps={{
-                          readOnly: true
-                        }}
-                      />
-                    </Stack>
-                  )
-                )}
+                <Stack spacing={4}>
+                  {Object.entries(job?.parameters ?? {}).map(
+                    ([parameter, value]) => (
+                      <Stack key={parameter} direction="row" spacing={1}>
+                        <TextFieldStyled
+                          label={trans.__('Parameter')}
+                          defaultValue={parameter}
+                          InputProps={{
+                            readOnly: true
+                          }}
+                        />
+                        <TextFieldStyled
+                          label={trans.__('Value')}
+                          defaultValue={value}
+                          InputProps={{
+                            readOnly: true
+                          }}
+                        />
+                      </Stack>
+                    )
+                  )}
+                </Stack>
               </AccordionDetails>
             </Accordion>
           </Stack>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -261,7 +261,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.retry_on_timeout?.toString() ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('start_time')}
+                  label={trans.__('Start time')}
                   defaultValue={job?.start_time?.toString() ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -162,6 +162,35 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 </FormGroup>
               </FormControl>
             )}
+
+            {job?.parameters && (
+              <>
+                <FormLabel component="legend">
+                  {trans.__('Parameters')}
+                </FormLabel>
+
+                {Object.entries(job?.parameters ?? {}).map(
+                  ([parameter, value]) => (
+                    <Stack key={parameter} direction="row" spacing={1}>
+                      <TextFieldStyled
+                        label={trans.__('Parameter')}
+                        defaultValue={parameter}
+                        InputProps={{
+                          readOnly: true
+                        }}
+                      />
+                      <TextFieldStyled
+                        label={trans.__('Value')}
+                        defaultValue={value}
+                        InputProps={{
+                          readOnly: true
+                        }}
+                      />
+                    </Stack>
+                  )
+                )}
+              </>
+            )}
           </Stack>
 
           <Accordion
@@ -177,24 +206,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             </AccordionSummary>
             <AccordionDetails id="panel-content">
               <Stack component="form" spacing={4}>
-                {advancedOptions.map((option, idx) => (
-                  <Stack key={idx} direction="row" spacing={1}>
-                    <TextFieldStyled
-                      label={trans.__('Name')}
-                      defaultValue={option.name}
-                      InputProps={{
-                        readOnly: true
-                      }}
-                    />
-                    <TextFieldStyled
-                      label={trans.__('Value')}
-                      defaultValue={option.value}
-                      InputProps={{
-                        readOnly: true
-                      }}
-                    />
-                  </Stack>
-                ))}
+                "Placeholder"
               </Stack>
             </AccordionDetails>
           </Accordion>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -147,51 +147,46 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               }}
             />
 
-            {job?.output_formats && (
-              <FormControl component="fieldset">
-                <FormLabel component="legend">
-                  {trans.__('Output formats')}
-                </FormLabel>
-                <FormGroup style={{ display: 'flex', flexDirection: 'row' }}>
-                  {job?.output_formats.map(format => (
+            <FormControl component="fieldset">
+              <FormLabel component="legend">
+                {trans.__('Output formats')}
+              </FormLabel>
+              <FormGroup style={{ display: 'flex', flexDirection: 'row' }}>
+                {job?.output_formats &&
+                  job?.output_formats.map(format => (
                     <FormControlLabel
                       key={format}
                       control={<Checkbox checked={true} defaultChecked />}
                       label={format}
                     />
                   ))}
-                </FormGroup>
-              </FormControl>
-            )}
+              </FormGroup>
+            </FormControl>
 
-            {job?.parameters && (
-              <>
-                <FormLabel component="legend">
-                  {trans.__('Parameters')}
-                </FormLabel>
+            <>
+              <FormLabel component="legend">{trans.__('Parameters')}</FormLabel>
 
-                {Object.entries(job?.parameters ?? {}).map(
-                  ([parameter, value]) => (
-                    <Stack key={parameter} direction="row" spacing={1}>
-                      <TextFieldStyled
-                        label={trans.__('Parameter')}
-                        defaultValue={parameter}
-                        InputProps={{
-                          readOnly: true
-                        }}
-                      />
-                      <TextFieldStyled
-                        label={trans.__('Value')}
-                        defaultValue={value}
-                        InputProps={{
-                          readOnly: true
-                        }}
-                      />
-                    </Stack>
-                  )
-                )}
-              </>
-            )}
+              {Object.entries(job?.parameters ?? {}).map(
+                ([parameter, value]) => (
+                  <Stack key={parameter} direction="row" spacing={1}>
+                    <TextFieldStyled
+                      label={trans.__('Parameter')}
+                      defaultValue={parameter}
+                      InputProps={{
+                        readOnly: true
+                      }}
+                    />
+                    <TextFieldStyled
+                      label={trans.__('Value')}
+                      defaultValue={value}
+                      InputProps={{
+                        readOnly: true
+                      }}
+                    />
+                  </Stack>
+                )
+              )}
+            </>
           </Stack>
 
           <Accordion defaultExpanded={true}>
@@ -200,7 +195,44 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               aria-controls="panel-content"
               id="panel-header"
             >
-              Advanced options
+              {trans.__('Additional options')}
+            </AccordionSummary>
+            <AccordionDetails id="panel-content">
+              <Stack spacing={4}>
+                <TextFieldStyled
+                  label={trans.__('Output Prefix')}
+                  defaultValue={job?.output_prefix ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('Output Prefix')}
+                  defaultValue={job?.idempotency_token ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('Output Prefix')}
+                  defaultValue={job?.job_definition_id ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
+
+          <Accordion defaultExpanded={true}>
+            <AccordionSummary
+              expandIcon={<caretDownIcon.react />}
+              aria-controls="panel-content"
+              id="panel-header"
+            >
+              <FormLabel component="legend">
+                {trans.__('Advanced options')}
+              </FormLabel>
             </AccordionSummary>
             <AccordionDetails id="panel-content">
               <Stack component="form" spacing={4}>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -229,16 +229,8 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             <AccordionDetails id="panel-content">
               <Stack spacing={4}>
                 <TextFieldStyled
-                  label={trans.__('Output prefix')}
-                  defaultValue={job?.output_prefix ?? ''}
-                />
-                <TextFieldStyled
                   label={trans.__('Idempotency token')}
                   defaultValue={job?.idempotency_token ?? ''}
-                />
-                <TextFieldStyled
-                  label={trans.__('Job definition ID')}
-                  defaultValue={job?.job_definition_id ?? ''}
                 />
                 <FormLabel component="legend">{trans.__('Tags')}</FormLabel>
                 {job?.tags &&
@@ -251,40 +243,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                       }}
                     />
                   ))}
-                <FormLabel component="legend">
-                  {trans.__('Email notifications')}
-                </FormLabel>
-                <TextFieldStyled
-                  label={trans.__('Job definition ID')}
-                  defaultValue={job?.timeout_seconds?.toString() ?? ''}
-                />
-                <TextFieldStyled
-                  label={trans.__('Maximum retries')}
-                  defaultValue={job?.max_retries?.toString() ?? ''}
-                />
-                <TextFieldStyled
-                  label={trans.__('Minimum retry interval (millisecond)')}
-                  defaultValue={
-                    job?.min_retry_interval_millis?.toString() ?? ''
-                  }
-                />
-                <TextFieldStyled
-                  label={trans.__('Retry on timeout')}
-                  defaultValue={job?.retry_on_timeout?.toString() ?? ''}
-                />
-                <TextFieldStyled
-                  label={trans.__('Output filename template')}
-                  defaultValue={job?.output_filename_template ?? ''}
-                />
-
-                <TextFieldStyled
-                  label={trans.__('URL')}
-                  defaultValue={job?.url ?? ''}
-                />
-                <TextFieldStyled
-                  label={trans.__('Status message')}
-                  defaultValue={job?.status_message ?? ''}
-                />
                 <TextFieldStyled
                   label={trans.__('Start time')}
                   defaultValue={timestampLocalize(job?.start_time ?? '')}

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -27,7 +27,7 @@ import {
 import { caretDownIcon } from '@jupyterlab/ui-components';
 import { useTranslator } from '../hooks';
 import { Heading } from '../components/heading';
-import { SchedulerService, Scheduler } from '../handler';
+import { SchedulerService } from '../handler';
 
 export interface IJobDetailProps {
   model: IJobDetailModel;
@@ -45,30 +45,29 @@ interface ITextFieldStyledProps {
 export function JobDetail(props: IJobDetailProps): JSX.Element {
   const [loading, setLoading] = useState(false);
   const [running, setRunning] = useState(false);
-  const [jobDefinition, setJobDefinition] = useState<
-    Scheduler.IDescribeJobDefinition[] | undefined
-  >(undefined);
 
   //TO DELETE
-  const prop = { model: { jobId: 'ee90bfac-a3e2-4ec5-ab0a-f897165c8c94' } };
+  const prop = { model: { jobId: '235877a5-3172-4e48-8832-ce880ffcfdd8' } };
 
   const trans = useTranslator('jupyterlab');
 
   const ss = new SchedulerService({});
+
+  const fetchJobDefinition = async () => {
+    const job = ss.getJob(prop.model.jobId);
+    job.then(job => {
+      console.log(job);
+    });
+  };
+
   useEffect(() => {
-    const fetchJobDefinition = async () => {
-      const job = await ss.getJobDefinitions(prop.model.jobId);
-      setJobDefinition(job);
-      console.log(`jobDefinition in the useEffect: ${jobDefinition}`);
-      //setLoading(false);
-    };
-    fetchJobDefinition();
+    console.log('element loaded');
   }, []);
 
   //const job = ss.getJobDefinitions(props.model.jobId);
 
   console.log(`jobId: ${props.model.jobId}`);
-  console.log(`jobDefinition in the body: ${jobDefinition}`);
+  //console.log(`jobDefinition in the body: ${jobDefinition}`);
   // Take props.jobId, make REST API request to get IJobDetailsModel with all of the job information
   // To rerun job:
   // 1) Call props.setCreateModel(<current model for this job>)
@@ -97,7 +96,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
         {...props}
         label={props.label}
         defaultValue={props.defaultValue}
-        size="small"
         variant="outlined"
       />
     );
@@ -115,22 +113,14 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
         <>
           <Stack direction="row" spacing={1} justifyContent="flex-end">
             {running && (
-              <Button
-                variant="contained"
-                size="small"
-                onClick={_ => setRunning(!running)}
-              >
+              <Button variant="outlined" onClick={_ => setRunning(!running)}>
                 {trans.__('Stop Job')}
               </Button>
             )}
-            <Button
-              variant="contained"
-              size="small"
-              onClick={_ => setRunning(!running)}
-            >
+            <Button variant="outlined" onClick={_ => setRunning(!running)}>
               {trans.__('Rerun Job')}
             </Button>
-            <Button variant="contained" size="small">
+            <Button variant="contained" color="error">
               {trans.__('Delete Job')}
             </Button>
           </Stack>
@@ -224,6 +214,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   return (
     <>
       <Button onClick={_ => setLoading(!loading)}> Toggle loading </Button>
+      <Button onClick={_ => fetchJobDefinition()}>Fetch job definition</Button>
       <Box sx={{ maxWidth: '500px', p: 4 }}>
         <Stack spacing={4}>
           <div role="presentation">

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -240,7 +240,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                     />
                   ))}
                 <FormLabel component="legend">
-                  {trans.__('Email Notifications')}
+                  {trans.__('Email notifications')}
                 </FormLabel>
                 <TextFieldStyled
                   label={trans.__('Job Definition Id')}

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -153,9 +153,9 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   {trans.__('Output formats')}
                 </FormLabel>
                 <FormGroup style={{ display: 'flex', flexDirection: 'row' }}>
-                  {job?.output_formats.map((format, idx) => (
+                  {job?.output_formats.map(format => (
                     <FormControlLabel
-                      key={idx}
+                      key={format}
                       control={<Checkbox checked={true} defaultChecked />}
                       label={format}
                     />

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -54,16 +54,39 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     setLoading(false);
   };
 
+  // Retrieve the key from the parameters list or return a parameter with a null value
+  const getParam = (key: string) => {
+    return {
+      name: key,
+      value: job?.parameters?.[key]
+    };
+  };
+
+  const rerunJob = () => {
+    const initialState: ICreateJobModel = {
+      inputFile: job?.input_uri ?? '',
+      jobName: job?.name ?? '',
+      outputPath: job?.output_uri ?? '',
+      environment: job?.runtime_environment_name ?? '',
+      parameters:
+        job?.parameters !== undefined
+          ? Object.keys(job.parameters).map(key => getParam(key))
+          : undefined,
+      outputFormats: job?.output_formats?.map(format => ({
+        name: format,
+        label: format
+      }))
+    };
+
+    props.setCreateJobModel(initialState);
+    props.setView('CreateJob');
+  };
+
   useEffect(() => {
     getJobDefinion();
   }, []);
 
   console.log(`jobId from props: ${props.model.jobId}`);
-  //console.log(`jobDefinition in the body: ${jobDefinition}`);
-  // Take props.jobId, make REST API request to get IJobDetailsModel with all of the job information
-  // To rerun job:
-  // 1) Call props.setCreateModel(<current model for this job>)
-  // 2) Call props.setView('CreateJob')
 
   function TextFieldStyled(props: ITextFieldStyledProps) {
     return (
@@ -87,7 +110,9 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       return (
         <>
           <Stack direction="row" spacing={1} justifyContent="flex-end">
-            <Button variant="outlined">{trans.__('Rerun Job')}</Button>
+            <Button variant="outlined" onClick={rerunJob}>
+              {trans.__('Rerun Job')}
+            </Button>
             <Button variant="contained" color="error">
               {trans.__('Delete Job')}
             </Button>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -265,7 +265,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.start_time?.toString() ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('output_filename_template')}
+                  label={trans.__('Output filename template')}
                   defaultValue={job?.output_filename_template ?? ''}
                 />
 

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -217,7 +217,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             <AccordionDetails id="panel-content">
               <Stack spacing={4}>
                 <TextFieldStyled
-                  label={trans.__('Output Prefix')}
+                  label={trans.__('Output prefix')}
                   defaultValue={job?.output_prefix ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -44,7 +44,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   const [job, setJob] = useState<Scheduler.IDescribeJob | undefined>(undefined);
 
   //TO DELETE
-  const prop = { model: { jobId: '3f062962-1e3e-442b-8454-e76af250da39' } };
+  const prop = { model: { jobId: '0d2779ad-3163-44b7-bc5b-da87adbaf90a' } };
 
   const trans = useTranslator('jupyterlab');
 
@@ -99,8 +99,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   useEffect(() => {
     getJobDefinion();
   }, []);
-
-  console.log(`jobId from props: ${props.model.jobId}`);
 
   function TextFieldStyled(props: ITextFieldStyledProps) {
     return (

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -14,7 +14,12 @@ import Accordion from '@mui/material/Accordion';
 import {
   AccordionDetails,
   AccordionSummary,
+  Checkbox,
   CircularProgress,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormLabel,
   OutlinedInputProps,
   TextField,
   Typography
@@ -65,7 +70,10 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     outputPath: 'foobar.jptr',
     environment: 'conda3',
     parameters: advancedOptions,
-    outputFormats: [{ name: 'hello', label: 'label' }]
+    outputFormats: [
+      { name: 'hello', label: 'label' },
+      { name: 'hello 2', label: 'label 2' }
+    ]
   };
 
   function TextFieldStyled(props: ITextFieldStyledProps) {
@@ -140,13 +148,23 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 readOnly: true
               }}
             />
-            <TextFieldStyled
-              label={trans.__('Job name')}
-              defaultValue={basicOptions.jobName}
-              InputProps={{
-                readOnly: true
-              }}
-            />
+
+            {basicOptions.outputFormats && (
+              <FormControl component="fieldset">
+                <FormLabel component="legend">
+                  {trans.__('Output format')}
+                </FormLabel>
+                <FormGroup>
+                  {basicOptions.outputFormats.map((option, idx) => (
+                    <FormControlLabel
+                      key={idx}
+                      control={<Checkbox checked={true} defaultChecked />}
+                      label={option.label}
+                    />
+                  ))}
+                </FormGroup>
+              </FormControl>
+            )}
           </Stack>
 
           <Accordion
@@ -162,25 +180,24 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             </AccordionSummary>
             <AccordionDetails id="panel-content">
               <Stack component="form" spacing={4}>
-                {advancedOptions.length > 0 &&
-                  advancedOptions.map((option, idx) => (
-                    <Stack key={idx} direction="row" spacing={1}>
-                      <TextFieldStyled
-                        label={trans.__('Name')}
-                        defaultValue={option.name}
-                        InputProps={{
-                          readOnly: true
-                        }}
-                      />
-                      <TextFieldStyled
-                        label={trans.__('Value')}
-                        defaultValue={option.value}
-                        InputProps={{
-                          readOnly: true
-                        }}
-                      />
-                    </Stack>
-                  ))}
+                {advancedOptions.map((option, idx) => (
+                  <Stack key={idx} direction="row" spacing={1}>
+                    <TextFieldStyled
+                      label={trans.__('Name')}
+                      defaultValue={option.name}
+                      InputProps={{
+                        readOnly: true
+                      }}
+                    />
+                    <TextFieldStyled
+                      label={trans.__('Value')}
+                      defaultValue={option.value}
+                      InputProps={{
+                        readOnly: true
+                      }}
+                    />
+                  </Stack>
+                ))}
               </Stack>
             </AccordionDetails>
           </Accordion>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -247,7 +247,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.timeout_seconds?.toString() ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('max_retries')}
+                  label={trans.__('Maximum retries')}
                   defaultValue={job?.max_retries?.toString() ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -82,6 +82,11 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     props.setView('CreateJob');
   };
 
+  const handleDeleteJob = async () => {
+    await ss.deleteJob(job?.job_id ?? '');
+    props.setView('ListJobs');
+  };
+
   useEffect(() => {
     getJobDefinion();
   }, []);
@@ -113,7 +118,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             <Button variant="outlined" onClick={rerunJob}>
               {trans.__('Rerun Job')}
             </Button>
-            <Button variant="contained" color="error">
+            <Button variant="contained" color="error" onClick={handleDeleteJob}>
               {trans.__('Delete Job')}
             </Button>
           </Stack>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -27,7 +27,7 @@ import {
 import { caretDownIcon } from '@jupyterlab/ui-components';
 import { useTranslator } from '../hooks';
 import { Heading } from '../components/heading';
-import { Scheduler, SchedulerService } from '../handler';
+import { Scheduler, SchedulerService } from '../handler'; 
 
 export interface IJobDetailProps {
   model: IJobDetailModel;
@@ -109,7 +109,10 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     if (loading) {
       return (
         <Stack direction="row" justifyContent="center">
-          <CircularProgress />
+          <Stack alignItems="center">
+            <span>{trans.__('Loading')}...</span>
+            <CircularProgress />
+          </Stack>
         </Stack>
       );
     } else {
@@ -217,6 +220,8 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   return (
     <>
+      <Button onClick={_ => setLoading(!loading)}> Toggle loading </Button>
+      <Button onClick={_ => getJobDefinion()}>Fetch job definition</Button>
       <Box sx={{ maxWidth: '500px', p: 4 }}>
         <Stack spacing={4}>
           <div role="presentation">

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -146,6 +146,13 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 readOnly: true
               }}
             />
+            <TextFieldStyled
+              label={trans.__('status_message')}
+              defaultValue={job?.status_message ?? ''}
+              InputProps={{
+                readOnly: true
+              }}
+            />
 
             <FormControl component="fieldset">
               <FormLabel component="legend">
@@ -163,30 +170,39 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               </FormGroup>
             </FormControl>
 
-            <>
-              <FormLabel component="legend">{trans.__('Parameters')}</FormLabel>
-
-              {Object.entries(job?.parameters ?? {}).map(
-                ([parameter, value]) => (
-                  <Stack key={parameter} direction="row" spacing={1}>
-                    <TextFieldStyled
-                      label={trans.__('Parameter')}
-                      defaultValue={parameter}
-                      InputProps={{
-                        readOnly: true
-                      }}
-                    />
-                    <TextFieldStyled
-                      label={trans.__('Value')}
-                      defaultValue={value}
-                      InputProps={{
-                        readOnly: true
-                      }}
-                    />
-                  </Stack>
-                )
-              )}
-            </>
+            <Accordion defaultExpanded={true}>
+              <AccordionSummary
+                expandIcon={<caretDownIcon.react />}
+                aria-controls="panel-content"
+                id="panel-header"
+              >
+                <FormLabel component="legend">
+                  {trans.__('Parameters')}
+                </FormLabel>
+              </AccordionSummary>
+              <AccordionDetails id="panel-content">
+                {Object.entries(job?.parameters ?? {}).map(
+                  ([parameter, value]) => (
+                    <Stack key={parameter} direction="row" spacing={1}>
+                      <TextFieldStyled
+                        label={trans.__('Parameter')}
+                        defaultValue={parameter}
+                        InputProps={{
+                          readOnly: true
+                        }}
+                      />
+                      <TextFieldStyled
+                        label={trans.__('Value')}
+                        defaultValue={value}
+                        InputProps={{
+                          readOnly: true
+                        }}
+                      />
+                    </Stack>
+                  )
+                )}
+              </AccordionDetails>
+            </Accordion>
           </Stack>
 
           <Accordion defaultExpanded={true}>
@@ -195,7 +211,9 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               aria-controls="panel-content"
               id="panel-header"
             >
-              {trans.__('Additional options')}
+              <FormLabel component="legend">
+                {trans.__('Additional options')}
+              </FormLabel>
             </AccordionSummary>
             <AccordionDetails id="panel-content">
               <Stack spacing={4}>
@@ -216,6 +234,93 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 <TextFieldStyled
                   label={trans.__('Job Definition Id')}
                   defaultValue={job?.job_definition_id ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <FormLabel component="legend">{trans.__('Tags')}</FormLabel>
+                {job?.tags &&
+                  job?.tags.map(tag => (
+                    <TextFieldStyled
+                      label={trans.__('Tag')}
+                      defaultValue={tag}
+                      InputProps={{
+                        readOnly: true
+                      }}
+                    />
+                  ))}
+                <FormLabel component="legend">
+                  {trans.__('Email Notifications')}
+                </FormLabel>
+                <TextFieldStyled
+                  label={trans.__('Job Definition Id')}
+                  defaultValue={job?.timeout_seconds?.toString() ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('max_retries')}
+                  defaultValue={job?.max_retries?.toString() ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('min_retry_interval_millis')}
+                  defaultValue={
+                    job?.min_retry_interval_millis?.toString() ?? ''
+                  }
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('retry_on_timeout')}
+                  defaultValue={job?.retry_on_timeout?.toString() ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('start_time')}
+                  defaultValue={job?.start_time?.toString() ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('output_filename_template')}
+                  defaultValue={job?.output_filename_template ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+
+                <TextFieldStyled
+                  label={trans.__('url')}
+                  defaultValue={job?.url ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('status')}
+                  defaultValue={job?.status ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('start_time')}
+                  defaultValue={job?.start_time?.toString() ?? ''}
+                  InputProps={{
+                    readOnly: true
+                  }}
+                />
+                <TextFieldStyled
+                  label={trans.__('end_time')}
+                  defaultValue={job?.end_time?.toString() ?? ''}
                   InputProps={{
                     readOnly: true
                   }}

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -217,8 +217,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   return (
     <>
-      <Button onClick={_ => setLoading(!loading)}> Toggle loading </Button>
-      <Button onClick={_ => getJobDefinion()}>Fetch job definition</Button>
       <Box sx={{ maxWidth: '500px', p: 4 }}>
         <Stack spacing={4}>
           <div role="presentation">

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -66,7 +66,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     const initialState: ICreateJobModel = {
       inputFile: job?.input_uri ?? '',
       jobName: job?.name ?? '',
-      outputPath: job?.output_uri ?? '',
+      outputPath: '.',
       environment: job?.runtime_environment_name ?? '',
       parameters:
         job?.parameters !== undefined

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -27,7 +27,7 @@ import {
 import { caretDownIcon } from '@jupyterlab/ui-components';
 import { useTranslator } from '../hooks';
 import { Heading } from '../components/heading';
-import { SchedulerService } from '../handler';
+import { Scheduler, SchedulerService } from '../handler';
 
 export interface IJobDetailProps {
   model: IJobDetailModel;
@@ -45,28 +45,32 @@ interface ITextFieldStyledProps {
 export function JobDetail(props: IJobDetailProps): JSX.Element {
   const [loading, setLoading] = useState(false);
   const [running, setRunning] = useState(false);
+  const [job, setJob] = useState<Scheduler.IDescribeJob | undefined>(undefined);
 
   //TO DELETE
-  const prop = { model: { jobId: '235877a5-3172-4e48-8832-ce880ffcfdd8' } };
+  const prop = { model: { jobId: 'd5bb0c08-d000-4be8-ba0f-25623f9effbd' } };
 
   const trans = useTranslator('jupyterlab');
 
   const ss = new SchedulerService({});
 
-  const fetchJobDefinition = async () => {
-    const job = ss.getJob(prop.model.jobId);
-    job.then(job => {
-      console.log(job);
-    });
+  const getJobDefinion = async () => {
+    const jobDefinition = await ss.getJob(prop.model.jobId);
+    console.log('fetched job');
+    console.log(jobDefinition);
+    setJob(jobDefinition);
+    console.log('state job');
+    console.log(job);
+    setLoading(false);
   };
 
   useEffect(() => {
-    console.log('element loaded');
+    getJobDefinion();
   }, []);
 
   //const job = ss.getJobDefinitions(props.model.jobId);
 
-  console.log(`jobId: ${props.model.jobId}`);
+  console.log(`jobId from props: ${props.model.jobId}`);
   //console.log(`jobDefinition in the body: ${jobDefinition}`);
   // Take props.jobId, make REST API request to get IJobDetailsModel with all of the job information
   // To rerun job:
@@ -214,7 +218,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   return (
     <>
       <Button onClick={_ => setLoading(!loading)}> Toggle loading </Button>
-      <Button onClick={_ => fetchJobDefinition()}>Fetch job definition</Button>
+      <Button onClick={_ => getJobDefinion()}>Fetch job definition</Button>
       <Box sx={{ maxWidth: '500px', p: 4 }}>
         <Stack spacing={4}>
           <div role="presentation">

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -175,7 +175,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   job?.output_formats.map(format => (
                     <FormControlLabel
                       key={format}
-                      control={<Checkbox checked={true} />}
+                      control={<Checkbox checked={true} disabled />}
                       label={format}
                     />
                   ))}

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -221,7 +221,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.output_prefix ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('Idempotency Token')}
+                  label={trans.__('Idempotency token')}
                   defaultValue={job?.idempotency_token ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -225,7 +225,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.idempotency_token ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('Job Definition Id')}
+                  label={trans.__('Job definition ID')}
                   defaultValue={job?.job_definition_id ?? ''}
                 />
                 <FormLabel component="legend">{trans.__('Tags')}</FormLabel>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -282,7 +282,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.start_time?.toString() ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('end_time')}
+                  label={trans.__('End time')}
                   defaultValue={job?.end_time?.toString() ?? ''}
                 />
               </Stack>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -257,7 +257,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   }
                 />
                 <TextFieldStyled
-                  label={trans.__('retry_on_timeout')}
+                  label={trans.__('Retry on timeout')}
                   defaultValue={job?.retry_on_timeout?.toString() ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -44,7 +44,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   const [job, setJob] = useState<Scheduler.IDescribeJob | undefined>(undefined);
 
   //TO DELETE
-  const prop = { model: { jobId: '0d2779ad-3163-44b7-bc5b-da87adbaf90a' } };
+  const prop = { model: { jobId: '3f062962-1e3e-442b-8454-e76af250da39' } };
 
   const trans = useTranslator('jupyterlab');
 
@@ -180,7 +180,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   job?.output_formats.map(format => (
                     <FormControlLabel
                       key={format}
-                      control={<Checkbox checked={true} defaultChecked />}
+                      control={<Checkbox checked={true} />}
                       label={format}
                     />
                   ))}

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   ICreateJobModel,
   IJobDetailModel,
@@ -27,7 +27,7 @@ import {
 import { caretDownIcon } from '@jupyterlab/ui-components';
 import { useTranslator } from '../hooks';
 import { Heading } from '../components/heading';
-import { SchedulerService } from '../handler';
+import { SchedulerService, Scheduler } from '../handler';
 
 export interface IJobDetailProps {
   model: IJobDetailModel;
@@ -45,19 +45,34 @@ interface ITextFieldStyledProps {
 export function JobDetail(props: IJobDetailProps): JSX.Element {
   const [loading, setLoading] = useState(false);
   const [running, setRunning] = useState(false);
+  const [jobDefinition, setJobDefinition] = useState<
+    Scheduler.IDescribeJobDefinition[] | undefined
+  >(undefined);
+
+  //TO DELETE
+  const prop = { model: { jobId: 'ee90bfac-a3e2-4ec5-ab0a-f897165c8c94' } };
 
   const trans = useTranslator('jupyterlab');
 
   const ss = new SchedulerService({});
-  const job = ss.getJobDefinitions(props.model.jobId);
+  useEffect(() => {
+    const fetchJobDefinition = async () => {
+      const job = await ss.getJobDefinitions(prop.model.jobId);
+      setJobDefinition(job);
+      console.log(`jobDefinition in the useEffect: ${jobDefinition}`);
+      //setLoading(false);
+    };
+    fetchJobDefinition();
+  }, []);
+
+  //const job = ss.getJobDefinitions(props.model.jobId);
+
   console.log(`jobId: ${props.model.jobId}`);
-  console.log(`job: ${job}`);
+  console.log(`jobDefinition in the body: ${jobDefinition}`);
   // Take props.jobId, make REST API request to get IJobDetailsModel with all of the job information
   // To rerun job:
   // 1) Call props.setCreateModel(<current model for this job>)
   // 2) Call props.setView('CreateJob')
-
-  const prop = { jobId: 'ee90bfac-a3e2-4ec5-ab0a-f897165c8c94' };
 
   const advancedOptions: IJobParameter[] = [
     { name: 'option 1', value: 'hello' },
@@ -224,7 +239,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               >
                 {trans.__('Notebook Jobs')}
               </Link>
-              <Typography color="text.primary">{prop.jobId}</Typography>
+              <Typography color="text.primary">{prop.model.jobId}</Typography>
             </Breadcrumbs>
           </div>
           <Heading level={1}>{trans.__('Job Detail')}</Heading>

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -274,7 +274,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.url ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('status_message')}
+                  label={trans.__('Status message')}
                   defaultValue={job?.status_message ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -261,10 +261,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.retry_on_timeout?.toString() ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('Start time')}
-                  defaultValue={job?.start_time?.toString() ?? ''}
-                />
-                <TextFieldStyled
                   label={trans.__('Output filename template')}
                   defaultValue={job?.output_filename_template ?? ''}
                 />
@@ -278,7 +274,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.status_message ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('start_time')}
+                  label={trans.__('Start time')}
                   defaultValue={job?.start_time?.toString() ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -49,15 +49,15 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
 
   const ss = new SchedulerService({});
-  //const job = ss.getJobDefinitions(props.model.jobId):
+  const job = ss.getJobDefinitions(props.model.jobId);
+  console.log(`jobId: ${props.model.jobId}`);
+  console.log(`job: ${job}`);
   // Take props.jobId, make REST API request to get IJobDetailsModel with all of the job information
   // To rerun job:
   // 1) Call props.setCreateModel(<current model for this job>)
   // 2) Call props.setView('CreateJob')
 
-  const prop = {
-    jobId: 'job-12'
-  };
+  const prop = { jobId: 'ee90bfac-a3e2-4ec5-ab0a-f897165c8c94' };
 
   const advancedOptions: IJobParameter[] = [
     { name: 'option 1', value: 'hello' },

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -243,7 +243,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   {trans.__('Email notifications')}
                 </FormLabel>
                 <TextFieldStyled
-                  label={trans.__('Job Definition Id')}
+                  label={trans.__('Job definition ID')}
                   defaultValue={job?.timeout_seconds?.toString() ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -270,7 +270,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                 />
 
                 <TextFieldStyled
-                  label={trans.__('url')}
+                  label={trans.__('URL')}
                   defaultValue={job?.url ?? ''}
                 />
                 <TextFieldStyled

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -251,7 +251,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   defaultValue={job?.max_retries?.toString() ?? ''}
                 />
                 <TextFieldStyled
-                  label={trans.__('min_retry_interval_millis')}
+                  label={trans.__('Minimum retry interval (millisecond)')}
                   defaultValue={
                     job?.min_retry_interval_millis?.toString() ?? ''
                   }

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -44,7 +44,7 @@ interface ITextFieldStyledProps {
 
 export function JobDetail(props: IJobDetailProps): JSX.Element {
   const [loading, setLoading] = useState(false);
-  const [running, setRunning] = useState(true);
+  const [running, setRunning] = useState(false);
 
   const trans = useTranslator('jupyterlab');
 

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -207,14 +207,14 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   }}
                 />
                 <TextFieldStyled
-                  label={trans.__('Output Prefix')}
+                  label={trans.__('Idempotency Token')}
                   defaultValue={job?.idempotency_token ?? ''}
                   InputProps={{
                     readOnly: true
                   }}
                 />
                 <TextFieldStyled
-                  label={trans.__('Output Prefix')}
+                  label={trans.__('Job Definition Id')}
                   defaultValue={job?.job_definition_id ?? ''}
                   InputProps={{
                     readOnly: true


### PR DESCRIPTION
This PR adds full-widget-sized job details view as per Issue #5 

Currently all fields of IDescribeJob (that extends ICreateJob) are rendered even if they are not filled. email_notifications field is not rendered