### PR TITLE
Add job definition list UI

### DIFF
--- a/src/components/advanced-table/advanced-table-header.tsx
+++ b/src/components/advanced-table/advanced-table-header.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { caretDownIcon, caretUpIcon, LabIcon } from '@jupyterlab/ui-components';
+import TableHead from '@mui/material/TableHead';
+import TableCell from '@mui/material/TableCell';
+
+import { AdvancedTableColumn, AdvancedTableQuery } from './advanced-table';
+import { Scheduler } from '../../handler';
+
+type AdvancedTableHeaderProps<Q extends AdvancedTableQuery> = {
+  columns: AdvancedTableColumn[];
+  query: Q;
+  setQuery: React.Dispatch<React.SetStateAction<Q>>;
+};
+
+export function AdvancedTableHeader<Q extends AdvancedTableQuery>(
+  props: AdvancedTableHeaderProps<Q>
+): JSX.Element {
+  return (
+    <TableHead>
+      {props.columns.map((column, idx) => (
+        <AdvancedTableHeaderCell
+          key={idx}
+          column={column}
+          query={props.query}
+          setQuery={props.setQuery}
+        />
+      ))}
+    </TableHead>
+  );
+}
+
+const sortAscendingIcon = (
+  <LabIcon.resolveReact icon={caretUpIcon} tag="span" />
+);
+const sortDescendingIcon = (
+  <LabIcon.resolveReact icon={caretDownIcon} tag="span" />
+);
+
+type AdvancedTableHeaderCellProps<Q extends AdvancedTableQuery> = Pick<
+  AdvancedTableHeaderProps<Q>,
+  'query' | 'setQuery'
+> & {
+  column: AdvancedTableColumn;
+};
+
+function AdvancedTableHeaderCell<Q extends AdvancedTableQuery>(
+  props: AdvancedTableHeaderCellProps<Q>
+): JSX.Element {
+  const sort = props.query.sort_by;
+  const defaultSort = sort?.[0];
+
+  const headerIsDefaultSort =
+    defaultSort && defaultSort.name === props.column.sortField;
+  const isSortedAscending =
+    headerIsDefaultSort &&
+    defaultSort &&
+    defaultSort.direction === Scheduler.SortDirection.ASC;
+  const isSortedDescending =
+    headerIsDefaultSort &&
+    defaultSort &&
+    defaultSort.direction === Scheduler.SortDirection.DESC;
+
+  const sortByThisColumn = () => {
+    // If this field is not sortable, do nothing.
+    if (!props.column.sortField) {
+      return;
+    }
+
+    // Change the sort of this column.
+    // If not sorted at all or if sorted descending, sort ascending. If sorted ascending, sort descending.
+    const newSortDirection = isSortedAscending
+      ? Scheduler.SortDirection.DESC
+      : Scheduler.SortDirection.ASC;
+
+    // Set the new sort direction.
+    const newSort: Scheduler.ISortField = {
+      name: props.column.sortField,
+      direction: newSortDirection
+    };
+
+    // If this field is already present in the sort list, remove it.
+    const oldSortList = sort || [];
+    const newSortList = [
+      newSort,
+      ...oldSortList.filter(item => item.name !== props.column.sortField)
+    ];
+
+    // Sub the new sort list in to the query.
+    props.setQuery(query => ({ ...query, sort_by: newSortList }));
+  };
+
+  return (
+    <TableCell
+      onClick={sortByThisColumn}
+      sx={props.column.sortField ? { cursor: 'pointer' } : {}}
+    >
+      {props.column.name}
+      {isSortedAscending && sortAscendingIcon}
+      {isSortedDescending && sortDescendingIcon}
+    </TableCell>
+  );
+}

