### PR TITLE
Fix outputFormats in model conversion

### DIFF
--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -104,9 +104,9 @@ function RefillButton(props: {
       props.job.runtime_environment_name
     );
     if (jobOutputFormats && outputFormats) {
-      newModel.outputFormats = outputFormats.filter(of =>
-        jobOutputFormats.some(jof => of.name === jof)
-      );
+      newModel.outputFormats = outputFormats
+        .filter(of => jobOutputFormats.some(jof => of.name === jof))
+        .map(of => of.name);
     }
 
     // Switch the view to the form.

--- a/src/components/output-format-picker.tsx
+++ b/src/components/output-format-picker.tsx
@@ -15,7 +15,7 @@ export type OutputFormatPickerProps = {
   environment: string;
   environmentList: Scheduler.IRuntimeEnvironment[];
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  value: IOutputFormat[];
+  value: string[];
 };
 
 export function outputFormatsForEnvironment(
@@ -51,7 +51,7 @@ export function OutputFormatPicker(
             key={idx}
             control={
               <Checkbox
-                defaultChecked={props.value.some(sof => of.name === sof.name)}
+                defaultChecked={props.value.some(sof => of.name === sof)}
                 id={`${props.id}-${of.name}`}
                 value={of.name}
                 onChange={props.onChange}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -648,7 +648,6 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
   const cantSubmit = trans.__('One or more of the fields has an error.');
 
-  console.log('Output formats: ' + JSON.stringify(props.model.outputFormats));
   return (
     <Box sx={{ p: 4 }}>
       <form className={`${formPrefix}form`} onSubmit={e => e.preventDefault()}>

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -12,12 +12,7 @@ import {
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
-import {
-  ICreateJobModel,
-  IJobParameter,
-  IOutputFormat,
-  ListJobsView
-} from '../model';
+import { ICreateJobModel, IJobParameter, ListJobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 
 import Button from '@mui/material/Button';
@@ -168,10 +163,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     const isChecked = event.target.checked;
 
     const wasChecked: boolean = props.model.outputFormats
-      ? props.model.outputFormats.some(of => of.name === formatName)
+      ? props.model.outputFormats.some(of => of === formatName)
       : false;
 
-    const oldOutputFormats: IOutputFormat[] = props.model.outputFormats || [];
+    const oldOutputFormats: string[] = props.model.outputFormats || [];
 
     // Go from unchecked to checked
     if (isChecked && !wasChecked) {
@@ -180,7 +175,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       if (newFormat) {
         props.handleModelChange({
           ...props.model,
-          outputFormats: [...oldOutputFormats, newFormat]
+          outputFormats: [...oldOutputFormats, newFormat.name]
         });
       }
     }
@@ -188,7 +183,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     else if (!isChecked && wasChecked) {
       props.handleModelChange({
         ...props.model,
-        outputFormats: oldOutputFormats.filter(of => of.name !== formatName)
+        outputFormats: oldOutputFormats.filter(of => of !== formatName)
       });
     }
 
@@ -561,6 +556,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       input_uri: props.model.inputFile,
       output_prefix: props.model.outputPath,
       runtime_environment_name: props.model.environment,
+      output_formats: props.model.outputFormats,
       compute_type: props.model.computeType,
       idempotency_token: props.model.idempotencyToken,
       tags: props.model.tags,
@@ -569,12 +565,6 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
     if (props.model.parameters !== undefined) {
       jobOptions.parameters = serializeParameters(props.model.parameters);
-    }
-
-    if (props.model.outputFormats !== undefined) {
-      jobOptions.output_formats = props.model.outputFormats.map(
-        entry => entry.name
-      );
     }
 
     api.createJob(jobOptions).then(response => {
@@ -597,7 +587,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       output_prefix: props.model.outputPath,
       runtime_environment_name: props.model.environment,
       compute_type: props.model.computeType,
-      // idempotency_token is in the form, but not in Scheduler.ICreateJobDefinition
+      output_formats: props.model.outputFormats,
       tags: props.model.tags,
       runtime_environment_parameters: props.model.runtimeEnvironmentParameters,
       schedule: props.model.schedule,
@@ -607,12 +597,6 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     if (props.model.parameters !== undefined) {
       jobDefinitionOptions.parameters = serializeParameters(
         props.model.parameters
-      );
-    }
-
-    if (props.model.outputFormats !== undefined) {
-      jobDefinitionOptions.output_formats = props.model.outputFormats.map(
-        entry => entry.name
       );
     }
 
@@ -664,6 +648,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
   const cantSubmit = trans.__('One or more of the fields has an error.');
 
+  console.log('Output formats: ' + JSON.stringify(props.model.outputFormats));
   return (
     <Box sx={{ p: 4 }}>
       <form className={`${formPrefix}form`} onSubmit={e => e.preventDefault()}>

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -66,6 +66,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       outputPath: props.model.outputPrefix ?? '',
       environment: props.model.environment,
       parameters: props.model.parameters,
+      outputFormats: props.model.outputFormats,
       createType: 'Job',
       scheduleInterval: 'weekday',
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone

--- a/src/model.ts
+++ b/src/model.ts
@@ -86,7 +86,8 @@ export interface ICreateJobModel {
   createType: 'Job' | 'JobDefinition';
   runtimeEnvironmentParameters?: { [key: string]: number | string };
   parameters?: IJobParameter[];
-  outputFormats?: IOutputFormat[];
+  // List of values for output formats; labels are specified by the environment
+  outputFormats?: string[];
   computeType?: string;
   idempotencyToken?: string;
   tags?: string[];
@@ -151,7 +152,6 @@ export function convertDescribeJobtoJobDetail(
     }
   );
 
-  // TODO: Convert outputFormats
   return {
     createType: 'Job',
     jobId: dj.job_id,
@@ -162,7 +162,7 @@ export function convertDescribeJobtoJobDetail(
     environment: dj.runtime_environment_name,
     runtimeEnvironmentParameters: dj.runtime_environment_parameters,
     parameters: jdParameters,
-    outputFormats: [],
+    outputFormats: dj.output_formats,
     computeType: dj.compute_type,
     idempotencyToken: dj.idempotency_token,
     tags: dj.tags,
@@ -188,7 +188,6 @@ export function convertDescribeDefinitiontoDefinition(
     }
   );
 
-  // TODO: Convert outputFormats
   return {
     name: dj.name ?? '',
     jobName: '',
@@ -200,7 +199,7 @@ export function convertDescribeDefinitiontoDefinition(
     environment: dj.runtime_environment_name,
     runtimeEnvironmentParameters: dj.runtime_environment_parameters,
     parameters: jdParameters,
-    outputFormats: [],
+    outputFormats: dj.output_formats,
     computeType: dj.compute_type,
     tags: dj.tags,
     active: dj.active ? 'IN_PROGRESS' : 'STOPPED',


### PR DESCRIPTION
Fixes #54. 

Changes outputFormats to be an array of strings; passes it when the user clicks the "rerun" button in the list and detail views.

See the following video showing that the output formats persist when rerunning a job from the list or details view.


https://user-images.githubusercontent.com/93281816/195218335-d9dde2d5-da98-4f63-91cf-0c476dbb4f94.mov

