### PR TITLE
Fix for deduping token for advanced options extension point

### DIFF
--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -5,7 +5,7 @@ import { FormLabel, Stack, TextField } from '@mui/material';
 import { Cluster } from './components/cluster';
 import { AddButton, DeleteButton } from './components/icon-buttons';
 import { useTranslator } from './hooks';
-import Scheduler from './tokens';
+import { Scheduler } from './tokens';
 
 const AdvancedOptions = (
   props: Scheduler.IAdvancedOptionsProps

--- a/src/components/parameters-picker.tsx
+++ b/src/components/parameters-picker.tsx
@@ -7,7 +7,7 @@ import { Cluster } from '../components/cluster';
 import { IJobParameter } from '../model';
 import { useTranslator } from '../hooks';
 import { AddButton, DeleteButton } from './icon-buttons';
-import Scheduler from '../tokens';
+import { Scheduler } from '../tokens';
 
 export type ParametersPickerProps = {
   label: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ import {
   calendarMonthIcon,
   eventNoteIcon
 } from './components/icons';
-import Scheduler from './tokens';
+import { Scheduler } from './tokens';
 import AdvancedOptions from './advanced-options';
 
 export namespace CommandIDs {
@@ -37,6 +37,7 @@ export namespace CommandIDs {
 }
 
 export const NotebookJobsPanelId = 'notebook-jobs-panel';
+export { Scheduler } from './tokens'
 
 /**
  * Initialization data for the jupyterlab-scheduler extension.

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -12,7 +12,7 @@ import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
 import { ICreateJobModel, IOutputFormat } from '../model';
-import SchedulerTokens from '../tokens';
+import { Scheduler as SchedulerTokens } from '../tokens';
 
 import Button from '@mui/material/Button';
 import Box from '@mui/system/Box';

--- a/src/mainviews/job-detail.tsx
+++ b/src/mainviews/job-detail.tsx
@@ -31,7 +31,7 @@ import { caretDownIcon } from '@jupyterlab/ui-components';
 import { Heading } from '../components/heading';
 import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
-import SchedulerTokens from '../tokens';
+import { Scheduler as SchedulerTokens } from '../tokens';
 
 export interface IJobDetailProps {
   app: JupyterFrontEnd;

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -14,7 +14,7 @@ import { NotebookJobsList } from './mainviews/list-jobs';
 import { JobDetail } from './mainviews/job-detail';
 import { ICreateJobModel, JobsModel } from './model';
 import { getJupyterLabTheme } from './theme-provider';
-import Scheduler from './tokens';
+import { Scheduler } from './tokens';
 
 export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   readonly _title?: string;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,7 +1,7 @@
 import { Token } from '@lumino/coreutils';
 import { ICreateJobModel, IJobDetailModel, JobsView } from './model';
 
-namespace Scheduler {
+export namespace Scheduler {
   export type EnvironmentParameterValue = string | number | boolean;
 
   export type ErrorsType = { [key: string]: string };
@@ -20,5 +20,3 @@ namespace Scheduler {
     '@jupyterlab/scheduler:IAdvancedOptions'
   );
 }
-
-export default Scheduler;


### PR DESCRIPTION
Plugin tokens are only deduped if they are imported directly from the package reference `@jupyterlab/scheduler`. Exporting the tokens from index to allow this. This fixes the issue with implementing advanced options extension point.