### PR TITLE
Adds compute type to create-job form

### DIFF
--- a/src/components/compute-type-picker.tsx
+++ b/src/components/compute-type-picker.tsx
@@ -20,7 +20,7 @@ export function ComputeTypePicker(
   const environmentObj = props.environmentList.find(
     env => env.name === props.environment
   );
-  if (!environmentObj || !environmentObj['output_formats']) {
+  if (!environmentObj || !environmentObj['compute_types']) {
     return null;
   }
 

--- a/src/components/compute-type-picker.tsx
+++ b/src/components/compute-type-picker.tsx
@@ -11,7 +11,7 @@ export type ComputeTypePickerProps = {
   environment: string;
   environmentList: Scheduler.IRuntimeEnvironment[];
   onChange: (event: SelectChangeEvent<string>) => void;
-  initialValue: string;
+  value: string | undefined;
 };
 
 export function ComputeTypePicker(
@@ -20,16 +20,13 @@ export function ComputeTypePicker(
   const environmentObj = props.environmentList.find(
     env => env.name === props.environment
   );
-  if (!environmentObj || !environmentObj['compute_types']) {
+  if (!environmentObj || !environmentObj.compute_types) {
     return null;
   }
 
-  const computeTypes = environmentObj['compute_types'] as string[];
+  const computeTypes = environmentObj.compute_types;
 
   const labelId = `${props.id}-label`;
-
-  // If no initial value was provided, default to the first value being selected.
-  const initialValue = props.initialValue || computeTypes[0];
 
   return (
     <>
@@ -39,7 +36,7 @@ export function ComputeTypePicker(
         name={props.name}
         id={props.id}
         onChange={props.onChange}
-        value={initialValue}
+        value={props.value}
       >
         {computeTypes.map((ct, idx) => (
           <MenuItem value={ct} key={idx}>

--- a/src/components/compute-type-picker.tsx
+++ b/src/components/compute-type-picker.tsx
@@ -25,7 +25,7 @@ export function ComputeTypePicker(
   }
 
   const computeTypes = environmentObj['compute_types'] as string[];
-  
+
   const labelId = `${props.id}-label`;
 
   return (

--- a/src/components/compute-type-picker.tsx
+++ b/src/components/compute-type-picker.tsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from 'react';
+
+import { InputLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+
+import { Scheduler } from '../handler';
+
+export type ComputeTypePickerProps = {
+  label: string;
+  name: string;
+  id: string;
+  environment: string;
+  onChange: (event: SelectChangeEvent<string>) => void;
+  initialValue: string;
+};
+
+export function computeTypesForEnvironment(
+  environment: string
+): string[] | null {
+  // Retrieve the environment data from session storage.
+  const environmentsData = sessionStorage.getItem('environments');
+  if (environmentsData === null) {
+    return null;
+  }
+
+  const environments = JSON.parse(
+    environmentsData
+  ) as Array<Scheduler.IRuntimeEnvironment>;
+  const environmentObj = environments.find(env => env.name === environment);
+  if (!environmentObj || !environmentObj['output_formats']) {
+    return null;
+  }
+
+  return environmentObj['compute_types'];
+}
+
+export function ComputeTypePicker(
+  props: ComputeTypePickerProps
+): JSX.Element | null {
+  const computeTypes = useMemo(
+    () => computeTypesForEnvironment(props.environment),
+    [props.environment]
+  );
+  if (computeTypes === null) {
+    return null;
+  }
+
+  const labelId = `${props.id}-label`;
+
+  return (
+    <>
+      <InputLabel id={labelId}>{props.label}</InputLabel>
+      <Select
+        labelId={labelId}
+        name={props.name}
+        id={props.id}
+        onChange={props.onChange}
+        value={props.initialValue}
+      >
+        {computeTypes.map((ct, idx) => (
+          <MenuItem value={ct} key={idx}>
+            {ct}
+          </MenuItem>
+        ))}
+      </Select>
+    </>
+  );
+}

--- a/src/components/compute-type-picker.tsx
+++ b/src/components/compute-type-picker.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { InputLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 
@@ -9,41 +9,23 @@ export type ComputeTypePickerProps = {
   name: string;
   id: string;
   environment: string;
+  environmentList: Scheduler.IRuntimeEnvironment[];
   onChange: (event: SelectChangeEvent<string>) => void;
   initialValue: string;
 };
 
-export function computeTypesForEnvironment(
-  environment: string
-): string[] | null {
-  // Retrieve the environment data from session storage.
-  const environmentsData = sessionStorage.getItem('environments');
-  if (environmentsData === null) {
-    return null;
-  }
-
-  const environments = JSON.parse(
-    environmentsData
-  ) as Array<Scheduler.IRuntimeEnvironment>;
-  const environmentObj = environments.find(env => env.name === environment);
+export function ComputeTypePicker(
+  props: ComputeTypePickerProps
+): JSX.Element | null {
+  const environmentObj = props.environmentList.find(
+    env => env.name === props.environment
+  );
   if (!environmentObj || !environmentObj['output_formats']) {
     return null;
   }
 
-  return environmentObj['compute_types'];
-}
-
-export function ComputeTypePicker(
-  props: ComputeTypePickerProps
-): JSX.Element | null {
-  const computeTypes = useMemo(
-    () => computeTypesForEnvironment(props.environment),
-    [props.environment]
-  );
-  if (computeTypes === null) {
-    return null;
-  }
-
+  const computeTypes = environmentObj['compute_types'] as string[];
+  
   const labelId = `${props.id}-label`;
 
   return (

--- a/src/components/compute-type-picker.tsx
+++ b/src/components/compute-type-picker.tsx
@@ -28,6 +28,9 @@ export function ComputeTypePicker(
 
   const labelId = `${props.id}-label`;
 
+  // If no initial value was provided, default to the first value being selected.
+  const initialValue = props.initialValue || computeTypes[0];
+
   return (
     <>
       <InputLabel id={labelId}>{props.label}</InputLabel>
@@ -36,7 +39,7 @@ export function ComputeTypePicker(
         name={props.name}
         id={props.id}
         onChange={props.onChange}
-        value={props.initialValue}
+        value={initialValue}
       >
         {computeTypes.map((ct, idx) => (
           <MenuItem value={ct} key={idx}>

--- a/src/components/environment-picker.tsx
+++ b/src/components/environment-picker.tsx
@@ -1,5 +1,5 @@
 import { InputLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Scheduler } from '../handler';
 import { useTranslator } from '../hooks';
@@ -9,21 +9,14 @@ export type EnvironmentPickerProps = {
   name: string;
   id: string;
   onChange: (event: SelectChangeEvent<string>) => void;
-  environmentsPromise: Promise<Scheduler.IRuntimeEnvironment[]>;
+  environmentList: Scheduler.IRuntimeEnvironment[];
   initialValue: string;
 };
 
 export function EnvironmentPicker(props: EnvironmentPickerProps): JSX.Element {
-  const [environmentList, setEnvironmentList] = useState(
-    [] as Scheduler.IRuntimeEnvironment[]
-  );
   const trans = useTranslator('jupyterlab');
 
-  React.useEffect(() => {
-    props.environmentsPromise.then(envList => setEnvironmentList(envList));
-  }, []);
-
-  if (environmentList.length === 0) {
+  if (props.environmentList.length === 0) {
     return <em>{trans.__('Loading …')}</em>;
   }
 
@@ -39,7 +32,7 @@ export function EnvironmentPicker(props: EnvironmentPickerProps): JSX.Element {
         onChange={props.onChange}
         value={props.initialValue}
       >
-        {environmentList.map((env, idx) => (
+        {props.environmentList.map((env, idx) => (
           <MenuItem value={env.label} title={env.description} key={idx}>
             {env.name}
           </MenuItem>

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -63,6 +63,7 @@ function DeleteButton(props: {
 
 function RefillButton(props: {
   job: Scheduler.IDescribeJob;
+  environmentList: Scheduler.IRuntimeEnvironment[];
   showCreateJob: (newModel: ICreateJobModel) => void;
 }): JSX.Element | null {
   const trans = useTranslator('jupyterlab');
@@ -96,6 +97,7 @@ function RefillButton(props: {
     // Convert the list of output formats, if any, into a list for the initial state
     const jobOutputFormats = props.job.output_formats;
     const outputFormats = outputFormatsForEnvironment(
+      props.environmentList,
       props.job.runtime_environment_name
     );
     if (jobOutputFormats && outputFormats) {
@@ -163,6 +165,7 @@ function OutputFiles(props: {
 
 export function buildTableRow(
   job: Scheduler.IDescribeJob,
+  environmentList: Scheduler.IRuntimeEnvironment[],
   app: JupyterFrontEnd,
   showCreateJob: (newModel: ICreateJobModel) => void,
   deleteRow: (id: Scheduler.IDescribeJob['job_id']) => void,
@@ -201,7 +204,11 @@ export function buildTableRow(
           deleteRow(job.job_id);
         }}
       />
-      <RefillButton job={job} showCreateJob={showCreateJob} />
+      <RefillButton
+        job={job}
+        environmentList={environmentList}
+        showCreateJob={showCreateJob}
+      />
     </Stack>
   ];
 

--- a/src/components/output-format-picker.tsx
+++ b/src/components/output-format-picker.tsx
@@ -33,7 +33,10 @@ export function outputFormatsForEnvironment(
 export function OutputFormatPicker(
   props: OutputFormatPickerProps
 ): JSX.Element | null {
-  const outputFormats = outputFormatsForEnvironment(props.environmentList, props.environment);
+  const outputFormats = outputFormatsForEnvironment(
+    props.environmentList,
+    props.environment
+  );
 
   if (outputFormats === null) {
     return null;

--- a/src/components/output-format-picker.tsx
+++ b/src/components/output-format-picker.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useMemo } from 'react';
+import React, { ChangeEvent } from 'react';
 
 import { Checkbox, FormControlLabel, InputLabel } from '@mui/material';
 
@@ -13,23 +13,16 @@ export type OutputFormatPickerProps = {
   name: string;
   id: string;
   environment: string;
+  environmentList: Scheduler.IRuntimeEnvironment[];
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   value: IOutputFormat[];
 };
 
 export function outputFormatsForEnvironment(
+  environmentList: Scheduler.IRuntimeEnvironment[],
   environment: string
 ): IOutputFormat[] | null {
-  // Retrieve the environment data from session storage.
-  const environmentsData = sessionStorage.getItem('environments');
-  if (environmentsData === null) {
-    return null;
-  }
-
-  const environments = JSON.parse(
-    environmentsData
-  ) as Array<Scheduler.IRuntimeEnvironment>;
-  const environmentObj = environments.find(env => env.name === environment);
+  const environmentObj = environmentList.find(env => env.name === environment);
   if (!environmentObj || !environmentObj['output_formats']) {
     return null;
   }
@@ -40,10 +33,8 @@ export function outputFormatsForEnvironment(
 export function OutputFormatPicker(
   props: OutputFormatPickerProps
 ): JSX.Element | null {
-  const outputFormats = useMemo(
-    () => outputFormatsForEnvironment(props.environment),
-    [props.environment]
-  );
+  const outputFormats = outputFormatsForEnvironment(props.environmentList, props.environment);
+
   if (outputFormats === null) {
     return null;
   }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -338,7 +338,7 @@ export namespace Scheduler {
     description: string;
     file_extensions: string[];
     output_formats: IOutputFormat[];
-    metadata: { [key: string]: any };
+    metadata: { [key: string]: string };
     compute_types: string[] | null;
   }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -338,6 +338,7 @@ export namespace Scheduler {
     file_extensions: string[];
     output_formats: IOutputFormat[];
     metadata: { [key: string]: any };
+    compute_types: string[] | null;
   }
 
   export interface IOutputFormat {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -278,6 +278,7 @@ export namespace Scheduler {
     retry_on_timeout?: boolean;
     output_filename_template?: string;
     output_formats?: string[];
+    compute_type?: string;
   }
 
   export type Status =

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -2,7 +2,10 @@ import React, { ChangeEvent, useEffect, useState } from 'react';
 
 import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
-import { OutputFormatPicker, outputFormatsForEnvironment } from '../components/output-format-picker';
+import {
+  OutputFormatPicker,
+  outputFormatsForEnvironment
+} from '../components/output-format-picker';
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
 import SchedulerTokens from '../tokens';
@@ -56,7 +59,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   );
 
   // Cache environment list.
-  const [environmentList, setEnvironmentList] = useState<Scheduler.IRuntimeEnvironment[]>([]);
+  const [environmentList, setEnvironmentList] = useState<
+    Scheduler.IRuntimeEnvironment[]
+  >([]);
 
   // A mapping from input names to error messages.
   // If an error message is "truthy" (i.e., not null or ''), we should display the

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -149,7 +149,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       name: props.model.jobName,
       input_uri: props.model.inputFile,
       output_prefix: props.model.outputPath,
-      runtime_environment_name: props.model.environment
+      runtime_environment_name: props.model.environment,
+      compute_type: props.model.computeType
     };
 
     if (props.model.parameters !== undefined) {
@@ -178,10 +179,6 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       jobOptions.output_formats = props.model.outputFormats.map(
         entry => entry.name
       );
-    }
-
-    if (props.model.computeType !== undefined) {
-      jobOptions.compute_type = props.model.computeType;
     }
 
     api.createJob(jobOptions).then(response => {

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -296,7 +296,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             id={`${formPrefix}computeType`}
             onChange={handleSelectChange}
             environment={props.model.environment}
-            initialValue={props.model.computeType || ''}          
+            initialValue={props.model.computeType || ''}
           />
           <ParametersPicker
             label={trans.__('Parameters')}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -18,6 +18,7 @@ import Stack from '@mui/system/Stack';
 import TextField from '@mui/material/TextField';
 import { EnvironmentPicker } from '../components/environment-picker';
 import { SelectChangeEvent } from '@mui/material';
+import { ComputeTypePicker } from '../components/compute-type-picker';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -287,6 +288,14 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             onChange={handleOutputFormatsChange}
             environment={props.model.environment}
             value={props.model.outputFormats || []}
+          />
+          <ComputeTypePicker
+            label={trans.__('Compute type')}
+            name="computeType"
+            id={`${formPrefix}computeType`}
+            onChange={handleSelectChange}
+            environment={props.model.environment}
+            initialValue={props.model.computeType || ''}          
           />
           <ParametersPicker
             label={trans.__('Parameters')}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -180,6 +180,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       );
     }
 
+    if (props.model.computeType !== undefined) {
+      jobOptions.compute_type = props.model.computeType;
+    }
+
     api.createJob(jobOptions).then(response => {
       props.toggleView();
     });

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -161,11 +161,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
               label={trans.__('Environment')}
               defaultValue={job?.runtime_environment_name ?? ''}
             />
-            <TextFieldStyled
-              label={trans.__('Status')}
-              defaultValue={job?.status ?? ''}
-            />
-
             <FormControl component="fieldset">
               <FormLabel component="legend">
                 {trans.__('Output formats')}
@@ -181,7 +176,14 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                   ))}
               </FormGroup>
             </FormControl>
-
+            <TextFieldStyled
+              label={trans.__('Compute type')}
+              defaultValue={job?.compute_type ?? ''}
+            />
+            <TextFieldStyled
+              label={trans.__('Status')}
+              defaultValue={job?.status ?? ''}
+            />
             <Accordion defaultExpanded={true}>
               <AccordionSummary
                 expandIcon={<caretDownIcon.react />}

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -67,7 +67,9 @@ export function NotebookJobsListBody(
   const theme = useTheme();
 
   // Cache environment list — we need this for the output formats.
-  const [environmentList, setEnvironmentList] = useState<Scheduler.IRuntimeEnvironment[]>([]);
+  const [environmentList, setEnvironmentList] = useState<
+    Scheduler.IRuntimeEnvironment[]
+  >([]);
 
   const api = new SchedulerService({});
 

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -66,6 +66,20 @@ export function NotebookJobsListBody(
   const [loading, setLoading] = useState<boolean>(false);
   const theme = useTheme();
 
+  // Cache environment list — we need this for the output formats.
+  const [environmentList, setEnvironmentList] = useState<Scheduler.IRuntimeEnvironment[]>([]);
+
+  const api = new SchedulerService({});
+
+  // Retrieve the environment list once.
+  useEffect(() => {
+    const setList = async () => {
+      setEnvironmentList(await api.getRuntimeEnvironments());
+    };
+
+    setList();
+  }, []);
+
   const deleteRow = useCallback((id: Scheduler.IDescribeJob['job_id']) => {
     setDeletedRows(deletedRows => new Set([...deletedRows, id]));
   }, []);
@@ -205,6 +219,7 @@ export function NotebookJobsListBody(
     .map(job =>
       buildTableRow(
         job,
+        environmentList,
         props.app,
         props.showCreateJob,
         deleteRow,

--- a/src/model.ts
+++ b/src/model.ts
@@ -84,6 +84,7 @@ export interface ICreateJobModel {
   environment: string;
   parameters?: IJobParameter[];
   outputFormats?: IOutputFormat[];
+  computeType?: string;
 }
 
 export interface IListJobsModel {


### PR DESCRIPTION
Partial fix for #23.

After the user selects an environment, if the environment has a non-null list of compute types, display a dropdown for compute type. Serialize the compute type in the POST request to create a job.

Demo with mocked list of compute types:

https://user-images.githubusercontent.com/93281816/192654979-1557805d-a5e8-4f7a-920e-fef3a6da6ac3.mov


