### PR TITLE
Theme improvements to better align with JupyterLab styling

### DIFF
--- a/src/theme-provider.ts
+++ b/src/theme-provider.ts
@@ -8,6 +8,75 @@ export function getJupyterLabTheme(): Theme {
   const light = document.body.getAttribute('data-jp-theme-light');
   return createTheme({
     spacing: 4,
+    components: {
+      MuiButton: {
+        defaultProps: {
+          size: 'small'
+        }
+      },
+      MuiFilledInput: {
+        defaultProps: {
+          margin: 'dense'
+        }
+      },
+      MuiFormControl: {
+        defaultProps: {
+          margin: 'dense'
+        }
+      },
+      MuiFormHelperText: {
+        defaultProps: {
+          margin: 'dense'
+        }
+      },
+      MuiIconButton: {
+        defaultProps: {
+          size: 'small'
+        }
+      },
+      MuiInputBase: {
+        defaultProps: {
+          margin: 'dense',
+          size: 'small'
+        }
+      },
+      MuiInputLabel: {
+        defaultProps: {
+          margin: 'dense'
+        }
+      },
+      MuiListItem: {
+        defaultProps: {
+          dense: true
+        }
+      },
+      MuiOutlinedInput: {
+        defaultProps: {
+          margin: 'dense'
+        }
+      },
+      MuiFab: {
+        defaultProps: {
+          size: 'small'
+        }
+      },
+      MuiTable: {
+        defaultProps: {
+          size: 'small'
+        }
+      },
+      MuiTextField: {
+        defaultProps: {
+          margin: 'dense',
+          size: 'small'
+        }
+      },
+      MuiToolbar: {
+        defaultProps: {
+          variant: 'dense'
+        }
+      }
+    },
     palette: {
       mode: light === 'true' ? 'light' : 'dark',
       primary: {
@@ -18,6 +87,9 @@ export function getJupyterLabTheme(): Theme {
         secondary: getCSSVariable('--jp-ui-font-color2'),
         disabled: getCSSVariable('--jp-ui-font-color3')
       }
+    },
+    shape: {
+      borderRadius: 2
     },
     typography: {
       fontFamily: getCSSVariable('--jp-ui-font-family'),

--- a/src/theme-provider.ts
+++ b/src/theme-provider.ts
@@ -80,7 +80,24 @@ export function getJupyterLabTheme(): Theme {
     palette: {
       mode: light === 'true' ? 'light' : 'dark',
       primary: {
-        main: getCSSVariable('--jp-brand-color1')
+        main: getCSSVariable('--jp-brand-color1'),
+        light: getCSSVariable('--jp-brand-color2'),
+        dark: getCSSVariable('--jp-brand-color0')
+      },
+      error: {
+        main: getCSSVariable('--jp-error-color1'),
+        light: getCSSVariable('--jp-error-color2'),
+        dark: getCSSVariable('--jp-error-color0')
+      },
+      warning: {
+        main: getCSSVariable('--jp-warn-color1'),
+        light: getCSSVariable('--jp-warn-color2'),
+        dark: getCSSVariable('--jp-warn-color0')
+      },
+      success: {
+        main: getCSSVariable('--jp-success-color1'),
+        light: getCSSVariable('--jp-success-color2'),
+        dark: getCSSVariable('--jp-success-color0')
       },
       text: {
         primary: getCSSVariable('--jp-ui-font-color1'),


### PR DESCRIPTION
* Uses small and dense MUI sizing where relevant.
* Changes default border radius to 2 to match the JLab default.
* Pull other color sequences from JupyterLab CSS variables.

Examples:

<img width="1007" alt="Screen Shot 2022-09-29 at 12 40 08 PM" src="https://user-images.githubusercontent.com/27600/193127209-3a81a78b-9657-4d74-91fa-3f3c4575365f.png">

<img width="930" alt="Screen Shot 2022-09-29 at 12 40 20 PM" src="https://user-images.githubusercontent.com/27600/193127240-41f1ed1b-1481-479b-9579-1eaeff8856d3.png">


