### PR TITLE
keep stop button area even when not shown

### DIFF
--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -25,21 +25,21 @@ function StopButton(props: {
   job: Scheduler.IDescribeJob;
   clickHandler: () => void;
 }): JSX.Element | null {
-  if (props.job.status !== 'IN_PROGRESS') {
-    return null;
-  }
-
   const trans = useTranslator('jupyterlab');
   const buttonTitle = props.job.name
     ? trans.__('Stop "%1"', props.job.name)
     : trans.__('Stop job');
 
   return (
-    <ToolbarButtonComponent
-      onClick={props.clickHandler}
-      tooltip={buttonTitle}
-      icon={stopIcon}
-    />
+    <div
+      style={props.job.status !== 'IN_PROGRESS' ? { visibility: 'hidden' } : {}}
+    >
+      <ToolbarButtonComponent
+        onClick={props.clickHandler}
+        tooltip={buttonTitle}
+        icon={stopIcon}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
Keeps the stop button area when not shown to keep all action buttons of a common type in a single column.

<img width="1044" alt="Screen Shot 2022-09-30 at 12 36 26 PM" src="https://user-images.githubusercontent.com/44106031/193344157-7ad608ac-3bf3-49ab-8134-f25802e88308.png">
