### PR TITLE
Adds cron tip link

### DIFF
--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -135,6 +135,17 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
     />
   );
 
+  const cronTips = (
+    <p>
+      <a
+        href="https://www.gnu.org/software/mcron/manual/html_node/Crontab-file.html"
+        target="_blank"
+      >
+        {trans.__('Get help with cron syntax')}
+      </a>
+    </p>
+  );
+
   return (
     <>
       <FormControl>
@@ -225,7 +236,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
       {props.model.scheduleInterval === 'custom' && (
         <>
           <TextField
-            label={trans.__('Cron expression')}
+            label={trans.__('cron expression')}
             variant="outlined"
             onChange={props.handleScheduleChange}
             value={props.model.schedule ?? ''}
@@ -234,6 +245,7 @@ export function ScheduleInputs(props: ScheduleInputsProps): JSX.Element | null {
             error={!!props.errors['schedule']}
             helperText={props.errors['schedule'] || cronString}
           />
+          {cronTips}
           {timezonePicker}
         </>
       )}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -122,7 +122,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     } catch {
       setErrors({
         ...errors,
-        schedule: trans.__('You must provide a valid Cron expression.')
+        schedule: trans.__('You must provide a valid cron expression.')
       });
     }
   };


### PR DESCRIPTION
Consistently uses all-lowercase for 'cron', and adds a link to a GNU help page for crontab syntax assistance. The link opens in a new window.

![image (1)](https://user-images.githubusercontent.com/93281816/194966620-9e4bb4f9-58f3-499c-841f-2610cd26f1c8.png)
