### PR TITLE
Hides idempotency token for JobSchedule

### DIFF
--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -119,17 +119,20 @@ const AdvancedOptions = (
   const tagsDisplay: JSX.Element | null =
     props.jobsView === 'CreateJob' ? createTags() : showTags();
 
+  // The idempotency token is only used for jobs, not for job definitions
   return (
     <Stack spacing={4}>
-      <TextField
-        label={trans.__('Idempotency token')}
-        variant="outlined"
-        onChange={handleInputChange}
-        value={props.model.idempotencyToken}
-        id={`${formPrefix}idempotencyToken`}
-        name="idempotencyToken"
-        InputProps={{ readOnly: props.jobsView !== 'CreateJob' }}
-      />
+      {props.model.createType === 'Job' && (
+        <TextField
+          label={trans.__('Idempotency token')}
+          variant="outlined"
+          onChange={handleInputChange}
+          value={props.model.idempotencyToken}
+          id={`${formPrefix}idempotencyToken`}
+          name="idempotencyToken"
+          InputProps={{ readOnly: props.jobsView !== 'CreateJob' }}
+        />
+      )}
       <FormLabel component="legend">{trans.__('Tags')}</FormLabel>
       {tagsDisplay}
     </Stack>


### PR DESCRIPTION
Fixes #99.

For job creation, continue to show idempotency token:

![image](https://user-images.githubusercontent.com/93281816/194423725-e5c13bf8-3bf8-4e0f-bb29-bb91c4c14401.png)

For job definition creation, do not show idempotency token:

![image](https://user-images.githubusercontent.com/93281816/194423799-3e496ac7-f0a1-4c80-8bf3-beced47810ad.png)
