### PR TITLE
Shows helper text for cron expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@mui/material": "^5.10.6",
     "@mui/system": "^5.10.6",
     "@types/react-dom": "^18.0.5",
-    "cron-validate": "^1.4.3",
     "cronstrue": "^2.12.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@mui/system": "^5.10.6",
     "@types/react-dom": "^18.0.5",
     "cron-validate": "^1.4.3",
+    "cronstrue": "^2.12.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "tzdata": "^1.0.33"

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -4,6 +4,7 @@ import { FormControlLabel, InputLabel, Radio, RadioGroup } from '@mui/material';
 import Stack from '@mui/system/Stack';
 
 import { useTranslator } from '../hooks';
+import { ICreateJobModel } from '../model';
 import { ScheduleInputs } from './schedule-inputs';
 import { Scheduler } from '../tokens';
 
@@ -11,6 +12,8 @@ export type CreateScheduleOptionsProps = {
   label: string;
   name: string;
   id: string;
+  model: ICreateJobModel;
+  handleModelChange: (model: ICreateJobModel) => void;
   createType: string;
   handleCreateTypeChange: (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -55,6 +58,8 @@ export function CreateScheduleOptions(
         <ScheduleInputs
           idPrefix={`${props.id}-definition-`}
           schedule={props.schedule}
+          model={props.model}
+          handleModelChange={props.handleModelChange}
           handleScheduleChange={props.handleScheduleChange}
           timezone={props.timezone}
           handleTimezoneChange={props.handleTimezoneChange}

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -1,4 +1,6 @@
 import React, { ChangeEvent } from 'react';
+
+import cronstrue from 'cronstrue';
 import tzdata from 'tzdata';
 
 import { Autocomplete, TextField } from '@mui/material';
@@ -23,6 +25,16 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
 
   const timezoneLabel = trans.__('Time zone');
 
+  let cronString;
+  try {
+    if (props.schedule !== undefined && !props.errors['schedule']) {
+      cronString = cronstrue.toString(props.schedule);
+    }
+  }
+  catch (e) {
+    // Do nothing; let the errors or nothing display instead
+  }
+
   return (
     <>
       <TextField
@@ -33,7 +45,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
         id={`${props.idPrefix}schedule`}
         name="schedule"
         error={!!props.errors['schedule']}
-        helperText={props.errors['schedule']}
+        helperText={props.errors['schedule'] || cronString}
       />
       <Autocomplete
         id={`${props.idPrefix}timezone`}

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -3,13 +3,18 @@ import React, { ChangeEvent } from 'react';
 import cronstrue from 'cronstrue';
 import tzdata from 'tzdata';
 
-import { Autocomplete, TextField } from '@mui/material';
+import { Autocomplete, Button, TextField } from '@mui/material';
 
 import { useTranslator } from '../hooks';
+import { ICreateJobModel } from '../model';
 import { Scheduler } from '../tokens';
+
+import { Cluster } from './cluster';
 
 export type ScheduleInputsProps = {
   idPrefix: string;
+  model: ICreateJobModel;
+  handleModelChange: (model: ICreateJobModel) => void;
   schedule?: string;
   handleScheduleChange: (event: ChangeEvent) => void;
   timezone?: string;
@@ -30,13 +35,49 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
     if (props.schedule !== undefined && !props.errors['schedule']) {
       cronString = cronstrue.toString(props.schedule);
     }
-  }
-  catch (e) {
+  } catch (e) {
     // Do nothing; let the errors or nothing display instead
   }
 
+  const presetButton = (label: string, schedule: string) => {
+    return (
+      <Button
+        onClick={e => {
+          props.handleModelChange({
+            ...props.model,
+            schedule: schedule
+          });
+        }}
+      >
+        {label}
+      </Button>
+    );
+  };
+
+  const presets = [
+    {
+      label: trans.__('Every day'),
+      schedule: '0 7 * * *'
+    },
+    {
+      label: trans.__('Every 6 hours'),
+      schedule: '* */6 * * *'
+    },
+    {
+      label: trans.__('Every weekday'),
+      schedule: '0 6 * * MON-FRI'
+    },
+    {
+      label: trans.__('Every month'),
+      schedule: '0 5 1 * *'
+    }
+  ];
+
   return (
     <>
+      <Cluster gap={4}>
+        {presets.map(preset => presetButton(preset.label, preset.schedule))}
+      </Cluster>
       <TextField
         label={trans.__('Cron expression')}
         variant="outlined"

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -483,6 +483,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             label={trans.__('Schedule')}
             name={'createType'}
             id={`${formPrefix}createType`}
+            model={props.model}
+            handleModelChange={props.handleModelChange}
             createType={props.model.createType}
             handleCreateTypeChange={handleScheduleOptionsChange}
             schedule={props.model.schedule}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -29,7 +29,7 @@ import {
 
 import { caretDownIcon } from '@jupyterlab/ui-components';
 
-import cron from 'cron-validate';
+import cronstrue from 'cronstrue';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -107,14 +107,14 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   };
 
   const validateSchedule = (schedule: string) => {
-    const cronResult = cron(schedule);
-    if (cronResult.isValid()) {
+    try {
+      cronstrue.toString(schedule);
       // No error
       setErrors({
         ...errors,
         schedule: ''
       });
-    } else {
+    } catch {
       setErrors({
         ...errors,
         schedule: trans.__('You must provide a valid Cron expression.')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4076,6 +4076,11 @@ cron-validate@^1.4.3:
   dependencies:
     yup "0.32.9"
 
+cronstrue@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-2.12.0.tgz#3497b98dab3cba54d3acdc63fe424947b708098b"
+  integrity sha512-PAIluUuZfZnJQcrS0XrhEVywO5+rIneWgBnwS4R0ebIeUdLnbsNBW/pWiJQIKx48WabRYwlxIEPy+qWJVmaINQ==
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,7 +890,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.5", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.19.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.19.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
   integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
@@ -2688,11 +2688,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/lodash@^4.14.165":
-  version "4.14.186"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.186.tgz#862e5514dd7bd66ada6c70ee5fce844b06c8ee97"
-  integrity sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==
-
 "@types/minimatch@*":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
@@ -4068,13 +4063,6 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
-
-cron-validate@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/cron-validate/-/cron-validate-1.4.3.tgz#d4ad8fb5b559a7df73b81e79c95c21b87bb4c5f4"
-  integrity sha512-N+qKw019oQBEPIP5Qwi8Z5XelQ00ThN6Maahwv+9UGu2u/b/MPb35zngMQI0T8pBoNiBrIXGlhvsmspNSYae/w==
-  dependencies:
-    yup "0.32.9"
 
 cronstrue@^2.12.0:
   version "2.12.0"
@@ -7008,11 +6996,6 @@ lockfile@1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash-es@^4.17.15:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
-
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -7068,7 +7051,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4, lodash@4.17.21, lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.7.0:
+lodash@4, lodash@4.17.21, lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7478,11 +7461,6 @@ mv@2.1.1:
     mkdirp "~0.5.1"
     ncp "~2.0.0"
     rimraf "~2.4.0"
-
-nanoclone@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
-  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@^3.1.23, nanoid@^3.3.4:
   version "3.3.4"
@@ -8171,11 +8149,6 @@ prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
-
-property-expr@^2.0.4:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
-  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -9520,11 +9493,6 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-toposort@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
-  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
-
 tough-cookie@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
@@ -10383,16 +10351,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-yup@0.32.9:
-  version "0.32.9"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.9.tgz#9367bec6b1b0e39211ecbca598702e106019d872"
-  integrity sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==
-  dependencies:
-    "@babel/runtime" "^7.10.5"
-    "@types/lodash" "^4.14.165"
-    lodash "^4.17.20"
-    lodash-es "^4.17.15"
-    nanoclone "^0.2.1"
-    property-expr "^2.0.4"
-    toposort "^2.0.2"


### PR DESCRIPTION
Partial fix for #98.

Displays the cron expression helpfully for the user. Adds a few hint buttons to get the user started with cron syntax.

https://user-images.githubusercontent.com/93281816/194433098-6fa50458-ea8f-42a4-93f6-7407dbd69d38.mov

The text box's helper text updates dynamically with interpretations of valid cron expressions:

https://user-images.githubusercontent.com/93281816/194433134-0052a870-79d5-435e-a53a-90a6f4a39c4c.mov

This is not yet localized; it always displays in English, although the library chosen supports other languages.