### PR TITLE
Added default formats when no formats are selected

### DIFF
--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -145,6 +145,9 @@ class Scheduler(BaseScheduler):
             if job:
                 return job.job_id
 
+            if not model.output_formats:
+                model.output_formats = ["ipynb"]
+
             job = Job(**model.dict(exclude_none=True))
             session.add(job)
             session.commit()


### PR DESCRIPTION
Adds a default format of `ipynb` if no selection is made when creating a job. This fixes the Output files listing in detail job view.