### PR TITLE
Sets schedule based on new schedule interval

### DIFF
--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -445,7 +445,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
     setErrors(newErrors);
 
-    switch (props.model.scheduleInterval) {
+    switch (newInterval) {
       case 'minute':
         schedule = '* * * * *'; // every minute
         break;


### PR DESCRIPTION
Fixes #129. Uses the new schedule interval, not the previous one, to set schedules in the model.