--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from 'react';
+
+import { useTheme } from '@mui/material/styles';
+import Table from '@mui/material/Table';
+import TableContainer from '@mui/material/TableContainer';
+import TableBody from '@mui/material/TableBody';
+import TablePagination from '@mui/material/TablePagination';
+import Paper from '@mui/material/Paper';
+
+import { Scheduler } from '../../handler';
+import { AdvancedTableHeader } from './advanced-table-header';
+
+const PAGE_SIZE = 25;
+
+export type AdvancedTableColumn = {
+  sortField: string | null;
+  name: string;
+};
+
+type AdvancedTablePayload =
+  | {
+      next_token?: string;
+      total_count: number;
+    }
+  | undefined;
+
+export type AdvancedTableQuery = {
+  max_items?: number;
+  next_token?: string;
+  sort_by?: Scheduler.ISortField[];
+};
+
+/**
+ * P = payload (response) type, Q = query (request) type, R = row type
+ *
+ * Requires `next_token` to be defined in Q to function.
+ */
+type AdvancedTableProps<
+  P extends AdvancedTablePayload,
+  Q extends AdvancedTableQuery,
+  R
+> = {
+  query: Q;
+  setQuery: React.Dispatch<React.SetStateAction<Q>>;
+  request: (query: Q) => Promise<P>;
+  renderRow: (row: R) => JSX.Element;
+  extractRows: (payload: P) => R[];
+  columns: AdvancedTableColumn[];
+  emptyRowMessage: string;
+  rowFilter?: (row: R) => boolean;
+};
+
+/**
+ * Advanced table that automatically fills remaining screen width, asynchronous
+ * pagination, and loading states.
+ */
+export function AdvancedTable<
+  P extends AdvancedTablePayload,
+  Q extends AdvancedTableQuery,
+  R
+>(props: AdvancedTableProps<P, Q, R>): JSX.Element {
+  const [rows, setRows] = useState<R[]>();
+  const [nextToken, setNextToken] = useState<string>();
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [page, setPage] = useState<number>(0);
+  const [maxPage, setMaxPage] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(true);
+  const theme = useTheme();
+
+  const fetchInitialRows = async () => {
+    // reset pagination state
+    setPage(0);
+    setMaxPage(0);
+
+    setLoading(true);
+    const payload = await props.request({
+      ...props.query,
+      max_items: PAGE_SIZE
+    });
+    setLoading(false);
+
+    // TODO: more elegant handling of a failed network request.
+    if (!payload) {
+      return;
+    }
+
+    setRows(props.extractRows(payload));
+    setNextToken(payload.next_token);
+    setTotalCount(payload.total_count);
+  };
+
+  // Fetch the initial rows asynchronously on component creation
+  // After setJobsQuery is called, force a reload.
+  useEffect(() => {
+    fetchInitialRows();
+  }, [props.query]);
+
+  const fetchMoreRows = async () => {
+    // Do nothing if the next token is undefined (shouldn't happen, but required for type safety)
+    if (nextToken === undefined) {
+      return;
+    }
+
+    // Apply the custom token to the existing query parameters
+    setLoading(true);
+    const payload = await props.request({
+      ...props.query,
+      max_items: PAGE_SIZE,
+      next_token: nextToken
+    });
+    setLoading(false);
+
+    if (!payload) {
+      return;
+    }
+
+    // Merge the two lists of jobs and keep the next token from the new response.
+    setRows(rows => [...(rows || []), ...(props.extractRows(payload) || [])]);
+    setNextToken(payload.next_token);
+    setTotalCount(payload.total_count);
+  };
+
+  if (rows && !rows.length) {
+    return (
+      <p className={'jp-notebook-job-list-empty'}>{props.emptyRowMessage}</p>
+    );
+  }
+
+  const renderedRows: JSX.Element[] = (rows || [])
+    .slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+    .filter(row => (props.rowFilter ? props.rowFilter(row) : true))
+    .map(row => props.renderRow(row));
+
+  const handlePageChange = async (e: unknown, newPage: number) => {
+    // if newPage <= maxPage, no need to fetch more rows
+    if (newPage <= maxPage) {
+      setPage(newPage);
+      return;
+    }
+
+    await fetchMoreRows();
+    setPage(newPage);
+    setMaxPage(newPage);
+  };
+
+  // outer div expands to fill rest of screen
+  return (
+    <div style={{ flex: 1, height: 0 }}>
+      <TableContainer
+        component={Paper}
+        sx={{
+          height: '100%',
+          ...(loading ? { pointerEvents: 'none', opacity: 0.5 } : {})
+        }}
+      >
+        <Table stickyHeader>
+          <AdvancedTableHeader
+            columns={props.columns}
+            query={props.query}
+            setQuery={props.setQuery}
+          />
+          <TableBody>{renderedRows}</TableBody>
+        </Table>
+        <TablePagination
+          component="div"
+          sx={{
+            position: 'sticky',
+            bottom: 0,
+            backgroundColor: theme.palette.background.paper,
+            borderTop: `1px solid ${theme.palette.divider}`
+          }}
+          count={totalCount}
+          page={page}
+          onPageChange={handlePageChange}
+          nextIconButtonProps={{
+            disabled: page === maxPage && !nextToken
+          }}
+          rowsPerPage={PAGE_SIZE}
+          rowsPerPageOptions={[PAGE_SIZE]}
+        />
+      </TableContainer>
+    </div>
+  );
+}

