### PR TITLE
remove timeout to fix job creation

### DIFF
--- a/jupyter_scheduler/executors.py
+++ b/jupyter_scheduler/executors.py
@@ -125,7 +125,6 @@ class DefaultExecutionManager(ExecutionManager):
             nb = add_parameters(nb, job.parameters)
 
         ep = ExecutePreprocessor(
-            timeout=job.timeout_seconds,
             kernel_name=nb.metadata.kernelspec["name"],
             store_widget_state=True,
         )


### PR DESCRIPTION
As of now, when I’m trying to create new job on main , job fails and I see error below in terminal. This is because as @jweill-aws pointed out "timeout_seconds was removed here: https://github.com/jupyter-server/jupyter-scheduler/commit/802a83a95fd34fed24d0a0bf3c395895150120bf"

Cc @3coins 

`Traceback (most recent call last):
  File "/Users/aieroshe/Documents/main/jupyter-scheduler/jupyter_scheduler/executors.py", line 56, in process
    self.execute()
  File "/Users/aieroshe/Documents/main/jupyter-scheduler/jupyter_scheduler/executors.py", line 128, in execute
    timeout=job.timeout_seconds,
AttributeError: 'DescribeJob' object has no attribute 'timeout_seconds'`