### PR TITLE
Adds friendly schedule, "paused" columns for job description in list

### DIFF
--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -9,6 +9,7 @@ import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 
 import { Scheduler } from '../handler';
+import { useTranslator } from '../hooks';
 
 function CreatedAt(props: {
   job: Scheduler.IDescribeJobDefinition;
@@ -38,6 +39,8 @@ export function buildJobDefinitionRow(
   app: JupyterFrontEnd,
   openJobDefinitionDetail: (jobDefId: string) => unknown
 ): JSX.Element {
+  const trans = useTranslator('jupyterlab');
+
   const cellContents: React.ReactNode[] = [
     // name
     <a onClick={() => openJobDefinitionDetail(jobDef.job_definition_id)}>
@@ -45,7 +48,8 @@ export function buildJobDefinitionRow(
     </a>,
     PathExt.basename(jobDef.input_uri),
     <CreatedAt job={jobDef} />,
-    <ScheduleSummary schedule={jobDef.schedule} />
+    <ScheduleSummary schedule={jobDef.schedule} />,
+    <>{jobDef.active ? trans.__('Active') : trans.__('Paused')}</>
   ];
 
   return (

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import cronstrue from 'cronstrue';
+
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { PathExt } from '@jupyterlab/coreutils';
 
@@ -21,6 +23,16 @@ function CreatedAt(props: {
   return <>{create_display_date}</>;
 }
 
+function ScheduleSummary(props: {
+  schedule: string | undefined;
+}): JSX.Element | null {
+  if (props.schedule === undefined) {
+    return null;
+  }
+
+  return <>{cronstrue.toString(props.schedule)}</>;
+}
+
 export function buildJobDefinitionRow(
   jobDef: Scheduler.IDescribeJobDefinition,
   app: JupyterFrontEnd,
@@ -32,7 +44,8 @@ export function buildJobDefinitionRow(
       {jobDef.name}
     </a>,
     PathExt.basename(jobDef.input_uri),
-    <CreatedAt job={jobDef} />
+    <CreatedAt job={jobDef} />,
+    <ScheduleSummary schedule={jobDef.schedule} />
   ];
 
   return (

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -183,6 +183,10 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
     {
       sortField: 'create_time',
       name: trans.__('Created at')
+    },
+    {
+      sortField: null,
+      name: trans.__('Schedule')
     }
   ];
 

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -187,6 +187,10 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
     {
       sortField: null,
       name: trans.__('Schedule')
+    },
+    {
+      sortField: null,
+      name: trans.__('Status')
     }
   ];
 


### PR DESCRIPTION
Adds friendly definition of schedule to job definition list. Adds friendly "paused" column to job description list. Partial fix for #133.

![image (3)](https://user-images.githubusercontent.com/93281816/195422065-13f56ea7-fef2-45ea-9e9c-4ee82e52eb87.png)
