### PR TITLE
Populates runtimeEnvironmentParameters on rerun from list, detail

### DIFF
--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -89,6 +89,7 @@ function RefillButton(props: {
       jobName: props.job.name ?? '',
       outputPath: props.job.output_prefix,
       environment: props.job.runtime_environment_name,
+      runtimeEnvironmentParameters: props.job.runtime_environment_parameters,
       parameters: jobParameters,
       createType: 'Job',
       scheduleInterval: 'weekday',

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -66,6 +66,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       inputFile: props.model.inputFile,
       outputPath: props.model.outputPrefix ?? '',
       environment: props.model.environment,
+      runtimeEnvironmentParameters: props.model.runtimeEnvironmentParameters,
       parameters: props.model.parameters,
       outputFormats: props.model.outputFormats,
       createType: 'Job',


### PR DESCRIPTION
Fixes #148 by populating `runtimeEnvironmentParameters` when a job is rerun from the list and detail views.