### PR TITLE
More restrictive types for runtime environment parameters

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -266,6 +266,7 @@ export namespace Scheduler {
     input_uri: string;
     output_prefix: string;
     runtime_environment_name: string;
+    runtime_environment_parameters?: { [key: string]: any };
     idempotency_token?: string;
     job_definition_id?: string;
     parameters?: { [key: string]: any };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -266,7 +266,7 @@ export namespace Scheduler {
     input_uri: string;
     output_prefix: string;
     runtime_environment_name: string;
-    runtime_environment_parameters?: { [key: string]: any };
+    runtime_environment_parameters?: { [key: string]: number | string };
     idempotency_token?: string;
     job_definition_id?: string;
     parameters?: { [key: string]: any };

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -176,7 +176,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       runtime_environment_name: props.model.environment,
       compute_type: props.model.computeType,
       idempotency_token: props.model.idempotencyToken,
-      tags: props.model.tags
+      tags: props.model.tags,
+      runtime_environment_parameters: props.model.runtimeEnvironmentParameters
     };
 
     if (props.model.parameters !== undefined) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -82,6 +82,7 @@ export interface ICreateJobModel {
   inputFile: string;
   outputPath: string;
   environment: string;
+  runtimeEnvironmentParameters?: { [key: string]: any };
   parameters?: IJobParameter[];
   outputFormats?: IOutputFormat[];
   computeType?: string;

--- a/src/model.ts
+++ b/src/model.ts
@@ -82,7 +82,7 @@ export interface ICreateJobModel {
   inputFile: string;
   outputPath: string;
   environment: string;
-  runtimeEnvironmentParameters?: { [key: string]: any };
+  runtimeEnvironmentParameters?: { [key: string]: number | string };
   parameters?: IJobParameter[];
   outputFormats?: IOutputFormat[];
   computeType?: string;


### PR DESCRIPTION
Replaces `any` with `string | number` to match API expectations