--- a/src/components/advanced-table/index.tsx
+++ b/src/components/advanced-table/index.tsx
@@ -1,1 +1,1 @@
-export { AdvancedTable } from './advanced-table';
+export * from './advanced-table';

--- a/src/components/advanced-table/index.tsx
+++ b/src/components/advanced-table/index.tsx
@@ -1,0 +1,1 @@
+export { AdvancedTable } from './advanced-table';

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import TableRow from '@mui/material/TableRow';
+import TableCell from '@mui/material/TableCell';
+
+import { Scheduler } from '../handler';
+
+export function buildJobDefinitionRow(
+  jobDef: Scheduler.IDescribeJobDefinition,
+  app: JupyterFrontEnd,
+  openJobDefinitionDetail: (jobDefId: string) => unknown
+) {
+  const cellContents: React.ReactNode[] = [
+    // name
+    <a onClick={() => openJobDefinitionDetail(jobDef.job_definition_id)}>
+      {jobDef.name}
+    </a>
+  ];
+
+  return (
+    <TableRow>
+      {cellContents.map((cellContent, idx) => (
+        <TableCell key={idx}>{cellContent}</TableCell>
+      ))}
+    </TableRow>
+  );
+}

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -1,20 +1,38 @@
 import React from 'react';
+
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { PathExt } from '@jupyterlab/coreutils';
+
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 
 import { Scheduler } from '../handler';
 
