### PR TITLE
use MUI Table in job list view

### DIFF
--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
-import Scheduler from './tokens'
+import React from 'react';
+import Scheduler from './tokens';
 
-const AdvancedOptions = (props: Scheduler.IAdvancedOptionsProps) => {
+const AdvancedOptions = (
+  props: Scheduler.IAdvancedOptionsProps
+): JSX.Element => {
   // This is a placeholder function that an alternative extension may override.
   return <></>;
 };

--- a/src/components/output-format-picker.tsx
+++ b/src/components/output-format-picker.tsx
@@ -61,9 +61,11 @@ export function OutputFormatPicker(
                 id={`${props.id}-${of.name}`}
                 value={of.name}
                 onChange={props.onChange}
-              />}
-            label={of.label} />
-          ))}
+              />
+            }
+            label={of.label}
+          />
+        ))}
       </Cluster>
     </Stack>
   );

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -309,6 +309,7 @@ export namespace Scheduler {
   export interface IListJobsResponse {
     jobs: IDescribeJob[];
     next_token?: string;
+    total_count: number;
   }
 
   export interface IRuntimeEnvironment {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,7 +29,7 @@ import {
 import Scheduler from './tokens';
 import AdvancedOptions from './advanced-options';
 
-namespace CommandIDs {
+export namespace CommandIDs {
   export const deleteJob = 'scheduling:delete-job';
   export const runNotebook = 'scheduling:run-notebook';
   export const showNotebookJobs = 'scheduling:show-notebook-jobs';
@@ -62,7 +62,7 @@ const advancedOptions: JupyterFrontEndPlugin<Scheduler.IAdvancedOptions> = {
   activate: (app: JupyterFrontEnd) => {
     return AdvancedOptions;
   }
-}
+};
 
 function getSelectedItem(widget: FileBrowser | null): Contents.IModel | null {
   if (widget === null) {
@@ -259,6 +259,9 @@ async function activatePlugin(
   }
 }
 
-const plugins: JupyterFrontEndPlugin<any>[] = [schedulerPlugin, advancedOptions];
+const plugins: JupyterFrontEndPlugin<any>[] = [
+  schedulerPlugin,
+  advancedOptions
+];
 
 export default plugins;

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -2,7 +2,10 @@ import React, { ChangeEvent } from 'react';
 
 import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
-import { OutputFormatPicker, outputFormatsForEnvironment } from '../components/output-format-picker';
+import {
+  OutputFormatPicker,
+  outputFormatsForEnvironment
+} from '../components/output-format-picker';
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
 import SchedulerTokens from '../tokens';
@@ -50,7 +53,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   // Cache text inputs so that React can update their state immediately, preventing
   // a situation where the cursor jumps to the end of the text box after the user
   // enters a character mid-input.
-  const [textInputs, setTextInputs] = React.useState<Record<string, string>>({});
+  const [textInputs, setTextInputs] = React.useState<Record<string, string>>(
+    {}
+  );
 
   // A mapping from input names to error messages.
   // If an error message is "truthy" (i.e., not null or ''), we should display the
@@ -130,7 +135,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
   const submitCreateJobRequest = async (event: React.MouseEvent) => {
     if (anyErrors) {
-      console.error('User attempted to submit a createJob request; button should have been disabled');
+      console.error(
+        'User attempted to submit a createJob request; button should have been disabled'
+      );
       return;
     }
 
@@ -192,14 +199,19 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   };
 
   // If the text field is blank, record an error.
-  const validateEmpty = (e: EventTarget & (HTMLInputElement | HTMLTextAreaElement)) => {
+  const validateEmpty = (
+    e: EventTarget & (HTMLInputElement | HTMLTextAreaElement)
+  ) => {
     const inputName = e.name;
     const inputValue = e.value;
 
-    if (inputValue === '') { // blank
-      setErrors({ ...errors, [inputName]: trans.__('You must provide a value.') })
-    }
-    else {
+    if (inputValue === '') {
+      // blank
+      setErrors({
+        ...errors,
+        [inputName]: trans.__('You must provide a value.')
+      });
+    } else {
       setErrors({ ...errors, [inputName]: '' });
     }
   };
@@ -210,7 +222,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   };
 
   const api = new SchedulerService({});
-  const environmentsPromise: () => Promise<Scheduler.IRuntimeEnvironment[]> = async () => {
+  const environmentsPromise: () => Promise<
+    Scheduler.IRuntimeEnvironment[]
+  > = async () => {
     const environmentsCache = sessionStorage.getItem('environments');
     if (environmentsCache !== null) {
       return JSON.parse(environmentsCache);
@@ -237,7 +251,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             onChange={handleInputChange}
             value={textInputs['jobName'] ?? props.model.jobName}
             id={`${formPrefix}jobName`}
-            name='jobName'
+            name="jobName"
           />
           <TextField
             label={trans.__('Input file')}
@@ -245,10 +259,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             onChange={handleInputChange}
             value={textInputs['inputFile'] ?? props.model.inputFile}
             id={`${formPrefix}inputFile`}
-            onBlur={(e) => validateEmpty(e.target)}
+            onBlur={e => validateEmpty(e.target)}
             error={hasError('inputFile')}
             helperText={errors['inputFile'] ?? ''}
-            name='inputFile'
+            name="inputFile"
           />
           <TextField
             label={trans.__('Output path')}
@@ -256,7 +270,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             onChange={handleInputChange}
             value={textInputs['outputPath'] ?? props.model.outputPath}
             id={`${formPrefix}outputPath`}
-            name='outputPath'
+            name="outputPath"
           />
           <EnvironmentPicker
             label={trans.__('Environment')}
@@ -268,7 +282,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
           />
           <OutputFormatPicker
             label={trans.__('Output formats')}
-            name='outputFormat'
+            name="outputFormat"
             id={`${formPrefix}outputFormat`}
             onChange={handleOutputFormatsChange}
             environment={props.model.environment}
@@ -289,7 +303,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             model={props.model}
             handleModelChange={props.handleModelChange}
             errors={errors}
-            handleErrorsChange={setErrors} />
+            handleErrorsChange={setErrors}
+          />
           <Cluster gap={3} justifyContent="flex-end">
             <Button variant="outlined" onClick={props.toggleView}>
               {trans.__('Cancel')}

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -17,6 +17,7 @@ import { Scheduler, SchedulerService } from '../handler';
 import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
 
+import { useTheme } from '@mui/material/styles';
 import Button from '@mui/material/Button';
 import Box from '@mui/system/Box';
 import Stack from '@mui/system/Stack';
@@ -61,6 +62,7 @@ export function NotebookJobsListBody(
   const [page, setPage] = useState<number>(0);
   const [maxPage, setMaxPage] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(false);
+  const theme = useTheme();
 
   const deleteRow = useCallback((id: Scheduler.IDescribeJob['job_id']) => {
     setDeletedRows(deletedRows => new Set([...deletedRows, id]));
@@ -248,8 +250,8 @@ export function NotebookJobsListBody(
             sx={{
               position: 'sticky',
               bottom: 0,
-              backgroundColor: 'white',
-              borderTop: '1px solid #e0e0e0'
+              backgroundColor: theme.palette.background.paper,
+              borderTop: `1px solid ${theme.palette.divider}`
             }}
             count={notebookJobs.total_count}
             page={page}

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -67,7 +67,7 @@ export function NotebookJobsListBody(
   }, []);
 
   const fetchInitialRows = async () => {
-    // reset pagiantion state
+    // reset pagination state
     setPage(0);
     setMaxPage(0);
     // Get initial job list (next_token is undefined)

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -1,14 +1,15 @@
-import React, { useEffect, useState } from 'react';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useEffect, useState, useCallback } from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 
 import { useTranslator } from '../hooks';
 
-import { JobRow } from '../components/job-row';
+import { buildTableRow } from '../components/job-row';
 import {
+  INotebookJobsWithToken,
   ICreateJobModel,
-  IListJobsModel,
-  INotebookJobsWithToken
+  IListJobsModel
 } from '../model';
 import { caretDownIcon, caretUpIcon, LabIcon } from '@jupyterlab/ui-components';
 import { Scheduler, SchedulerService } from '../handler';
@@ -19,10 +20,15 @@ import { Cluster } from '../components/cluster';
 import Button from '@mui/material/Button';
 import Box from '@mui/system/Box';
 import Stack from '@mui/system/Stack';
+import Table from '@mui/material/Table';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TablePagination from '@mui/material/TablePagination';
+import Paper from '@mui/material/Paper';
 
-const ListItemClass = 'jp-notebook-job-list-item';
-
-export const JobListPageSize = 25;
+export const PAGE_SIZE = 25;
 
 interface INotebookJobsListBodyProps {
   showHeaders?: boolean;
@@ -37,9 +43,6 @@ interface INotebookJobsListBodyProps {
   ) => Promise<INotebookJobsWithToken | undefined>;
 }
 
-// Used for table cells including headers
-const jobTraitClass = 'jp-notebook-job-list-trait';
-
 type GridColumn = {
   sortField: string | null;
   name: string;
@@ -52,17 +55,33 @@ export function NotebookJobsListBody(
     INotebookJobsWithToken | undefined
   >(undefined);
   const [jobsQuery, setJobsQuery] = useState<Scheduler.IListJobsQuery>({});
+  const [deletedRows, setDeletedRows] = useState<
+    Set<Scheduler.IDescribeJob['job_id']>
+  >(new Set());
+  const [page, setPage] = useState<number>(0);
+  const [maxPage, setMaxPage] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(false);
 
-  const fetchInitialRows = () => {
+  const deleteRow = useCallback((id: Scheduler.IDescribeJob['job_id']) => {
+    setDeletedRows(deletedRows => new Set([...deletedRows, id]));
+  }, []);
+
+  const fetchInitialRows = async () => {
+    // reset pagiantion state
+    setPage(0);
+    setMaxPage(0);
     // Get initial job list (next_token is undefined)
-    props.getJobs(jobsQuery).then(initialNotebookJobs => {
-      setNotebookJobs(initialNotebookJobs);
-    });
+    setLoading(true);
+    const initialNotebookJobs = await props.getJobs(jobsQuery);
+    setLoading(false);
+    setNotebookJobs(initialNotebookJobs);
   };
 
   // Fetch the initial rows asynchronously on component creation
   // After setJobsQuery is called, force a reload.
-  useEffect(() => fetchInitialRows(), [jobsQuery]);
+  useEffect(() => {
+    fetchInitialRows();
+  }, [jobsQuery]);
 
   const fetchMoreRows = async (next_token: string | undefined) => {
     // Do nothing if the next token is undefined (shouldn't happen, but required for type safety)
@@ -71,7 +90,9 @@ export function NotebookJobsListBody(
     }
 
     // Apply the custom token to the existing query parameters
+    setLoading(true);
     const newNotebookJobs = await props.getJobs({ ...jobsQuery, next_token });
+    setLoading(false);
 
     if (!newNotebookJobs) {
       return;
@@ -80,7 +101,8 @@ export function NotebookJobsListBody(
     // Merge the two lists of jobs and keep the next token from the new response.
     setNotebookJobs({
       jobs: [...(notebookJobs?.jobs || []), ...(newNotebookJobs?.jobs || [])],
-      next_token: newNotebookJobs.next_token
+      next_token: newNotebookJobs.next_token,
+      total_count: newNotebookJobs.total_count
     });
   };
 
@@ -96,6 +118,27 @@ export function NotebookJobsListBody(
         {trans.__('Reload')}
       </Button>
     </Cluster>
+  );
+
+  const translateStatus = useCallback(
+    (status: Scheduler.Status) => {
+      // This may look inefficient, but it's intended to call the `trans` function
+      // with distinct, static values, so that code analyzers can pick up all the
+      // needed source strings.
+      switch (status) {
+        case 'COMPLETED':
+          return trans.__('Completed');
+        case 'FAILED':
+          return trans.__('Failed');
+        case 'IN_PROGRESS':
+          return trans.__('In progress');
+        case 'STOPPED':
+          return trans.__('Stopped');
+        case 'STOPPING':
+          return trans.__('Stopping');
+      }
+    },
+    [trans]
   );
 
   if (notebookJobs === undefined) {
@@ -148,38 +191,77 @@ export function NotebookJobsListBody(
     }
   ];
 
+  const rows: JSX.Element[] = notebookJobs.jobs
+    .filter(job => !deletedRows.has(job.job_id))
+    .map(job =>
+      buildTableRow(
+        job,
+        props.app,
+        props.showCreateJob,
+        deleteRow,
+        translateStatus
+      )
+    );
+
+  const handlePageChange = async (e: unknown, newPage: number) => {
+    // if newPage <= maxPage, no need to fetch more rows
+    if (newPage <= maxPage) {
+      setPage(newPage);
+      return;
+    }
+
+    await fetchMoreRows(notebookJobs.next_token);
+    setPage(newPage);
+    setMaxPage(newPage);
+  };
+
+  // note that the parent must be a JSX fragment for DataGrid to be sized properly
   return (
     <>
       {reloadButton}
-      <div className={`${ListItemClass} jp-notebook-job-list-header`}>
-        {columns.map((column, idx) => (
-          <NotebookJobsColumnHeader
-            key={idx}
-            gridColumn={column}
-            jobsQuery={jobsQuery}
-            setJobsQuery={setJobsQuery}
-          />
-        ))}
-      </div>
-      {notebookJobs.jobs.map(job => (
-        <JobRow
-          key={job.job_id}
-          job={job}
-          rowClass={ListItemClass}
-          cellClass={jobTraitClass}
-          app={props.app}
-          showCreateJob={props.showCreateJob}
-        />
-      ))}
-      {notebookJobs.next_token !== undefined && (
-        <Button
-          onClick={(e: React.MouseEvent<HTMLElement>) =>
-            fetchMoreRows(notebookJobs.next_token)
-          }
+      {/* outer div expands to fill rest of screen */}
+      <div style={{ flex: 1, height: 0 }}>
+        <TableContainer
+          component={Paper}
+          sx={{
+            height: '100%',
+            ...(loading ? { pointerEvents: 'none', opacity: 0.5 } : {})
+          }}
         >
-          {trans.__('Show more')}
-        </Button>
-      )}
+          <Table stickyHeader>
+            <TableHead>
+              {columns.map((column, idx) => (
+                <NotebookJobsColumnHeader
+                  key={idx}
+                  gridColumn={column}
+                  jobsQuery={jobsQuery}
+                  setJobsQuery={setJobsQuery}
+                />
+              ))}
+            </TableHead>
+            <TableBody>
+              {rows.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)}
+            </TableBody>
+          </Table>
+          <TablePagination
+            component="div"
+            sx={{
+              position: 'sticky',
+              bottom: 0,
+              backgroundColor: 'white',
+              borderTop: '1px solid #e0e0e0'
+            }}
+            count={notebookJobs.total_count}
+            page={page}
+            onPageChange={handlePageChange}
+            nextIconButtonProps={{
+              disabled: page === maxPage && !notebookJobs.next_token
+            }}
+            rowsPerPage={PAGE_SIZE}
+            rowsPerPageOptions={[PAGE_SIZE]}
+          />
+        </TableContainer>
+      </div>
     </>
   );
 }
@@ -244,11 +326,14 @@ function NotebookJobsColumnHeader(
   };
 
   return (
-    <div className={jobTraitClass} onClick={sortByThisColumn}>
+    <TableCell
+      onClick={sortByThisColumn}
+      sx={props.gridColumn.sortField ? { cursor: 'pointer' } : {}}
+    >
       {props.gridColumn.name}
       {isSortedAscending && sortAscendingIcon}
       {isSortedDescending && sortDescendingIcon}
-    </div>
+    </TableCell>
   );
 }
 
@@ -259,7 +344,7 @@ function getJobs(
 
   // Impose max_items if not otherwise specified.
   if (jobQuery['max_items'] === undefined) {
-    jobQuery.max_items = JobListPageSize;
+    jobQuery.max_items = PAGE_SIZE;
   }
 
   return api.getJobs(jobQuery);
@@ -277,8 +362,8 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
 
   // Retrieve the initial jobs list
   return (
-    <Box sx={{ p: 4 }}>
-      <Stack spacing={3}>
+    <Box sx={{ p: 4 }} style={{ height: '100%', boxSizing: 'border-box' }}>
+      <Stack spacing={3} style={{ height: '100%' }}>
         <Heading level={1}>{trans.__('Notebook Jobs')}</Heading>
         <NotebookJobsListBody
           showHeaders={true}

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -194,6 +194,7 @@ export function NotebookJobsListBody(
   ];
 
   const rows: JSX.Element[] = notebookJobs.jobs
+    .slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
     .filter(job => !deletedRows.has(job.job_id))
     .map(job =>
       buildTableRow(
@@ -241,9 +242,7 @@ export function NotebookJobsListBody(
                 />
               ))}
             </TableHead>
-            <TableBody>
-              {rows.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)}
-            </TableBody>
+            <TableBody>{rows}</TableBody>
           </Table>
           <TablePagination
             component="div"

--- a/src/model.ts
+++ b/src/model.ts
@@ -52,6 +52,7 @@ export class NotebookJobsListingModel implements INotebookJobsListingModel {
 export interface INotebookJobsWithToken {
   jobs: Scheduler.IDescribeJob[];
   next_token?: string;
+  total_count: number;
 }
 
 export interface INotebookJobsListingModel {

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -64,7 +64,9 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
           {this.model.jobsView === 'CreateJob' && (
             <CreateJob
               model={this.model.createJobModel}
-              handleModelChange={newModel => (this.model.createJobModel = newModel)}
+              handleModelChange={newModel =>
+                (this.model.createJobModel = newModel)
+              }
               toggleView={this.toggleView.bind(this)}
               advancedOptions={this._advancedOptions}
             />
@@ -73,14 +75,18 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
             <NotebookJobsList
               app={this._app}
               model={this.model.listJobsModel}
-              handleModelChange={newModel => (this.model.listJobsModel = newModel)}
+              handleModelChange={newModel =>
+                (this.model.listJobsModel = newModel)
+              }
               showCreateJob={showCreateJob}
             />
           )}
           {this.model.jobsView === 'JobDetail' && (
             <JobDetail
               model={this.model.jobDetailModel}
-              handleModelChange={newModel => (this.model.jobDetailModel = newModel)}
+              handleModelChange={newModel =>
+                (this.model.jobDetailModel = newModel)
+              }
               setView={view => (this.model.jobsView = view)}
             />
           )}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -2,10 +2,9 @@ import { Token } from '@lumino/coreutils';
 import { ICreateJobModel, IJobDetailModel, JobsView } from './model';
 
 namespace Scheduler {
+  export type EnvironmentParameterValue = string | number | boolean;
 
-  export type EnvironmentParameterValue = string | number | boolean
-
-  export type ErrorsType = { [key: string]: string; };
+  export type ErrorsType = { [key: string]: string };
 
   export interface IAdvancedOptionsProps {
     jobsView: JobsView;
@@ -15,8 +14,7 @@ namespace Scheduler {
     handleErrorsChange: (errors: ErrorsType) => void;
   }
 
-  export type IAdvancedOptions =
-    React.FC<IAdvancedOptionsProps>;
+  export type IAdvancedOptions = React.FC<IAdvancedOptionsProps>;
 
   export const IAdvancedOptions = new Token<IAdvancedOptions>(
     '@jupyterlab/scheduler:IAdvancedOptions'

--- a/style/base.css
+++ b/style/base.css
@@ -19,92 +19,6 @@
   overflow-y: auto;
 }
 
-.jp-notebook-jobs-header {
-  padding: 0 12px;
-  margin-bottom: 15px;
-}
-
-.jp-notebook-jobs-header h2 {
-  margin-bottom: 5px;
-}
-
-.jp-notebook-jobs-search {
-  display: flex;
-  gap: 12px;
-  padding: 0 12px 15px;
-}
-
-.jp-notebook-jobs-search .jp-InputGroup {
-  width: 100%;
-}
-
-.jp-notebook-jobs-search button {
-  width: 120px;
-}
-
-.jp-notebook-job-list {
-  /* This is itself a flex container */
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  padding: 10px;
-}
-
-a.jp-notebook-job-name {
-  text-decoration-line: underline;
-  text-decoration-style: dashed;
-}
-
-.jp-notebook-job-name-details-button {
-  display: inline-block;
-  height: 16px;
-  width: 16px;
-}
-
-.jp-notebook-job-list-item {
-  flex: 1 1 auto;
-  width: 100%;
-  padding: 6px;
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
-  display: flex;
-  flex-direction: row;
-}
-
-.jp-notebook-job-list-item:hover {
-  background-color: var(--jp-layout-color2);
-}
-
-.jp-notebook-job-list-item:active {
-  background-color: var(--jp-layout-color3);
-}
-
-.jp-notebook-job-list-item.details-visible {
-  background-color: var(--jp-layout-color3);
-}
-
-.jp-notebook-job-list-trait {
-  flex: 0 0 calc(100% / 6);
-  display: flex; /* This cell can contain multiple elements */
-}
-
-.jp-notebook-job-list-header {
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
-}
-
-.jp-notebook-job-list-header .jp-notebook-job-list-trait {
-  font-weight: bold;
-}
-
-.jp-notebook-job-list-item-deleted {
-  background-color: var(--jp-layout-color3);
-  opacity: 0.3;
-}
-
-.jp-notebook-job-list-item strong {
-  font-weight: bold;
-}
-
 .jp-notebook-jobs-panel a {
   color: var(--jp-content-link-color);
 }
@@ -113,15 +27,7 @@ a.jp-notebook-job-name {
   margin-top: 12px;
 }
 
-.jp-notebook-jobs-list-container {
-  margin-left: 12px;
-  margin-right: 12px;
-}
-
-ul.jp-notebook-job-output-formats-options {
-  list-style: none;
-  margin: 0 0 0 -40px;
-}
+/* Create job form */
 
 .jp-create-job-form {
   max-width: 500px;


### PR DESCRIPTION
This set of changes integrates the MUI Table component into the job list view. Pagination, sorting, and loading states are correctly handled.

https://user-images.githubusercontent.com/44106031/192384710-f15af7d5-07da-430c-8c23-a355fc0b573e.mov

What this PR does NOT include:

- does not open the job details view upon clicking on job name (waiting for @andrii-i 's detail view to be merged)
- does not remove `job-detail.tsx` despite being unused, since the contents of this file may be replaced by @andrii-i 