### PR TITLE
Easy create: Create job schedule by minute, hour, day, weekday, week, or month

### DIFF
--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -1,6 +1,12 @@
 import React, { ChangeEvent } from 'react';
 
-import { FormControlLabel, InputLabel, Radio, RadioGroup } from '@mui/material';
+import {
+  FormControlLabel,
+  InputLabel,
+  Radio,
+  RadioGroup,
+  SelectChangeEvent
+} from '@mui/material';
 import Stack from '@mui/system/Stack';
 
 import { useTranslator } from '../hooks';
@@ -14,7 +20,8 @@ export type CreateScheduleOptionsProps = {
   id: string;
   model: ICreateJobModel;
   handleModelChange: (model: ICreateJobModel) => void;
-  createType: string;
+  handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
+  handleScheduleTimeChange: (event: ChangeEvent) => void;
   handleCreateTypeChange: (
     event: React.ChangeEvent<HTMLInputElement>,
     value: string
@@ -40,7 +47,7 @@ export function CreateScheduleOptions(
       <RadioGroup
         aria-labelledby={labelId}
         name={props.name}
-        value={props.createType}
+        value={props.model.createType}
         onChange={props.handleCreateTypeChange}
       >
         <FormControlLabel
@@ -54,14 +61,14 @@ export function CreateScheduleOptions(
           label={trans.__('Run on a schedule')}
         />
       </RadioGroup>
-      {props.createType === 'JobDefinition' && (
+      {props.model.createType === 'JobDefinition' && (
         <ScheduleInputs
           idPrefix={`${props.id}-definition-`}
-          schedule={props.schedule}
           model={props.model}
           handleModelChange={props.handleModelChange}
+          handleScheduleIntervalChange={props.handleScheduleIntervalChange}
+          handleScheduleTimeChange={props.handleScheduleTimeChange}
           handleScheduleChange={props.handleScheduleChange}
-          timezone={props.timezone}
           handleTimezoneChange={props.handleTimezoneChange}
           errors={props.errors}
           handleErrorsChange={props.handleErrorsChange}

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -22,15 +22,15 @@ export type CreateScheduleOptionsProps = {
   handleModelChange: (model: ICreateJobModel) => void;
   handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
   handleScheduleWeekDayChange: (event: SelectChangeEvent<string>) => void;
-  handleScheduleMonthDayChange: (event: ChangeEvent) => void;
-  handleScheduleTimeChange: (event: ChangeEvent) => void;
-  handleScheduleMinuteChange: (event: ChangeEvent) => void;
+  handleScheduleMonthDayChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleScheduleTimeChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleScheduleMinuteChange: (event: ChangeEvent<HTMLInputElement>) => void;
   handleCreateTypeChange: (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: ChangeEvent<HTMLInputElement>,
     value: string
   ) => void;
   schedule?: string;
-  handleScheduleChange: (event: ChangeEvent) => void;
+  handleScheduleChange: (event: ChangeEvent<HTMLInputElement>) => void;
   timezone?: string;
   handleTimezoneChange: (newValue: string | null) => void;
   errors: Scheduler.ErrorsType;

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -21,6 +21,7 @@ export type CreateScheduleOptionsProps = {
   model: ICreateJobModel;
   handleModelChange: (model: ICreateJobModel) => void;
   handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
+  handleScheduleWeekDayChange: (event: SelectChangeEvent<string>) => void;
   handleScheduleTimeChange: (event: ChangeEvent) => void;
   handleScheduleMinuteChange: (event: ChangeEvent) => void;
   handleCreateTypeChange: (
@@ -68,6 +69,7 @@ export function CreateScheduleOptions(
           model={props.model}
           handleModelChange={props.handleModelChange}
           handleScheduleIntervalChange={props.handleScheduleIntervalChange}
+          handleScheduleWeekDayChange={props.handleScheduleWeekDayChange}
           handleScheduleTimeChange={props.handleScheduleTimeChange}
           handleScheduleMinuteChange={props.handleScheduleMinuteChange}
           handleScheduleChange={props.handleScheduleChange}

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -22,6 +22,7 @@ export type CreateScheduleOptionsProps = {
   handleModelChange: (model: ICreateJobModel) => void;
   handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
   handleScheduleTimeChange: (event: ChangeEvent) => void;
+  handleScheduleMinuteChange: (event: ChangeEvent) => void;
   handleCreateTypeChange: (
     event: React.ChangeEvent<HTMLInputElement>,
     value: string
@@ -68,6 +69,7 @@ export function CreateScheduleOptions(
           handleModelChange={props.handleModelChange}
           handleScheduleIntervalChange={props.handleScheduleIntervalChange}
           handleScheduleTimeChange={props.handleScheduleTimeChange}
+          handleScheduleMinuteChange={props.handleScheduleMinuteChange}
           handleScheduleChange={props.handleScheduleChange}
           handleTimezoneChange={props.handleTimezoneChange}
           errors={props.errors}

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -22,6 +22,7 @@ export type CreateScheduleOptionsProps = {
   handleModelChange: (model: ICreateJobModel) => void;
   handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
   handleScheduleWeekDayChange: (event: SelectChangeEvent<string>) => void;
+  handleScheduleMonthDayChange: (event: ChangeEvent) => void;
   handleScheduleTimeChange: (event: ChangeEvent) => void;
   handleScheduleMinuteChange: (event: ChangeEvent) => void;
   handleCreateTypeChange: (
@@ -70,6 +71,7 @@ export function CreateScheduleOptions(
           handleModelChange={props.handleModelChange}
           handleScheduleIntervalChange={props.handleScheduleIntervalChange}
           handleScheduleWeekDayChange={props.handleScheduleWeekDayChange}
+          handleScheduleMonthDayChange={props.handleScheduleMonthDayChange}
           handleScheduleTimeChange={props.handleScheduleTimeChange}
           handleScheduleMinuteChange={props.handleScheduleMinuteChange}
           handleScheduleChange={props.handleScheduleChange}

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -93,7 +93,7 @@ function RefillButton(props: {
       environment: props.job.runtime_environment_name,
       parameters: jobParameters,
       createType: 'Job',
-      scheduleInterval: 'custom'
+      scheduleInterval: 'weekday'
     };
 
     // Convert the list of output formats, if any, into a list for the initial state

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -92,7 +92,8 @@ function RefillButton(props: {
       outputPath: props.job.output_prefix,
       environment: props.job.runtime_environment_name,
       parameters: jobParameters,
-      createType: 'Job'
+      createType: 'Job',
+      scheduleInterval: 'custom'
     };
 
     // Convert the list of output formats, if any, into a list for the initial state

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -44,6 +44,17 @@ function formatTime(hours: number, minutes: number): string {
   );
 }
 
+// Converts 24-hour hh:mm format to 12-hour hh:mm AM/PM format
+function twentyFourToTwelveHourTime(hours: number, minutes: number): string {
+  if (hours === 12) {
+    return `${hours}:${minutes} PM`;
+  } else if (hours > 12) {
+    return `${hours - 12}:${minutes} PM`;
+  } else {
+    return `${hours}:${minutes} AM`;
+  }
+}
+
 export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
   const trans = useTranslator('jupyterlab');
 
@@ -108,6 +119,16 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
           props.model.scheduleMonthDay
         )
       : '1–31';
+
+  const timeHelperText =
+    !props.errors['scheduleTime'] &&
+    props.model.scheduleHour !== undefined &&
+    props.model.scheduleMinute !== undefined
+      ? twentyFourToTwelveHourTime(
+          props.model.scheduleHour,
+          props.model.scheduleMinute
+        )
+      : trans.__('00:00–23:59');
 
   const timezonePicker = (
     <Autocomplete
@@ -199,7 +220,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
             }
             onChange={props.handleScheduleTimeChange}
             error={!!props.errors['scheduleTime']}
-            helperText={props.errors['scheduleTime'] || trans.__('00:00–23:59')}
+            helperText={props.errors['scheduleTime'] || timeHelperText}
           />
           {timezonePicker}
         </>
@@ -218,7 +239,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
             }
             onChange={props.handleScheduleTimeChange}
             error={!!props.errors['scheduleTime']}
-            helperText={props.errors['scheduleTime'] || trans.__('00:00–23:59')}
+            helperText={props.errors['scheduleTime'] || timeHelperText}
           />
           {timezonePicker}
         </>
@@ -247,7 +268,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
             }
             onChange={props.handleScheduleTimeChange}
             error={!!props.errors['scheduleTime']}
-            helperText={props.errors['scheduleTime'] || trans.__('00:00–23:59')}
+            helperText={props.errors['scheduleTime'] || timeHelperText}
           />
           {timezonePicker}
         </>

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -44,17 +44,6 @@ function formatTime(hours: number, minutes: number): string {
   );
 }
 
-// Converts 24-hour hh:mm format to 12-hour hh:mm AM/PM format
-function twentyFourToTwelveHourTime(hours: number, minutes: number): string {
-  if (hours === 12) {
-    return `${hours}:${minutes} PM`;
-  } else if (hours > 12) {
-    return `${hours - 12}:${minutes} PM`;
-  } else {
-    return `${hours}:${minutes} AM`;
-  }
-}
-
 export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
   const trans = useTranslator('jupyterlab');
 
@@ -84,6 +73,19 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
         {label}
       </Button>
     );
+  };
+
+  // Converts 24-hour hh:mm format to 12-hour hh:mm AM/PM format
+  const twentyFourToTwelveHourTime = (hours: number, minutes: number) => {
+    if (hours === 0) {
+      return trans.__('%1:%2 AM', hours, minutes);
+    } else if (hours === 12) {
+      return trans.__('%1:%2 PM', hours, minutes);
+    } else if (hours > 12) {
+      return trans.__('%1:%2 PM', hours - 12, minutes);
+    } else {
+      return trans.__('%1:%2 AM', hours, minutes);
+    }
   };
 
   const presets = [

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -50,7 +50,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
 
   let cronString;
   try {
-    if (props.model.schedule !== undefined && !props.errors['schedule']) {
+    if (props.model.schedule && !props.errors['schedule']) {
       cronString = cronstrue.toString(props.model.schedule);
     }
   } catch (e) {

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -26,6 +26,7 @@ export type ScheduleInputsProps = {
   handleModelChange: (model: ICreateJobModel) => void;
   handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
   handleScheduleTimeChange: (event: ChangeEvent) => void;
+  handleScheduleMinuteChange: (event: ChangeEvent) => void;
   handleScheduleChange: (event: ChangeEvent) => void;
   handleTimezoneChange: (newValue: string | null) => void;
   errors: Scheduler.ErrorsType;
@@ -130,11 +131,25 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
           onChange={props.handleScheduleIntervalChange}
         >
           <MenuItem value={'minute'}>{trans.__('Minute')}</MenuItem>
+          <MenuItem value={'hour'}>{trans.__('Hour')}</MenuItem>
           <MenuItem value={'day'}>{trans.__('Day')}</MenuItem>
           <MenuItem value={'weekday'}>{trans.__('Weekday')}</MenuItem>
           <MenuItem value={'custom'}>{trans.__('Custom schedule')}</MenuItem>
         </Select>
       </FormControl>
+      {props.model.scheduleInterval === 'hour' && (
+        <>
+          <TextField
+            label={trans.__('Minutes past the hour')}
+            value={
+              props.model.scheduleMinuteInput ?? props.model.scheduleMinute ?? 0
+            }
+            onChange={props.handleScheduleMinuteChange}
+            error={!!props.errors['scheduleMinute']}
+            helperText={props.errors['scheduleMinute'] || trans.__('0–59')}
+          />
+        </>
+      )}
       {(props.model.scheduleInterval === 'weekday' ||
         props.model.scheduleInterval === 'day') && (
         <>

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -26,6 +26,7 @@ export type ScheduleInputsProps = {
   handleModelChange: (model: ICreateJobModel) => void;
   handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
   handleScheduleWeekDayChange: (event: SelectChangeEvent<string>) => void;
+  handleScheduleMonthDayChange: (event: ChangeEvent) => void;
   handleScheduleTimeChange: (event: ChangeEvent) => void;
   handleScheduleMinuteChange: (event: ChangeEvent) => void;
   handleScheduleChange: (event: ChangeEvent) => void;
@@ -99,6 +100,15 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
   const dayOfWeekLabelId = `${props.idPrefix}dayofweek-label`;
   const dayOfWeekText = trans.__('Day of the week');
 
+  const monthDayHelperText =
+    props.model.scheduleMonthDay !== undefined &&
+    props.model.scheduleMonthDay > 28
+      ? trans.__(
+          'Will not execute in months with fewer than %1 days',
+          props.model.scheduleMonthDay
+        )
+      : '1–31';
+
   const timezonePicker = (
     <Autocomplete
       id={`${props.idPrefix}timezone`}
@@ -166,7 +176,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
               variant="outlined"
               id={`${props.idPrefix}dayOfWeek`}
               name="dayOfWeek"
-              value={props.model.scheduleWeekDay + ''}
+              value={props.model.scheduleWeekDay ?? '1'}
               onChange={props.handleScheduleWeekDayChange}
             >
               <MenuItem value={'1'}>{trans.__('Monday')}</MenuItem>
@@ -197,6 +207,35 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
       {(props.model.scheduleInterval === 'weekday' ||
         props.model.scheduleInterval === 'day') && (
         <>
+          <TextField
+            label={trans.__('Time')}
+            value={
+              props.model.scheduleTimeInput ??
+              formatTime(
+                props.model.scheduleHour ?? 0,
+                props.model.scheduleMinute ?? 0
+              )
+            }
+            onChange={props.handleScheduleTimeChange}
+            error={!!props.errors['scheduleTime']}
+            helperText={props.errors['scheduleTime'] || trans.__('00:00–23:59')}
+          />
+          {timezonePicker}
+        </>
+      )}
+      {props.model.scheduleInterval === 'month' && (
+        <>
+          <TextField
+            label={trans.__('Day of the month')}
+            value={
+              props.model.scheduleMonthDayInput ??
+              props.model.scheduleMonthDay ??
+              ''
+            }
+            onChange={props.handleScheduleMonthDayChange}
+            error={!!props.errors['scheduleMonthDay']}
+            helperText={props.errors['scheduleMonthDay'] || monthDayHelperText}
+          />
           <TextField
             label={trans.__('Time')}
             value={

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -23,10 +23,10 @@ export type ScheduleInputsProps = {
   handleModelChange: (model: ICreateJobModel) => void;
   handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
   handleScheduleWeekDayChange: (event: SelectChangeEvent<string>) => void;
-  handleScheduleMonthDayChange: (event: ChangeEvent) => void;
-  handleScheduleTimeChange: (event: ChangeEvent) => void;
-  handleScheduleMinuteChange: (event: ChangeEvent) => void;
-  handleScheduleChange: (event: ChangeEvent) => void;
+  handleScheduleMonthDayChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleScheduleTimeChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleScheduleMinuteChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleScheduleChange: (event: ChangeEvent<HTMLInputElement>) => void;
   handleTimezoneChange: (newValue: string | null) => void;
   errors: Scheduler.ErrorsType;
   handleErrorsChange: (errors: Scheduler.ErrorsType) => void;

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -82,7 +82,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
     props.model.scheduleMonthDay !== undefined &&
     props.model.scheduleMonthDay > 28
       ? trans.__(
-          'Will not execute in months with fewer than %1 days',
+          'The job will not run in months with fewer than %1 days',
           props.model.scheduleMonthDay
         )
       : '1–31';

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -152,6 +152,22 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
     />
   );
 
+  const timePicker = (
+    <TextField
+      label={trans.__('Time')}
+      value={
+        props.model.scheduleTimeInput ??
+        formatTime(
+          props.model.scheduleHour ?? 0,
+          props.model.scheduleMinute ?? 0
+        )
+      }
+      onChange={props.handleScheduleTimeChange}
+      error={!!props.errors['scheduleTime']}
+      helperText={props.errors['scheduleTime'] || timeHelperText}
+    />
+  );
+
   return (
     <>
       <FormControl>
@@ -209,38 +225,14 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
               <MenuItem value={'0'}>{trans.__('Sunday')}</MenuItem>
             </Select>
           </FormControl>
-          <TextField
-            label={trans.__('Time')}
-            value={
-              props.model.scheduleTimeInput ??
-              formatTime(
-                props.model.scheduleHour ?? 0,
-                props.model.scheduleMinute ?? 0
-              )
-            }
-            onChange={props.handleScheduleTimeChange}
-            error={!!props.errors['scheduleTime']}
-            helperText={props.errors['scheduleTime'] || timeHelperText}
-          />
+          {timePicker}
           {timezonePicker}
         </>
       )}
       {(props.model.scheduleInterval === 'weekday' ||
         props.model.scheduleInterval === 'day') && (
         <>
-          <TextField
-            label={trans.__('Time')}
-            value={
-              props.model.scheduleTimeInput ??
-              formatTime(
-                props.model.scheduleHour ?? 0,
-                props.model.scheduleMinute ?? 0
-              )
-            }
-            onChange={props.handleScheduleTimeChange}
-            error={!!props.errors['scheduleTime']}
-            helperText={props.errors['scheduleTime'] || timeHelperText}
-          />
+          {timePicker}
           {timezonePicker}
         </>
       )}
@@ -257,19 +249,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
             error={!!props.errors['scheduleMonthDay']}
             helperText={props.errors['scheduleMonthDay'] || monthDayHelperText}
           />
-          <TextField
-            label={trans.__('Time')}
-            value={
-              props.model.scheduleTimeInput ??
-              formatTime(
-                props.model.scheduleHour ?? 0,
-                props.model.scheduleMinute ?? 0
-              )
-            }
-            onChange={props.handleScheduleTimeChange}
-            error={!!props.errors['scheduleTime']}
-            helperText={props.errors['scheduleTime'] || timeHelperText}
-          />
+          {timePicker}
           {timezonePicker}
         </>
       )}

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -72,8 +72,8 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
     }
   };
 
-  const everyLabelId = `${props.idPrefix}every-label`;
-  const everyLabelText = trans.__('Every');
+  const intervalLabelId = `${props.idPrefix}interval-label`;
+  const intervalLabelText = trans.__('Interval');
 
   const dayOfWeekLabelId = `${props.idPrefix}dayofweek-label`;
   const dayOfWeekText = trans.__('Day of the week');
@@ -138,13 +138,13 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
   return (
     <>
       <FormControl>
-        <InputLabel id={everyLabelId}>{everyLabelText}</InputLabel>
+        <InputLabel id={intervalLabelId}>{intervalLabelText}</InputLabel>
         <Select
-          labelId={everyLabelId}
-          label={everyLabelText}
+          labelId={intervalLabelId}
+          label={intervalLabelText}
           variant="outlined"
-          id={`${props.idPrefix}every`}
-          name="every"
+          id={`${props.idPrefix}interval`}
+          name="interval"
           value={props.model.scheduleInterval}
           onChange={props.handleScheduleIntervalChange}
         >

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -129,11 +129,14 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
           value={props.model.scheduleInterval}
           onChange={props.handleScheduleIntervalChange}
         >
+          <MenuItem value={'minute'}>{trans.__('Minute')}</MenuItem>
+          <MenuItem value={'day'}>{trans.__('Day')}</MenuItem>
           <MenuItem value={'weekday'}>{trans.__('Weekday')}</MenuItem>
           <MenuItem value={'custom'}>{trans.__('Custom schedule')}</MenuItem>
         </Select>
       </FormControl>
-      {props.model.scheduleInterval === 'weekday' && (
+      {(props.model.scheduleInterval === 'weekday' ||
+        props.model.scheduleInterval === 'day') && (
         <>
           <TextField
             label={trans.__('Time')}

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -25,6 +25,7 @@ export type ScheduleInputsProps = {
   model: ICreateJobModel;
   handleModelChange: (model: ICreateJobModel) => void;
   handleScheduleIntervalChange: (event: SelectChangeEvent<string>) => void;
+  handleScheduleWeekDayChange: (event: SelectChangeEvent<string>) => void;
   handleScheduleTimeChange: (event: ChangeEvent) => void;
   handleScheduleMinuteChange: (event: ChangeEvent) => void;
   handleScheduleChange: (event: ChangeEvent) => void;
@@ -92,8 +93,11 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
     }
   ];
 
-  const labelId = `${props.idPrefix}every-label`;
-  const labelText = trans.__('Every');
+  const everyLabelId = `${props.idPrefix}every-label`;
+  const everyLabelText = trans.__('Every');
+
+  const dayOfWeekLabelId = `${props.idPrefix}dayofweek-label`;
+  const dayOfWeekText = trans.__('Day of the week');
 
   const timezonePicker = (
     <Autocomplete
@@ -120,10 +124,10 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
   return (
     <>
       <FormControl>
-        <InputLabel id={labelId}>{labelText}</InputLabel>
+        <InputLabel id={everyLabelId}>{everyLabelText}</InputLabel>
         <Select
-          labelId={labelId}
-          label={labelText}
+          labelId={everyLabelId}
+          label={everyLabelText}
           variant="outlined"
           id={`${props.idPrefix}every`}
           name="every"
@@ -133,7 +137,9 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
           <MenuItem value={'minute'}>{trans.__('Minute')}</MenuItem>
           <MenuItem value={'hour'}>{trans.__('Hour')}</MenuItem>
           <MenuItem value={'day'}>{trans.__('Day')}</MenuItem>
+          <MenuItem value={'week'}>{trans.__('Week')}</MenuItem>
           <MenuItem value={'weekday'}>{trans.__('Weekday')}</MenuItem>
+          <MenuItem value={'month'}>{trans.__('Month')}</MenuItem>
           <MenuItem value={'custom'}>{trans.__('Custom schedule')}</MenuItem>
         </Select>
       </FormControl>
@@ -148,6 +154,44 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
             error={!!props.errors['scheduleMinute']}
             helperText={props.errors['scheduleMinute'] || trans.__('0–59')}
           />
+        </>
+      )}
+      {props.model.scheduleInterval === 'week' && (
+        <>
+          <FormControl>
+            <InputLabel id={dayOfWeekLabelId}>{dayOfWeekText}</InputLabel>
+            <Select
+              labelId={dayOfWeekLabelId}
+              label={dayOfWeekText}
+              variant="outlined"
+              id={`${props.idPrefix}dayOfWeek`}
+              name="dayOfWeek"
+              value={props.model.scheduleWeekDay + ''}
+              onChange={props.handleScheduleWeekDayChange}
+            >
+              <MenuItem value={'1'}>{trans.__('Monday')}</MenuItem>
+              <MenuItem value={'2'}>{trans.__('Tuesday')}</MenuItem>
+              <MenuItem value={'3'}>{trans.__('Wednesday')}</MenuItem>
+              <MenuItem value={'4'}>{trans.__('Thursday')}</MenuItem>
+              <MenuItem value={'5'}>{trans.__('Friday')}</MenuItem>
+              <MenuItem value={'6'}>{trans.__('Saturday')}</MenuItem>
+              <MenuItem value={'0'}>{trans.__('Sunday')}</MenuItem>
+            </Select>
+          </FormControl>
+          <TextField
+            label={trans.__('Time')}
+            value={
+              props.model.scheduleTimeInput ??
+              formatTime(
+                props.model.scheduleHour ?? 0,
+                props.model.scheduleMinute ?? 0
+              )
+            }
+            onChange={props.handleScheduleTimeChange}
+            error={!!props.errors['scheduleTime']}
+            helperText={props.errors['scheduleTime'] || trans.__('00:00–23:59')}
+          />
+          {timezonePicker}
         </>
       )}
       {(props.model.scheduleInterval === 'weekday' ||

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -5,7 +5,6 @@ import tzdata from 'tzdata';
 
 import {
   Autocomplete,
-  Button,
   FormControl,
   InputLabel,
   MenuItem,
@@ -17,8 +16,6 @@ import {
 import { useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
 import { Scheduler } from '../tokens';
-
-import { Cluster } from './cluster';
 
 export type ScheduleInputsProps = {
   idPrefix: string;
@@ -60,21 +57,6 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
     // Do nothing; let the errors or nothing display instead
   }
 
-  const presetButton = (label: string, schedule: string) => {
-    return (
-      <Button
-        onClick={e => {
-          props.handleModelChange({
-            ...props.model,
-            schedule: schedule
-          });
-        }}
-      >
-        {label}
-      </Button>
-    );
-  };
-
   // Converts 24-hour hh:mm format to 12-hour hh:mm AM/PM format
   const twentyFourToTwelveHourTime = (hours: number, minutes: number) => {
     const displayMinutes: string = minutes < 10 ? '0' + minutes : '' + minutes;
@@ -89,25 +71,6 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
       return trans.__('%1:%2 AM', hours, displayMinutes);
     }
   };
-
-  const presets = [
-    {
-      label: trans.__('Every day'),
-      schedule: '0 7 * * *'
-    },
-    {
-      label: trans.__('Every 6 hours'),
-      schedule: '* */6 * * *'
-    },
-    {
-      label: trans.__('Every weekday'),
-      schedule: '0 6 * * MON-FRI'
-    },
-    {
-      label: trans.__('Every month'),
-      schedule: '0 5 1 * *'
-    }
-  ];
 
   const everyLabelId = `${props.idPrefix}every-label`;
   const everyLabelText = trans.__('Every');
@@ -261,9 +224,6 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
       )}
       {props.model.scheduleInterval === 'custom' && (
         <>
-          <Cluster gap={4}>
-            {presets.map(preset => presetButton(preset.label, preset.schedule))}
-          </Cluster>
           <TextField
             label={trans.__('Cron expression')}
             variant="outlined"

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -197,11 +197,13 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
           <TextField
             label={trans.__('Minutes past the hour')}
             value={
-              props.model.scheduleMinuteInput ?? props.model.scheduleMinute ?? 0
+              props.model.scheduleMinuteInput ??
+              props.model.scheduleHourMinute ??
+              0
             }
             onChange={props.handleScheduleMinuteChange}
-            error={!!props.errors['scheduleMinute']}
-            helperText={props.errors['scheduleMinute'] || trans.__('0–59')}
+            error={!!props.errors['scheduleHourMinute']}
+            helperText={props.errors['scheduleHourMinute'] || trans.__('0–59')}
           />
         </>
       )}

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -77,14 +77,16 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
 
   // Converts 24-hour hh:mm format to 12-hour hh:mm AM/PM format
   const twentyFourToTwelveHourTime = (hours: number, minutes: number) => {
+    const displayMinutes: string = minutes < 10 ? '0' + minutes : '' + minutes;
+
     if (hours === 0) {
-      return trans.__('%1:%2 AM', hours, minutes);
+      return trans.__('%1:%2 AM', hours, displayMinutes);
     } else if (hours === 12) {
-      return trans.__('%1:%2 PM', hours, minutes);
+      return trans.__('%1:%2 PM', hours, displayMinutes);
     } else if (hours > 12) {
-      return trans.__('%1:%2 PM', hours - 12, minutes);
+      return trans.__('%1:%2 PM', hours - 12, displayMinutes);
     } else {
-      return trans.__('%1:%2 AM', hours, minutes);
+      return trans.__('%1:%2 AM', hours, displayMinutes);
     }
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -205,7 +205,8 @@ async function activatePlugin(
         jobName: fileName,
         outputPath: '',
         environment: '',
-        createType: 'Job'
+        createType: 'Job',
+        scheduleInterval: 'custom'
       };
 
       model.createJobModel = newModel;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -206,7 +206,7 @@ async function activatePlugin(
         outputPath: '',
         environment: '',
         createType: 'Job',
-        scheduleInterval: 'custom'
+        scheduleInterval: 'weekday'
       };
 
       model.createJobModel = newModel;

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -236,9 +236,31 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   };
 
   const handleScheduleIntervalChange = (event: SelectChangeEvent<string>) => {
-    // TODO: Set the schedule (in cron format) based on the new interval
+    // Set the schedule (in cron format) based on the new interval
+    let schedule = props.model.schedule;
+
+    switch (props.model.scheduleInterval) {
+      case 'minute':
+        schedule = '* * * * *'; // every minute
+        break;
+      case 'hour':
+        schedule = `${props.model.scheduleMinute ?? '*'} * * * *`;
+        break;
+      case 'day':
+        schedule = `${props.model.scheduleMinute ?? '*'} ${
+          props.model.scheduleHour ?? '*'
+        } * * *`;
+        break;
+      case 'weekday':
+        schedule = `${props.model.scheduleMinute ?? '*'} ${
+          props.model.scheduleHour ?? '*'
+        } * * MON-FRI`;
+        break;
+    }
+
     props.handleModelChange({
       ...props.model,
+      schedule: schedule,
       scheduleInterval: event.target.value
     });
   };

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -293,6 +293,23 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     });
   };
 
+  const handleScheduleWeekDayChange = (event: SelectChangeEvent<string>) => {
+    // Days of the week are numbered 0 (Sunday) through 6 (Saturday)
+    const value = (event.target as HTMLSelectElement).value;
+
+    let schedule = props.model.schedule;
+
+    schedule = `${props.model.scheduleMinute ?? '0'} ${
+      props.model.scheduleHour ?? '0'
+    } * * ${value}`;
+
+    props.handleModelChange({
+      ...props.model,
+      schedule: schedule,
+      scheduleWeekDay: value
+    });
+  };
+
   const handleScheduleIntervalChange = (event: SelectChangeEvent<string>) => {
     // Set the schedule (in cron format) based on the new interval
     let schedule = props.model.schedule;
@@ -308,6 +325,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         schedule = `${props.model.scheduleMinute ?? '0'} ${
           props.model.scheduleHour ?? '0'
         } * * *`;
+        break;
+      case 'week':
+        schedule = `${props.model.scheduleMinute ?? '0'} ${
+          props.model.scheduleHour ?? '0'
+        } * * ${props.model.scheduleWeekDay ?? '1'}`;
         break;
       case 'weekday':
         schedule = `${props.model.scheduleMinute ?? '0'} ${
@@ -619,6 +641,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             model={props.model}
             handleModelChange={props.handleModelChange}
             handleScheduleIntervalChange={handleScheduleIntervalChange}
+            handleScheduleWeekDayChange={handleScheduleWeekDayChange}
             handleScheduleTimeChange={handleScheduleTimeChange}
             handleScheduleMinuteChange={handleScheduleMinuteChange}
             handleCreateTypeChange={handleScheduleOptionsChange}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -202,6 +202,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     const timeResult = timeRegex.exec(value);
 
     let hours, minutes;
+    let schedule = props.model.schedule;
 
     if (timeResult) {
       setErrors({
@@ -211,6 +212,13 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
       hours = parseInt(timeResult[1]);
       minutes = parseInt(timeResult[2]);
+
+      // Compose a new schedule in cron format
+      switch (props.model.scheduleInterval) {
+        case 'weekday':
+          schedule = `${minutes} ${hours} * * MON-FRI`;
+          break;
+      }
     } else {
       setErrors({
         ...errors,
@@ -220,6 +228,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
     props.handleModelChange({
       ...props.model,
+      schedule: schedule,
       scheduleTimeInput: value,
       scheduleHour: hours,
       scheduleMinute: minutes

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -254,7 +254,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     const minuteRegex = /^(\d\d?)$/;
     const minuteResult = minuteRegex.exec(value);
 
-    let minutes = props.model.scheduleMinute;
+    let minutes = props.model.scheduleHourMinute;
     let schedule = props.model.schedule;
 
     if (minuteResult) {
@@ -269,7 +269,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     ) {
       setErrors({
         ...errors,
-        scheduleMinute: ''
+        scheduleHourMinute: ''
       });
 
       // Compose a new schedule in cron format
@@ -281,7 +281,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     } else {
       setErrors({
         ...errors,
-        scheduleMinute: trans.__('Minute must be between 0 and 59')
+        scheduleHourMinute: trans.__('Minute must be between 0 and 59')
       });
     }
 
@@ -289,7 +289,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       ...props.model,
       schedule: schedule,
       scheduleMinuteInput: value,
-      scheduleMinute: minutes
+      scheduleHourMinute: minutes
     });
   };
 
@@ -366,7 +366,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         schedule = '* * * * *'; // every minute
         break;
       case 'hour':
-        schedule = `${props.model.scheduleMinute ?? '0'} * * * *`;
+        schedule = `${props.model.scheduleHourMinute ?? '0'} * * * *`;
         break;
       case 'day':
         schedule = `${props.model.scheduleMinute ?? '0'} ${

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -201,20 +201,34 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     const timeRegex = /^(\d\d?):(\d\d)$/;
     const timeResult = timeRegex.exec(value);
 
-    let hours, minutes;
+    let hours = props.model.scheduleHour;
+    let minutes = props.model.scheduleMinute;
     let schedule = props.model.schedule;
 
     if (timeResult) {
+      hours = parseInt(timeResult[1]);
+      minutes = parseInt(timeResult[2]);
+    }
+
+    if (
+      timeResult &&
+      hours !== undefined &&
+      hours >= 0 &&
+      hours <= 23 &&
+      minutes !== undefined &&
+      minutes >= 0 &&
+      minutes <= 59
+    ) {
       setErrors({
         ...errors,
         scheduleTime: ''
       });
 
-      hours = parseInt(timeResult[1]);
-      minutes = parseInt(timeResult[2]);
-
       // Compose a new schedule in cron format
       switch (props.model.scheduleInterval) {
+        case 'day':
+          schedule = `${minutes} ${hours} * * *`;
+          break;
         case 'weekday':
           schedule = `${minutes} ${hours} * * MON-FRI`;
           break;
@@ -231,6 +245,50 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       schedule: schedule,
       scheduleTimeInput: value,
       scheduleHour: hours,
+      scheduleMinute: minutes
+    });
+  };
+
+  const handleScheduleMinuteChange = (event: ChangeEvent) => {
+    const value = (event.target as HTMLInputElement).value;
+    const minuteRegex = /^(\d\d?)$/;
+    const minuteResult = minuteRegex.exec(value);
+
+    let minutes = props.model.scheduleMinute;
+    let schedule = props.model.schedule;
+
+    if (minuteResult) {
+      minutes = parseInt(minuteResult[1]);
+    }
+
+    if (
+      minuteResult &&
+      minutes !== undefined &&
+      minutes >= 0 &&
+      minutes <= 59
+    ) {
+      setErrors({
+        ...errors,
+        scheduleMinute: ''
+      });
+
+      // Compose a new schedule in cron format
+      switch (props.model.scheduleInterval) {
+        case 'hour':
+          schedule = `${minutes} * * * *`;
+          break;
+      }
+    } else {
+      setErrors({
+        ...errors,
+        scheduleMinute: trans.__('Minute must be between 0 and 59')
+      });
+    }
+
+    props.handleModelChange({
+      ...props.model,
+      schedule: schedule,
+      scheduleMinuteInput: value,
       scheduleMinute: minutes
     });
   };
@@ -562,6 +620,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             handleModelChange={props.handleModelChange}
             handleScheduleIntervalChange={handleScheduleIntervalChange}
             handleScheduleTimeChange={handleScheduleTimeChange}
+            handleScheduleMinuteChange={handleScheduleMinuteChange}
             handleCreateTypeChange={handleScheduleOptionsChange}
             handleScheduleChange={handleScheduleChange}
             handleTimezoneChange={handleTimezoneChange}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -195,6 +195,45 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     // If no change in checkedness, don't do anything
   };
 
+  const handleScheduleTimeChange = (event: ChangeEvent) => {
+    const value = (event.target as HTMLInputElement).value;
+    // Allow h:mm or hh:mm
+    const timeRegex = /^(\d\d?):(\d\d)$/;
+    const timeResult = timeRegex.exec(value);
+
+    let hours, minutes;
+
+    if (timeResult) {
+      setErrors({
+        ...errors,
+        scheduleTime: ''
+      });
+
+      hours = parseInt(timeResult[1]);
+      minutes = parseInt(timeResult[2]);
+    } else {
+      setErrors({
+        ...errors,
+        scheduleTime: trans.__('Time must be in hh:mm format')
+      });
+    }
+
+    props.handleModelChange({
+      ...props.model,
+      scheduleTimeInput: value,
+      scheduleHour: hours,
+      scheduleMinute: minutes
+    });
+  };
+
+  const handleScheduleIntervalChange = (event: SelectChangeEvent<string>) => {
+    // TODO: Set the schedule (in cron format) based on the new interval
+    props.handleModelChange({
+      ...props.model,
+      scheduleInterval: event.target.value
+    });
+  };
+
   const handleScheduleOptionsChange = (
     event: React.ChangeEvent<HTMLInputElement>,
     value: string
@@ -490,11 +529,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             id={`${formPrefix}createType`}
             model={props.model}
             handleModelChange={props.handleModelChange}
-            createType={props.model.createType}
+            handleScheduleIntervalChange={handleScheduleIntervalChange}
+            handleScheduleTimeChange={handleScheduleTimeChange}
             handleCreateTypeChange={handleScheduleOptionsChange}
-            schedule={props.model.schedule}
             handleScheduleChange={handleScheduleChange}
-            timezone={props.model.timezone}
             handleTimezoneChange={handleTimezoneChange}
             errors={errors}
             handleErrorsChange={setErrors}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -91,8 +91,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   // If any error message is "truthy" (not null or empty), the form should not be submitted.
   const anyErrors = Object.keys(errors).some(key => !!errors[key]);
 
-  const handleInputChange = (event: ChangeEvent) => {
-    const target = event.target as HTMLInputElement;
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const target = event.target;
 
     const parameterNameIdx = parameterNameMatch(target.name);
     const parameterValueIdx = parameterValueMatch(target.name);
@@ -127,9 +127,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     }
   };
 
-  const handleScheduleChange = (event: ChangeEvent) => {
+  const handleScheduleChange = (event: ChangeEvent<HTMLInputElement>) => {
     // Validate the cron expression
-    validateSchedule((event.target as HTMLInputElement).value);
+    validateSchedule(event.target.value);
     handleInputChange(event);
   };
 
@@ -139,7 +139,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   };
 
   const handleSelectChange = (event: SelectChangeEvent<string>) => {
-    const target = event.target as HTMLInputElement;
+    const target = event.target;
 
     // if setting the environment, default the compute type to its first value (if any are presnt)
     if (target.name === 'environment') {
@@ -230,11 +230,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     return '';
   };
 
-  const handleScheduleTimeChange = (event: ChangeEvent) => {
-    const value = (event.target as HTMLInputElement).value;
+  const handleScheduleTimeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
 
-    let hours: number | null | undefined = props.model.scheduleHour;
-    let minutes: number | null | undefined = props.model.scheduleMinute;
+    let hours = props.model.scheduleHour;
+    let minutes = props.model.scheduleMinute;
     let schedule = props.model.schedule;
 
     const timeError = validateTime(value);
@@ -290,8 +290,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     return ''; // No error
   };
 
-  const handleScheduleMinuteChange = (event: ChangeEvent) => {
-    const value = (event.target as HTMLInputElement).value;
+  const handleScheduleMinuteChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
 
     let minutes = props.model.scheduleHourMinute;
     let schedule = props.model.schedule;
@@ -339,8 +339,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     return ''; // No error
   };
 
-  const handleScheduleMonthDayChange = (event: ChangeEvent) => {
-    const value = (event.target as HTMLInputElement).value;
+  const handleScheduleMonthDayChange = (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = event.target.value;
 
     let monthDay = props.model.scheduleMonthDay;
     let schedule = props.model.schedule;
@@ -374,7 +376,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
   const handleScheduleWeekDayChange = (event: SelectChangeEvent<string>) => {
     // Days of the week are numbered 0 (Sunday) through 6 (Saturday)
-    const value = (event.target as HTMLSelectElement).value;
+    const value = event.target.value;
 
     let schedule = props.model.schedule;
 
@@ -487,7 +489,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   };
 
   const handleScheduleOptionsChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: ChangeEvent<HTMLInputElement>,
     value: string
   ) => {
     const name = event.target.name;

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -244,16 +244,16 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         schedule = '* * * * *'; // every minute
         break;
       case 'hour':
-        schedule = `${props.model.scheduleMinute ?? '*'} * * * *`;
+        schedule = `${props.model.scheduleMinute ?? '0'} * * * *`;
         break;
       case 'day':
-        schedule = `${props.model.scheduleMinute ?? '*'} ${
-          props.model.scheduleHour ?? '*'
+        schedule = `${props.model.scheduleMinute ?? '0'} ${
+          props.model.scheduleHour ?? '0'
         } * * *`;
         break;
       case 'weekday':
-        schedule = `${props.model.scheduleMinute ?? '*'} ${
-          props.model.scheduleHour ?? '*'
+        schedule = `${props.model.scheduleMinute ?? '0'} ${
+          props.model.scheduleHour ?? '0'
         } * * MON-FRI`;
         break;
     }

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -62,7 +62,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       environment: props.model.environment,
       parameters: props.model.parameters,
       createType: 'Job',
-      scheduleInterval: 'custom'
+      scheduleInterval: 'weekday'
     };
 
     props.setCreateJobModel(initialState);

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -61,7 +61,8 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       outputPath: props.model.outputPrefix ?? '',
       environment: props.model.environment,
       parameters: props.model.parameters,
-      createType: 'Job'
+      createType: 'Job',
+      scheduleInterval: 'custom'
     };
 
     props.setCreateJobModel(initialState);

--- a/src/model.ts
+++ b/src/model.ts
@@ -94,6 +94,16 @@ export interface ICreateJobModel {
   schedule?: string;
   // String for timezone in tz database format
   timezone?: string;
+  // "Easy scheduling" inputs
+  // Intervals: 'minute' | 'hour' | 'day' | 'week' | 'weekday' | 'month' | 'custom'
+  scheduleInterval: string;
+  // Form input values for time and minutes
+  scheduleTimeInput?: string;
+  scheduleMinuteInput?: string;
+  scheduleMinute?: number;
+  scheduleHour?: number;
+  scheduleMonthDay?: number;
+  scheduleWeekDay?: number;
 }
 
 export interface IListJobsModel {
@@ -156,7 +166,8 @@ export function convertDescribeJobtoJobDetail(
     createTime: dj.create_time,
     updateTime: dj.update_time,
     startTime: dj.start_time,
-    endTime: dj.end_time
+    endTime: dj.end_time,
+    scheduleInterval: 'custom'
   };
 }
 
@@ -284,7 +295,8 @@ namespace Private {
       inputFile: '',
       outputPath: '',
       environment: '',
-      createType: 'Job'
+      createType: 'Job',
+      scheduleInterval: 'custom'
     };
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -202,7 +202,8 @@ export function convertDescribeDefinitiontoDefinition(
     createTime: dj.create_time,
     updateTime: dj.update_time,
     schedule: dj.schedule,
-    timezone: dj.timezone
+    timezone: dj.timezone,
+    scheduleInterval: 'custom'
   };
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -167,7 +167,7 @@ export function convertDescribeJobtoJobDetail(
     updateTime: dj.update_time,
     startTime: dj.start_time,
     endTime: dj.end_time,
-    scheduleInterval: 'custom'
+    scheduleInterval: 'weekday'
   };
 }
 
@@ -296,7 +296,7 @@ namespace Private {
       outputPath: '',
       environment: '',
       createType: 'Job',
-      scheduleInterval: 'custom'
+      scheduleInterval: 'weekday'
     };
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -102,6 +102,7 @@ export interface ICreateJobModel {
   scheduleMinuteInput?: string;
   scheduleMinute?: number;
   scheduleHour?: number;
+  scheduleMonthDayInput?: string;
   scheduleMonthDay?: number;
   scheduleWeekDay?: string;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -97,9 +97,11 @@ export interface ICreateJobModel {
   // "Easy scheduling" inputs
   // Intervals: 'minute' | 'hour' | 'day' | 'week' | 'weekday' | 'month' | 'custom'
   scheduleInterval: string;
-  // Form input values for time and minutes
-  scheduleTimeInput?: string;
+  // Minute for an input that only accepts minutes (of the hour)
   scheduleMinuteInput?: string;
+  scheduleHourMinute?: number;
+  // Hour and minute for time inputs
+  scheduleTimeInput?: string;
   scheduleMinute?: number;
   scheduleHour?: number;
   scheduleMonthDayInput?: string;

--- a/src/model.ts
+++ b/src/model.ts
@@ -103,7 +103,7 @@ export interface ICreateJobModel {
   scheduleMinute?: number;
   scheduleHour?: number;
   scheduleMonthDay?: number;
-  scheduleWeekDay?: number;
+  scheduleWeekDay?: string;
 }
 
 export interface IListJobsModel {


### PR DESCRIPTION
Adds six additional options to schedule a job every minute, every hour at _M_ minutes past the hour, every day at time _T_, every weekday at time _T_, every week at time _T_ on day-of-week _W_, and every month at time _T_ on day-of-month _D_.

Text inputs are validated. Changes are persisted in the `cron` schedule format.

Fixes #84, #98, #80.

Screen shots:

![every minute](https://user-images.githubusercontent.com/93281816/194923233-9ac75d6a-26ee-4ef7-8fac-36529d06b861.png)

![every hour](https://user-images.githubusercontent.com/93281816/194923270-004a728d-d31d-407d-8059-bef7b7f77758.png)

![every day](https://user-images.githubusercontent.com/93281816/194923305-d96c56ea-0360-447f-922b-7de3c94009f1.png)

![every week](https://user-images.githubusercontent.com/93281816/194923330-cf048468-4a39-4d35-b5d2-1d61e306e10b.png)

![every weekday](https://user-images.githubusercontent.com/93281816/194923366-fb0c4aa4-00e6-4001-a518-aedd949e34fb.png)

![every month](https://user-images.githubusercontent.com/93281816/194923396-a0f261e8-7a9d-4003-b8d3-147b6fb09455.png)

![custom schedule](https://user-images.githubusercontent.com/93281816/194923415-731bfa4b-3b4f-4bd9-a01a-0fb3125d822f.png)
