### PR TITLE
Automated Changelog Entry for 0.2.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.1
+
+([Full Changelog](https://github.com/jupyter-server/jupyter-scheduler/compare/v0.1.1...3e7a0ed95f4ee3fdc04e732edaf69884a58d0133))
+
+### Enhancements made
+
+- CollapsiblePanel [#12](https://github.com/jupyter-server/jupyter-scheduler/pull/12) ([@andrii-i](https://github.com/andrii-i))
+
+### Bugs fixed
+
+- Fix params picker when zero params exist [#43](https://github.com/jupyter-server/jupyter-scheduler/pull/43) ([@jweill-aws](https://github.com/jweill-aws))
+
+### Other merged PRs
+
+- Job details view [#48](https://github.com/jupyter-server/jupyter-scheduler/pull/48) ([@3coins](https://github.com/3coins))
+- use MUI Table in job list view [#47](https://github.com/jupyter-server/jupyter-scheduler/pull/47) ([@dlqqq](https://github.com/dlqqq))
+- Adds errors, errorsChanged, validation for input field [#44](https://github.com/jupyter-server/jupyter-scheduler/pull/44) ([@jweill-aws](https://github.com/jweill-aws))
+- Updated handlers to support async scheduler apis [#41](https://github.com/jupyter-server/jupyter-scheduler/pull/41) ([@3coins](https://github.com/3coins))
+- Added a script to seed fake jobs for development [#39](https://github.com/jupyter-server/jupyter-scheduler/pull/39) ([@3coins](https://github.com/3coins))
+- Added compute types [#33](https://github.com/jupyter-server/jupyter-scheduler/pull/33) ([@3coins](https://github.com/3coins))
+- Fix create job form [#32](https://github.com/jupyter-server/jupyter-scheduler/pull/32) ([@jweill-aws](https://github.com/jweill-aws))
+- Material UI integration [#25](https://github.com/jupyter-server/jupyter-scheduler/pull/25) ([@dlqqq](https://github.com/dlqqq))
+- Adds extension point for custom environment UI [#24](https://github.com/jupyter-server/jupyter-scheduler/pull/24) ([@jweill-aws](https://github.com/jweill-aws))
+- Create job form inputs component [#11](https://github.com/jupyter-server/jupyter-scheduler/pull/11) ([@jweill-aws](https://github.com/jweill-aws))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter-scheduler/graphs/contributors?from=2022-09-15&to=2022-09-27&type=c))
+
+[@3coins](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3A3coins+updated%3A2022-09-15..2022-09-27&type=Issues) | [@andrii-i](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Aandrii-i+updated%3A2022-09-15..2022-09-27&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Adlqqq+updated%3A2022-09-15..2022-09-27&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Agithub-actions+updated%3A2022-09-15..2022-09-27&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Ajweill-aws+updated%3A2022-09-15..2022-09-27&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Awelcome+updated%3A2022-09-15..2022-09-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.1
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter-scheduler/compare/4dab98695d7251ae61bd224c18609efe9b6daf44...40d15d9fc3a4e7ea5d6e594c662a61a1ac4a43f7))
@@ -18,5 +51,3 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter-scheduler/graphs/contributors?from=2022-09-10&to=2022-09-15&type=c))
 
 [@3coins](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3A3coins+updated%3A2022-09-10..2022-09-15&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Awelcome+updated%3A2022-09-10..2022-09-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,29 +9,26 @@
 ### Enhancements made
 
 - CollapsiblePanel [#12](https://github.com/jupyter-server/jupyter-scheduler/pull/12) ([@andrii-i](https://github.com/andrii-i))
-
-### Bugs fixed
-
-- Fix params picker when zero params exist [#43](https://github.com/jupyter-server/jupyter-scheduler/pull/43) ([@jweill-aws](https://github.com/jweill-aws))
-
-### Other merged PRs
-
 - Job details view [#48](https://github.com/jupyter-server/jupyter-scheduler/pull/48) ([@3coins](https://github.com/3coins))
 - use MUI Table in job list view [#47](https://github.com/jupyter-server/jupyter-scheduler/pull/47) ([@dlqqq](https://github.com/dlqqq))
 - Adds errors, errorsChanged, validation for input field [#44](https://github.com/jupyter-server/jupyter-scheduler/pull/44) ([@jweill-aws](https://github.com/jweill-aws))
 - Updated handlers to support async scheduler apis [#41](https://github.com/jupyter-server/jupyter-scheduler/pull/41) ([@3coins](https://github.com/3coins))
 - Added a script to seed fake jobs for development [#39](https://github.com/jupyter-server/jupyter-scheduler/pull/39) ([@3coins](https://github.com/3coins))
 - Added compute types [#33](https://github.com/jupyter-server/jupyter-scheduler/pull/33) ([@3coins](https://github.com/3coins))
-- Fix create job form [#32](https://github.com/jupyter-server/jupyter-scheduler/pull/32) ([@jweill-aws](https://github.com/jweill-aws))
 - Material UI integration [#25](https://github.com/jupyter-server/jupyter-scheduler/pull/25) ([@dlqqq](https://github.com/dlqqq))
 - Adds extension point for custom environment UI [#24](https://github.com/jupyter-server/jupyter-scheduler/pull/24) ([@jweill-aws](https://github.com/jweill-aws))
 - Create job form inputs component [#11](https://github.com/jupyter-server/jupyter-scheduler/pull/11) ([@jweill-aws](https://github.com/jweill-aws))
+
+### Bugs fixed
+
+- Fix params picker when zero params exist [#43](https://github.com/jupyter-server/jupyter-scheduler/pull/43) ([@jweill-aws](https://github.com/jweill-aws))
+- Fix create job form [#32](https://github.com/jupyter-server/jupyter-scheduler/pull/32) ([@jweill-aws](https://github.com/jweill-aws))
 
 ### Contributors to this release
 
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter-scheduler/graphs/contributors?from=2022-09-15&to=2022-09-27&type=c))
 
-[@3coins](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3A3coins+updated%3A2022-09-15..2022-09-27&type=Issues) | [@andrii-i](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Aandrii-i+updated%3A2022-09-15..2022-09-27&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Adlqqq+updated%3A2022-09-15..2022-09-27&type=Issues) | [@github-actions](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Agithub-actions+updated%3A2022-09-15..2022-09-27&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Ajweill-aws+updated%3A2022-09-15..2022-09-27&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Awelcome+updated%3A2022-09-15..2022-09-27&type=Issues)
+[@3coins](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3A3coins+updated%3A2022-09-15..2022-09-27&type=Issues) | [@andrii-i](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Aandrii-i+updated%3A2022-09-15..2022-09-27&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Adlqqq+updated%3A2022-09-15..2022-09-27&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Ajweill-aws+updated%3A2022-09-15..2022-09-27&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter-scheduler+involves%3Aellisonbg+updated%3A2022-09-15..2022-09-27&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyter-server/jupyter-scheduler/releases/tag/untagged-fb78aa253219de3464f7  |
| Since | v0.1.1 |