### PR TITLE
Sets default time zone in create-job form

### DIFF
--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -93,7 +93,8 @@ function RefillButton(props: {
       environment: props.job.runtime_environment_name,
       parameters: jobParameters,
       createType: 'Job',
-      scheduleInterval: 'weekday'
+      scheduleInterval: 'weekday',
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
     };
 
     // Convert the list of output formats, if any, into a list for the initial state

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -206,7 +206,8 @@ async function activatePlugin(
         outputPath: '',
         environment: '',
         createType: 'Job',
-        scheduleInterval: 'weekday'
+        scheduleInterval: 'weekday',
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
       };
 
       model.createJobModel = newModel;

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -62,7 +62,8 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       environment: props.model.environment,
       parameters: props.model.parameters,
       createType: 'Job',
-      scheduleInterval: 'weekday'
+      scheduleInterval: 'weekday',
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
     };
 
     props.setCreateJobModel(initialState);

--- a/src/model.ts
+++ b/src/model.ts
@@ -300,7 +300,8 @@ namespace Private {
       outputPath: '',
       environment: '',
       createType: 'Job',
-      scheduleInterval: 'weekday'
+      scheduleInterval: 'weekday',
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
     };
   }
 }


### PR DESCRIPTION
Uses the browser API, supported in all browsers (with fallback to `undefined`), to retrieve the default time zone for the user. Prepopulates it in forms that could create a new job definition.

Fixes #112.

https://user-images.githubusercontent.com/93281816/194961306-23421cb9-1da0-4936-aaf0-5e8d6511e0f1.mov

