### PR TITLE
Additional padding to cause icon buttons to be circular

### DIFF
--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -1,12 +1,11 @@
 import React, { ChangeEvent } from 'react';
 
-import { addIcon, closeIcon } from '@jupyterlab/ui-components';
+import { FormLabel, Stack, TextField } from '@mui/material';
 
-import { FormLabel, IconButton, Stack, TextField } from '@mui/material';
-
+import { Cluster } from './components/cluster';
+import { AddButton, DeleteButton } from './components/icon-buttons';
 import { useTranslator } from './hooks';
 import Scheduler from './tokens';
-import { Cluster } from './components/cluster';
 
 const AdvancedOptions = (
   props: Scheduler.IAdvancedOptionsProps
@@ -81,29 +80,24 @@ const AdvancedOptions = (
               value={tag}
               onChange={handleTagChange}
             />
-            <IconButton
-              aria-label="delete"
+            <DeleteButton
               onClick={() => {
                 // Remove tag
                 deleteTag(idx);
                 return false;
               }}
               title={trans.__('Delete tag %1', idx + 1)}
-            >
-              <closeIcon.react />
-            </IconButton>
+            />
           </Cluster>
         ))}
         <Cluster justifyContent="flex-start">
-          <IconButton
+          <AddButton
             onClick={(e: React.MouseEvent) => {
               addTag();
               return false;
             }}
             title={trans.__('Add new tag')}
-          >
-            <addIcon.react />
-          </IconButton>
+          />
         </Cluster>
       </Stack>
     );

--- a/src/components/icon-buttons.tsx
+++ b/src/components/icon-buttons.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { addIcon, closeIcon } from '@jupyterlab/ui-components';
+import { IconButton } from '@mui/material';
+
+export interface IDeleteButtonProps {
+  onClick: React.MouseEventHandler<HTMLButtonElement> | undefined;
+  title: string;
+}
+
+// Exaggerate horizontal padding to make the button circular, not oblate
+const extraHorizontalPadding = { px: '12.5px', py: '8px' };
+
+export function DeleteButton(props: IDeleteButtonProps): JSX.Element {
+  return (
+    <IconButton
+      aria-label="delete"
+      onClick={props.onClick}
+      title={props.title}
+      sx={extraHorizontalPadding}
+    >
+      <closeIcon.react />
+    </IconButton>
+  );
+}
+
+export function AddButton(props: IDeleteButtonProps): JSX.Element {
+  return (
+    <IconButton
+      onClick={props.onClick}
+      title={props.title}
+      sx={extraHorizontalPadding}
+    >
+      <addIcon.react />
+    </IconButton>
+  );
+}

--- a/src/components/icon-buttons.tsx
+++ b/src/components/icon-buttons.tsx
@@ -8,8 +8,8 @@ export interface IDeleteButtonProps {
   title: string;
 }
 
