### PR TITLE
remove idempotency token from all job definition models and API requests

### DIFF
--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -188,7 +188,6 @@ class UpdateJobDefinition(BaseModel):
     runtime_environment_name: Optional[str]
     runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
     output_formats: Optional[List[str]] = None
-    idempotency_token: Optional[str] = None
     parameters: Optional[Dict[str, ParameterValues]] = None
     tags: Optional[Tags] = None
     name: Optional[str] = None

--- a/jupyter_scheduler/orm.py
+++ b/jupyter_scheduler/orm.py
@@ -102,7 +102,6 @@ class CommonColumns:
     output_prefix = Column(String(256))
     output_formats = Column(JsonType(512))
     name = Column(String(256))
-    idempotency_token = Column(String(256))
     tags = Column(JsonType(1024))
     parameters = Column(JsonType(1024))
     email_notifications = Column(EmailNotificationType(1024))
@@ -126,6 +125,7 @@ class Job(CommonColumns, Base):
     end_time = Column(Integer)
     url = Column(String(256), default=generate_jobs_url)
     pid = Column(Integer)
+    idempotency_token = Column(String(256))
 
 
 class JobDefinition(CommonColumns, Base):

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -256,7 +256,6 @@ export namespace Scheduler {
 
   export interface IUpdateJobDefinition extends ICreateJobDefinition {
     job_definition_id: string;
-    idempotency_token?: string;
     url?: string;
   }
 


### PR DESCRIPTION
Idempotency tokens are not valid for job definitions. This removes all erroneous occurrences of it in data models and API requests.