+function CreatedAt(props: {
+  job: Scheduler.IDescribeJobDefinition;
+}): JSX.Element | null {
+  const create_date: Date | null = props.job.create_time
+    ? new Date(props.job.create_time)
+    : null;
+  const create_display_date: string | null = create_date
+    ? create_date.toLocaleString()
+    : null;
+
+  return <>{create_display_date}</>;
+}
+
 export function buildJobDefinitionRow(
   jobDef: Scheduler.IDescribeJobDefinition,
   app: JupyterFrontEnd,
   openJobDefinitionDetail: (jobDefId: string) => unknown
-) {
+): JSX.Element {
   const cellContents: React.ReactNode[] = [
     // name
     <a onClick={() => openJobDefinitionDetail(jobDef.job_definition_id)}>
       {jobDef.name}
-    </a>
+    </a>,
+    PathExt.basename(jobDef.input_uri),
+    <CreatedAt job={jobDef} />
   ];
 
   return (

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -164,7 +164,7 @@ function OutputFiles(props: {
   );
 }
 
-export function buildTableRow(
+export function buildJobRow(
   job: Scheduler.IDescribeJob,
   environmentList: Scheduler.IRuntimeEnvironment[],
   app: JupyterFrontEnd,

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -12,7 +12,12 @@ import {
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
-import { ICreateJobModel, IJobParameter, IOutputFormat } from '../model';
+import {
+  ICreateJobModel,
+  IJobParameter,
+  IOutputFormat,
+  ListJobsView
+} from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 
 import Button from '@mui/material/Button';
@@ -34,7 +39,7 @@ import cronstrue from 'cronstrue';
 export interface ICreateJobProps {
   model: ICreateJobModel;
   handleModelChange: (model: ICreateJobModel) => void;
-  toggleView: () => unknown;
+  showListView: (list: ListJobsView) => unknown;
   // Extension point: optional additional component
   advancedOptions: React.FunctionComponent<SchedulerTokens.IAdvancedOptionsProps>;
 }
@@ -280,8 +285,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     }
 
     api.createJob(jobOptions).then(response => {
-      // TODO: Switch to the list view with "Job List" active
-      props.toggleView();
+      // Switch to the list view with "Job List" active
+      props.showListView('Job');
     });
   };
 
@@ -319,8 +324,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     }
 
     api.createJobDefinition(jobDefinitionOptions).then(response => {
-      // TODO: Switch to the list view with "Job Definition List" active
-      props.toggleView();
+      // Switch to the list view with "Job Definition List" active
+      props.showListView('JobDefinition');
     });
   };
 
@@ -495,7 +500,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             handleErrorsChange={setErrors}
           />
           <Cluster gap={3} justifyContent="flex-end">
-            <Button variant="outlined" onClick={props.toggleView}>
+            <Button variant="outlined" onClick={e => props.showListView('Job')}>
               {trans.__('Cancel')}
             </Button>
             <Button

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -1,47 +1,24 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
-
-import { useTranslator } from '../hooks';
-
-import { buildTableRow } from '../components/job-row';
-import {
-  INotebookJobsWithToken,
-  ICreateJobModel,
-  IListJobsModel
-} from '../model';
-import { caretDownIcon, caretUpIcon, LabIcon } from '@jupyterlab/ui-components';
-import { Scheduler, SchedulerService } from '../handler';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
 
 import { Heading } from '../components/heading';
+import { useTranslator } from '../hooks';
+import { buildTableRow } from '../components/job-row';
+import { ICreateJobModel, IListJobsModel } from '../model';
+import { Scheduler, SchedulerService } from '../handler';
 import { Cluster } from '../components/cluster';
-
-import { useTheme } from '@mui/material/styles';
-import Button from '@mui/material/Button';
-import Box from '@mui/system/Box';
-import Stack from '@mui/system/Stack';
-import Table from '@mui/material/Table';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TablePagination from '@mui/material/TablePagination';
-import Paper from '@mui/material/Paper';
-
-export const PAGE_SIZE = 25;
+import { AdvancedTable } from '../components/advanced-table';
 
 interface INotebookJobsListBodyProps {
-  showHeaders?: boolean;
   startToken?: string;
   app: JupyterFrontEnd;
   // Function that results in the create job form being made visible
   // with job details prepopulated.
   showCreateJob: (state: ICreateJobModel) => void;
-  // Function that retrieves some jobs
-  getJobs: (
-    query: Scheduler.IListJobsQuery
-  ) => Promise<INotebookJobsWithToken | undefined>;
   // function that shows job detail view
   showDetailView: (jobId: string) => void;
 }
@@ -54,24 +31,18 @@ type GridColumn = {
 export function NotebookJobsListBody(
   props: INotebookJobsListBodyProps
 ): JSX.Element {
-  const [notebookJobs, setNotebookJobs] = useState<
-    INotebookJobsWithToken | undefined
-  >(undefined);
   const [jobsQuery, setJobsQuery] = useState<Scheduler.IListJobsQuery>({});
   const [deletedRows, setDeletedRows] = useState<
     Set<Scheduler.IDescribeJob['job_id']>
   >(new Set());
-  const [page, setPage] = useState<number>(0);
-  const [maxPage, setMaxPage] = useState<number>(0);
-  const [loading, setLoading] = useState<boolean>(false);
-  const theme = useTheme();
+  const trans = useTranslator('jupyterlab');
 
   // Cache environment list — we need this for the output formats.
   const [environmentList, setEnvironmentList] = useState<
     Scheduler.IRuntimeEnvironment[]
   >([]);
 
-  const api = new SchedulerService({});
+  const api = useMemo(() => new SchedulerService({}), []);
 
   // Retrieve the environment list once.
   useEffect(() => {
@@ -86,55 +57,9 @@ export function NotebookJobsListBody(
     setDeletedRows(deletedRows => new Set([...deletedRows, id]));
   }, []);
 
-  const fetchInitialRows = async () => {
-    // reset pagination state
-    setPage(0);
-    setMaxPage(0);
-    // Get initial job list (next_token is undefined)
-    setLoading(true);
-    const initialNotebookJobs = await props.getJobs(jobsQuery);
-    setLoading(false);
-    setNotebookJobs(initialNotebookJobs);
-  };
-
-  // Fetch the initial rows asynchronously on component creation
-  // After setJobsQuery is called, force a reload.
-  useEffect(() => {
-    fetchInitialRows();
-  }, [jobsQuery]);
-
-  const fetchMoreRows = async (next_token: string | undefined) => {
-    // Do nothing if the next token is undefined (shouldn't happen, but required for type safety)
-    if (next_token === undefined) {
-      return;
-    }
-
-    // Apply the custom token to the existing query parameters
-    setLoading(true);
-    const newNotebookJobs = await props.getJobs({ ...jobsQuery, next_token });
-    setLoading(false);
-
-    if (!newNotebookJobs) {
-      return;
-    }
-
-    // Merge the two lists of jobs and keep the next token from the new response.
-    setNotebookJobs({
-      jobs: [...(notebookJobs?.jobs || []), ...(newNotebookJobs?.jobs || [])],
-      next_token: newNotebookJobs.next_token,
-      total_count: newNotebookJobs.total_count
-    });
-  };
-
-  const trans = useTranslator('jupyterlab');
-
   const reloadButton = (
     <Cluster justifyContent="flex-end">
-      <Button
-        variant="contained"
-        size="small"
-        onClick={() => fetchInitialRows()}
-      >
+      <Button variant="contained" size="small" onClick={() => setJobsQuery({})}>
         {trans.__('Reload')}
       </Button>
     </Cluster>
@@ -165,28 +90,6 @@ export function NotebookJobsListBody(
     [trans]
   );
 
-  if (notebookJobs === undefined) {
-    return (
-      <p>
-        <em>{trans.__('Loading …')}</em>
-      </p>
-    );
-  }
-
-  if (!notebookJobs?.jobs.length) {
-    return (
-      <>
-        {reloadButton}
-        <p className={'jp-notebook-job-list-empty'}>
-          {trans.__(
-            'There are no notebook jobs. ' +
-              'Right-click on a file in the file browser to run or schedule a notebook as a job.'
-          )}
-        </p>
-      </>
-    );
-  }
-
   // Display column headers with sort indicators.
   const columns: GridColumn[] = [
     {
@@ -215,164 +118,47 @@ export function NotebookJobsListBody(
     }
   ];
 
-  const rows: JSX.Element[] = notebookJobs.jobs
-    .slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
-    .filter(job => !deletedRows.has(job.job_id))
-    .map(job =>
-      buildTableRow(
-        job,
-        environmentList,
-        props.app,
-        props.showCreateJob,
-        deleteRow,
-        translateStatus,
-        props.showDetailView
-      )
+  const renderRow = (job: Scheduler.IDescribeJob) =>
+    buildTableRow(
+      job,
+      environmentList,
+      props.app,
+      props.showCreateJob,
+      deleteRow,
+      translateStatus,
+      props.showDetailView
     );
 
-  const handlePageChange = async (e: unknown, newPage: number) => {
-    // if newPage <= maxPage, no need to fetch more rows
-    if (newPage <= maxPage) {
-      setPage(newPage);
-      return;
-    }
+  const rowFilter = (job: Scheduler.IDescribeJob) =>
+    !deletedRows.has(job.job_id);
 
-    await fetchMoreRows(notebookJobs.next_token);
-    setPage(newPage);
-    setMaxPage(newPage);
-  };
+  const emptyRowMessage = useMemo(
+    () =>
+      trans.__(
+        'There are no notebook jobs. ' +
+          'Right-click on a file in the file browser to run or schedule a notebook as a job.'
+      ),
+    [trans]
+  );
 
-  // note that the parent must be a JSX fragment for DataGrid to be sized properly
+  // note that root element here must be a JSX fragment for DataGrid to be sized properly
   return (
     <>
       {reloadButton}
-      {/* outer div expands to fill rest of screen */}
-      <div style={{ flex: 1, height: 0 }}>
-        <TableContainer
-          component={Paper}
-          sx={{
-            height: '100%',
-            ...(loading ? { pointerEvents: 'none', opacity: 0.5 } : {})
-          }}
-        >
-          <Table stickyHeader>
-            <TableHead>
-              {columns.map((column, idx) => (
-                <NotebookJobsColumnHeader
-                  key={idx}
-                  gridColumn={column}
-                  jobsQuery={jobsQuery}
-                  setJobsQuery={setJobsQuery}
-                />
-              ))}
-            </TableHead>
-            <TableBody>{rows}</TableBody>
-          </Table>
-          <TablePagination
-            component="div"
-            sx={{
-              position: 'sticky',
-              bottom: 0,
-              backgroundColor: theme.palette.background.paper,
-              borderTop: `1px solid ${theme.palette.divider}`
-            }}
-            count={notebookJobs.total_count}
-            page={page}
-            onPageChange={handlePageChange}
-            nextIconButtonProps={{
-              disabled: page === maxPage && !notebookJobs.next_token
-            }}
-            rowsPerPage={PAGE_SIZE}
-            rowsPerPageOptions={[PAGE_SIZE]}
-          />
-        </TableContainer>
-      </div>
+      <AdvancedTable
+        query={jobsQuery}
+        setQuery={setJobsQuery}
+        request={api.getJobs.bind(api)}
+        extractRows={(payload: Scheduler.IListJobsResponse) =>
+          payload?.jobs || []
+        }
+        renderRow={renderRow}
+        columns={columns}
+        emptyRowMessage={emptyRowMessage}
+        rowFilter={rowFilter}
+      />
     </>
   );
-}
-
-interface INotebookJobsColumnHeaderProps {
-  gridColumn: GridColumn;
-  jobsQuery: Scheduler.IListJobsQuery;
-  setJobsQuery: React.Dispatch<React.SetStateAction<Scheduler.IListJobsQuery>>;
-}
-
-const sortAscendingIcon = (
-  <LabIcon.resolveReact icon={caretUpIcon} tag="span" />
-);
-const sortDescendingIcon = (
-  <LabIcon.resolveReact icon={caretDownIcon} tag="span" />
-);
-
-function NotebookJobsColumnHeader(
-  props: INotebookJobsColumnHeaderProps
-): JSX.Element {
-  const sort = props.jobsQuery.sort_by;
-  const defaultSort = sort?.[0];
-
-  const headerIsDefaultSort =
-    defaultSort && defaultSort.name === props.gridColumn.sortField;
-  const isSortedAscending =
-    headerIsDefaultSort &&
-    defaultSort &&
-    defaultSort.direction === Scheduler.SortDirection.ASC;
-  const isSortedDescending =
-    headerIsDefaultSort &&
-    defaultSort &&
-    defaultSort.direction === Scheduler.SortDirection.DESC;
-
-  const sortByThisColumn = () => {
-    // If this field is not sortable, do nothing.
-    if (!props.gridColumn.sortField) {
-      return;
-    }
-
-    // Change the sort of this column.
-    // If not sorted at all or if sorted descending, sort ascending. If sorted ascending, sort descending.
-    const newSortDirection = isSortedAscending
-      ? Scheduler.SortDirection.DESC
-      : Scheduler.SortDirection.ASC;
-
-    // Set the new sort direction.
-    const newSort: Scheduler.ISortField = {
-      name: props.gridColumn.sortField,
-      direction: newSortDirection
-    };
-
-    // If this field is already present in the sort list, remove it.
-    const oldSortList = sort || [];
-    const newSortList = [
-      newSort,
-      ...oldSortList.filter(item => item.name !== props.gridColumn.sortField)
-    ];
-
-    // Sub the new sort list in to the query.
-    props.setJobsQuery({ ...props.jobsQuery, sort_by: newSortList });
-  };
-
-  return (
-    <TableCell
-      onClick={sortByThisColumn}
-      sx={props.gridColumn.sortField ? { cursor: 'pointer' } : {}}
-    >
-      {props.gridColumn.name}
-      {isSortedAscending && sortAscendingIcon}
-      {isSortedDescending && sortDescendingIcon}
-    </TableCell>
-  );
-}
-
-function getJobs(
-  jobQuery: Scheduler.IListJobsQuery
-): Promise<INotebookJobsWithToken | undefined> {
-  const api = new SchedulerService({});
-
-  // Impose max_items if not otherwise specified.
-  if (jobQuery['max_items'] === undefined) {
-    jobQuery.max_items = PAGE_SIZE;
-  }
-
-  return api.getJobs(jobQuery);
 }
 
 export interface IListJobsProps {
@@ -392,10 +178,8 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
       <Stack spacing={3} style={{ height: '100%' }}>
         <Heading level={1}>{trans.__('Notebook Jobs')}</Heading>
         <NotebookJobsListBody
-          showHeaders={true}
           app={props.app}
           showCreateJob={props.showCreateJob}
-          getJobs={getJobs}
           showDetailView={props.showDetailView}
         />
       </Stack>

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -175,6 +175,14 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
     {
       sortField: 'name',
       name: trans.__('Job definition name')
+    },
+    {
+      sortField: 'input_uri',
+      name: trans.__('Input file')
+    },
+    {
+      sortField: 'create_time',
+      name: trans.__('Created at')
     }
   ];
 

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -11,7 +11,7 @@ import { Heading } from '../components/heading';
 import { useTranslator } from '../hooks';
 import { buildJobRow } from '../components/job-row';
 import { buildJobDefinitionRow } from '../components/job-definition-row';
-import { ICreateJobModel, IListJobsModel } from '../model';
+import { ICreateJobModel, IListJobsModel, ListJobsView } from '../model';
 import { Scheduler, SchedulerService } from '../handler';
 import { Cluster } from '../components/cluster';
 import {
@@ -236,9 +236,7 @@ export interface IListJobsProps {
 export function NotebookJobsList(props: IListJobsProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
   // Set the initial tab based on the initial view.
-  const [tab, setTab] = useState<number>(
-    props.model.listJobsView === 'Job' ? 0 : 1
-  );
+  const [tab, setTab] = useState<ListJobsView>(props.model.listJobsView);
 
   const jobsHeader = useMemo(() => trans.__('Notebook Jobs'), [trans]);
   const jobDefinitionsHeader = useMemo(
@@ -251,10 +249,10 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
     <Box sx={{ p: 4 }} style={{ height: '100%', boxSizing: 'border-box' }}>
       <Stack spacing={3} style={{ height: '100%' }}>
         <Tabs value={tab} onChange={(_, newTab) => setTab(newTab)}>
-          <Tab label={jobsHeader} />
-          <Tab label={jobDefinitionsHeader} />
+          <Tab label={jobsHeader} value="Job" />
+          <Tab label={jobDefinitionsHeader} value="JobDefinition" />
         </Tabs>
-        {tab === 0 && (
+        {tab === 'Job' && (
           <>
             <Heading level={1}>{jobsHeader}</Heading>
             <ListJobsTable
@@ -264,7 +262,7 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
             />
           </>
         )}
-        {tab === 1 && (
+        {tab === 'JobDefinition' && (
           <>
             <Heading level={1}>{jobDefinitionsHeader}</Heading>
             <ListJobDefinitionsTable

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -235,7 +235,10 @@ export interface IListJobsProps {
 
 export function NotebookJobsList(props: IListJobsProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
-  const [tab, setTab] = useState<number>(0);
+  // Set the initial tab based on the initial view.
+  const [tab, setTab] = useState<number>(
+    props.model.listJobsView === 'Job' ? 0 : 1
+  );
 
   const jobsHeader = useMemo(() => trans.__('Notebook Jobs'), [trans]);
   const jobDefinitionsHeader = useMemo(

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -235,8 +235,6 @@ export interface IListJobsProps {
 
 export function NotebookJobsList(props: IListJobsProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
-  // Set the initial tab based on the initial view.
-  const [tab, setTab] = useState<ListJobsView>(props.model.listJobsView);
 
   const jobsHeader = useMemo(() => trans.__('Notebook Jobs'), [trans]);
   const jobDefinitionsHeader = useMemo(
@@ -244,15 +242,24 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
     [trans]
   );
 
+  const changeTab = (newTab: ListJobsView) => {
+    const newModel: IListJobsModel = props.model;
+    newModel.listJobsView = newTab;
+    props.handleModelChange(newModel);
+  };
+
   // Retrieve the initial jobs list
   return (
     <Box sx={{ p: 4 }} style={{ height: '100%', boxSizing: 'border-box' }}>
       <Stack spacing={3} style={{ height: '100%' }}>
-        <Tabs value={tab} onChange={(_, newTab) => setTab(newTab)}>
+        <Tabs
+          value={props.model.listJobsView}
+          onChange={(_, newTab) => changeTab(newTab)}
+        >
           <Tab label={jobsHeader} value="Job" />
           <Tab label={jobDefinitionsHeader} value="JobDefinition" />
         </Tabs>
-        {tab === 'Job' && (
+        {props.model.listJobsView === 'Job' && (
           <>
             <Heading level={1}>{jobsHeader}</Heading>
             <ListJobsTable
@@ -262,7 +269,7 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
             />
           </>
         )}
-        {tab === 'JobDefinition' && (
+        {props.model.listJobsView === 'JobDefinition' && (
           <>
             <Heading level={1}>{jobDefinitionsHeader}</Heading>
             <ListJobDefinitionsTable

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -50,8 +50,8 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   }
 
   showListView(list: ListJobsView): void {
-    this.model.jobsView = 'ListJobs';
     this.model.listJobsModel.listJobsView = list;
+    this.model.jobsView = 'ListJobs';
   }
 
   showDetailView(jobId: string): void {

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -94,9 +94,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
               }
               showCreateJob={showCreateJob}
               showJobDetail={this.showDetailView.bind(this)}
-              showJobDefinitionDetail={jobDefinitionId => {
-                /* TODO */
-              }}
+              showJobDefinitionDetail={this.showJobDefinitionDetail.bind(this)}
             />
           )}
           {this.model.jobsView === 'JobDetail' && (

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -100,7 +100,10 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
                 (this.model.listJobsModel = newModel)
               }
               showCreateJob={showCreateJob}
-              showDetailView={this.showDetailView.bind(this)}
+              showJobDetail={this.showDetailView.bind(this)}
+              showJobDefinitionDetail={jobDefinitionId => {
+                /* TODO */
+              }}
             />
           )}
           {this.model.jobsView === 'JobDetail' && (

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -11,10 +11,10 @@ import { calendarMonthIcon } from './components/icons';
 import TranslatorContext from './context';
 import { CreateJob } from './mainviews/create-job';
 import { NotebookJobsList } from './mainviews/list-jobs';
-import { ICreateJobModel, JobsModel } from './model';
+import { ICreateJobModel, JobsModel, ListJobsView } from './model';
 import { getJupyterLabTheme } from './theme-provider';
 import { Scheduler } from './tokens';
-import { DetailView } from './mainviews/detail-view/index';
+import { DetailView } from './mainviews/detail-view';
 
 export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   readonly _title?: string;
@@ -49,16 +49,9 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     this.node.setAttribute('aria-label', trans.__('Notebook Jobs'));
   }
 
-  toggleView(): void {
-    if (
-      this.model.jobsView !== 'CreateJob' &&
-      this.model.jobsView !== 'ListJobs'
-    ) {
-      return;
-    }
-
-    this.model.jobsView =
-      this.model.jobsView === 'ListJobs' ? 'CreateJob' : 'ListJobs';
+  showListView(list: ListJobsView): void {
+    this.model.jobsView = 'ListJobs';
+    this.model.listJobsModel.listJobsView = list;
   }
 
   showDetailView(jobId: string): void {
@@ -88,7 +81,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
               handleModelChange={newModel =>
                 (this.model.createJobModel = newModel)
               }
-              toggleView={this.toggleView.bind(this)}
+              showListView={this.showListView.bind(this)}
               advancedOptions={this._advancedOptions}
             />
           )}


### PR DESCRIPTION
Fixes #81.

- Adds `AdvancedTable` component, which handles pagination, column sorting, and loading state management out-of-the-box.
- Refactors old list view table to use `AdvancedTable`.
- Adds tabs to list view, toggles between jobs list and job definitions list
  - Columns can be added by appending to both the column definition in the `ListJobDefinitionsTable` component and to the `buildJobDefinitionRow()` function.
- Deletes unused notebook jobs navigation components

TODO:
- [x] add missing properties to `Scheduler.IDescribeJobDefinition`.
- [x] discuss which columns to show in list view and add them to this table.
- [x] add "open job definition detail" logic in `notebook-jobs-panel.tsx`.

Notes:
I would like to refactor the `AdvancedTable` further such that the user does not need to provide a `renderRow()` prop, but instead have the cell render logic be placed in the column definition. See the [MUI X GridColDef](https://mui.com/x/api/data-grid/grid-col-def/) API for reference.