-// Exaggerate horizontal padding to make the button circular, not oblate
-const extraHorizontalPadding = { px: '12.5px', py: '8px' };
+// Avoid extra vertical padding to force icon to be a square inside a circle
+const zeroLineHeight = { lineHeight: 0 };
 
 export function DeleteButton(props: IDeleteButtonProps): JSX.Element {
   return (
@@ -17,7 +17,7 @@ export function DeleteButton(props: IDeleteButtonProps): JSX.Element {
       aria-label="delete"
       onClick={props.onClick}
       title={props.title}
-      sx={extraHorizontalPadding}
+      sx={zeroLineHeight}
     >
       <closeIcon.react />
     </IconButton>
@@ -26,11 +26,7 @@ export function DeleteButton(props: IDeleteButtonProps): JSX.Element {
 
 export function AddButton(props: IDeleteButtonProps): JSX.Element {
   return (
-    <IconButton
-      onClick={props.onClick}
-      title={props.title}
-      sx={extraHorizontalPadding}
-    >
+    <IconButton onClick={props.onClick} title={props.title} sx={zeroLineHeight}>
       <addIcon.react />
     </IconButton>
   );

--- a/src/components/parameters-picker.tsx
+++ b/src/components/parameters-picker.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent } from 'react';
 
-import { addIcon, closeIcon, LabIcon } from '@jupyterlab/ui-components';
+import { addIcon, closeIcon } from '@jupyterlab/ui-components';
 
 import { IconButton, InputLabel, TextField } from '@mui/material';
 import Stack from '@mui/system/Stack';
@@ -43,6 +43,7 @@ export function ParametersPicker(props: ParametersPickerProps): JSX.Element {
             placeholder={trans.__('Value')}
             onChange={props.onChange}
           />
+          {/* Exaggerate horizontal padding to make the button circular, not oblate */}
           <IconButton
             aria-label="delete"
             onClick={() => {
@@ -50,21 +51,24 @@ export function ParametersPicker(props: ParametersPickerProps): JSX.Element {
               return false;
             }}
             title={trans.__('Delete this parameter')}
+            sx={{ px: '12.5px', py: '8px' }}
           >
-            <LabIcon.resolveReact icon={closeIcon} tag="span" />
+            <closeIcon.react />
           </IconButton>
         </Cluster>
       ))}
       {/* A one-item cluster to prevent the add-param button from being as wide as the widget */}
       <Cluster justifyContent="flex-start">
+        {/* Exaggerate horizontal padding to make the button circular, not oblate */}
         <IconButton
           onClick={(e: React.MouseEvent) => {
             props.addParameter();
             return false;
           }}
           title={trans.__('Add new parameter')}
+          sx={{ px: '12.5px', py: '8px' }}
         >
-          <LabIcon.resolveReact icon={addIcon} tag="span" />
+          <addIcon.react />
         </IconButton>
       </Cluster>
     </Stack>

--- a/src/components/parameters-picker.tsx
+++ b/src/components/parameters-picker.tsx
@@ -1,13 +1,12 @@
 import React, { ChangeEvent } from 'react';
 
-import { addIcon, closeIcon } from '@jupyterlab/ui-components';
-
-import { IconButton, InputLabel, TextField } from '@mui/material';
+import { InputLabel, TextField } from '@mui/material';
 import Stack from '@mui/system/Stack';
 
 import { Cluster } from '../components/cluster';
 import { IJobParameter } from '../model';
 import { useTranslator } from '../hooks';
+import { AddButton, DeleteButton } from './icon-buttons';
 
 export type ParametersPickerProps = {
   label: string;
@@ -43,33 +42,24 @@ export function ParametersPicker(props: ParametersPickerProps): JSX.Element {
             placeholder={trans.__('Value')}
             onChange={props.onChange}
           />
-          {/* Exaggerate horizontal padding to make the button circular, not oblate */}
-          <IconButton
-            aria-label="delete"
+          <DeleteButton
             onClick={() => {
               props.removeParameter(paramIdx);
               return false;
             }}
             title={trans.__('Delete this parameter')}
-            sx={{ px: '12.5px', py: '8px' }}
-          >
-            <closeIcon.react />
-          </IconButton>
+          />
         </Cluster>
       ))}
       {/* A one-item cluster to prevent the add-param button from being as wide as the widget */}
       <Cluster justifyContent="flex-start">
-        {/* Exaggerate horizontal padding to make the button circular, not oblate */}
-        <IconButton
+        <AddButton
           onClick={(e: React.MouseEvent) => {
             props.addParameter();
             return false;
           }}
           title={trans.__('Add new parameter')}
-          sx={{ px: '12.5px', py: '8px' }}
-        >
-          <addIcon.react />
-        </IconButton>
+        />
       </Cluster>
     </Stack>
   );


### PR DESCRIPTION
Add and delete buttons are now circular, not 🥚 -shaped.

![image](https://user-images.githubusercontent.com/93281816/193144107-aad0ded8-a385-4086-a4a9-26c0aae96299.png)

![image](https://user-images.githubusercontent.com/93281816/193144136-1f6d4698-8bbc-448e-9337-fc1c16bc5d18.png)
