### PR TITLE
add jobs table in job definition detail view

### DIFF
--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -48,6 +48,7 @@ type AdvancedTableProps<
   columns: AdvancedTableColumn[];
   emptyRowMessage: string;
   rowFilter?: (row: R) => boolean;
+  pageSize?: number;
   /**
    * Height of the table. If set to 'auto', this table automatically expands to
    * fit the remaining height of the page when wrapped in a flex container with
@@ -74,6 +75,8 @@ export function AdvancedTable<
   const [loading, setLoading] = useState<boolean>(true);
   const theme = useTheme();
 
+  const pageSize = props.pageSize ?? PAGE_SIZE;
+
   const fetchInitialRows = async () => {
     // reset pagination state
     setPage(0);
@@ -82,7 +85,7 @@ export function AdvancedTable<
     setLoading(true);
     const payload = await props.request({
       ...props.query,
-      max_items: PAGE_SIZE
+      max_items: pageSize
     });
     setLoading(false);
 
@@ -112,7 +115,7 @@ export function AdvancedTable<
     setLoading(true);
     const payload = await props.request({
       ...props.query,
-      max_items: PAGE_SIZE,
+      max_items: pageSize,
       next_token: nextToken
     });
     setLoading(false);
@@ -134,7 +137,7 @@ export function AdvancedTable<
   }
 
   const renderedRows: JSX.Element[] = (rows || [])
-    .slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+    .slice(page * pageSize, (page + 1) * pageSize)
     .filter(row => (props.rowFilter ? props.rowFilter(row) : true))
     .map(row => props.renderRow(row));
 
@@ -185,8 +188,8 @@ export function AdvancedTable<
           nextIconButtonProps={{
             disabled: page === maxPage && !nextToken
           }}
-          rowsPerPage={PAGE_SIZE}
-          rowsPerPageOptions={[PAGE_SIZE]}
+          rowsPerPage={pageSize}
+          rowsPerPageOptions={[pageSize]}
         />
       </TableContainer>
     </div>

--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -48,6 +48,13 @@ type AdvancedTableProps<
   columns: AdvancedTableColumn[];
   emptyRowMessage: string;
   rowFilter?: (row: R) => boolean;
+  /**
+   * Height of the table. If set to 'auto', this table automatically expands to
+   * fit the remaining height of the page when wrapped in a flex container with
+   * its height equal to the height of the page. Otherwise the max-height is
+   * manually set to whatever value is provided. Defaults to 'auto'.
+   */
+  height?: 'auto' | string | number;
 };
 
 /**
@@ -143,9 +150,12 @@ export function AdvancedTable<
     setMaxPage(newPage);
   };
 
-  // outer div expands to fill rest of screen
+  const height = props.height ?? 'auto';
+
   return (
-    <div style={{ flex: 1, height: 0 }}>
+    <div
+      style={height === 'auto' ? { flex: 1, height: 0 } : { maxHeight: height }}
+    >
       <TableContainer
         component={Paper}
         sx={{

--- a/src/mainviews/detail-view/detail-view.tsx
+++ b/src/mainviews/detail-view/detail-view.tsx
@@ -33,6 +33,8 @@ export interface IDetailViewProps {
   setCreateJobModel: (createModel: ICreateJobModel) => void;
   setJobsView: (view: JobsView) => void;
   setListJobsView: (view: ListJobsView) => void;
+  showJobDetail: (jobId: string) => void;
+  showCreateJob: (state: ICreateJobModel) => void;
   // Extension point: optional additional component
   advancedOptions: React.FunctionComponent<Scheduler.IAdvancedOptionsProps>;
 }
@@ -87,7 +89,7 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
         fetchJobDefinitionModel();
         break;
     }
-  }, [props.model]);
+  }, [props.model, props.model.detailType, props.model.id]);
 
   const BreadcrumbsStyled = (
     <div role="presentation">
@@ -144,10 +146,13 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
           )}
           {props.model.detailType === 'JobDefinition' && jobDefinitionModel && (
             <JobDefinition
+              app={props.app}
               model={jobDefinitionModel}
               setJobsView={props.setJobsView}
               setListJobsView={props.setListJobsView}
               refresh={fetchJobDefinitionModel}
+              showCreateJob={props.showCreateJob}
+              showJobDetail={props.showJobDetail}
             />
           )}
           {!jobModel && !jobDefinitionModel && (

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -157,7 +157,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
             showCreateJob={props.showCreateJob}
             showJobDetail={props.showJobDetail}
             jobDefinitionId={props.model.definitionId}
-            pageSize={3}
+            pageSize={5}
           />
         </Stack>
       </CardContent>

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -1,9 +1,15 @@
 import React, { useMemo } from 'react';
-import { IJobDefinitionModel, JobsView, ListJobsView } from '../../model';
+import {
+  IJobDefinitionModel,
+  JobsView,
+  ListJobsView,
+  ICreateJobModel
+} from '../../model';
 import { useTranslator } from '../../hooks';
 import { TextFieldStyled, timestampLocalize } from './job-detail';
 import { SchedulerService } from '../../handler';
 import cronstrue from 'cronstrue';
+import { ListJobsTable } from '../list-jobs';
 
 import {
   Button,
@@ -13,12 +19,16 @@ import {
   TextFieldProps
 } from '@mui/material';
 import { DeleteWithConfirmationButton } from '../../components/delete-with-confirmation-button';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 
 export interface IJobDefinitionProps {
+  app: JupyterFrontEnd;
   model: IJobDefinitionModel;
   refresh: () => void;
   setJobsView: (view: JobsView) => void;
   setListJobsView: (view: ListJobsView) => void;
+  showJobDetail: (jobId: string) => void;
+  showCreateJob: (state: ICreateJobModel) => void;
 }
 
 export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
@@ -141,7 +151,15 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const JobsList = (
     <Card>
       <CardContent>
-        <Stack spacing={4}> List of jobs will go here </Stack>
+        <Stack spacing={3}>
+          <ListJobsTable
+            app={props.app}
+            showCreateJob={props.showCreateJob}
+            showJobDetail={props.showJobDetail}
+            jobDefinitionId={props.model.definitionId}
+            height={300}
+          />
+        </Stack>
       </CardContent>
     </Card>
   );

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -157,7 +157,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
             showCreateJob={props.showCreateJob}
             showJobDetail={props.showJobDetail}
             jobDefinitionId={props.model.definitionId}
-            height={300}
+            pageSize={3}
           />
         </Stack>
       </CardContent>

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -28,6 +28,7 @@ interface IListJobsTableProps {
   showJobDetail: (jobId: string) => void;
   jobDefinitionId?: string;
   height?: 'auto' | string | number;
+  pageSize?: number;
 }
 
 export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
@@ -163,6 +164,7 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
         emptyRowMessage={emptyRowMessage}
         rowFilter={rowFilter}
         height={props.height}
+        pageSize={props.pageSize}
       />
     </>
   );

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -20,17 +20,24 @@ import {
 } from '../components/advanced-table';
 
 interface IListJobsTableProps {
-  startToken?: string;
   app: JupyterFrontEnd;
   // Function that results in the create job form being made visible
   // with job details prepopulated.
   showCreateJob: (state: ICreateJobModel) => void;
   // function that shows job detail view
-  showDetailView: (jobId: string) => void;
+  showJobDetail: (jobId: string) => void;
+  jobDefinitionId?: string;
+  height?: 'auto' | string | number;
 }
 
-function ListJobsTable(props: IListJobsTableProps): JSX.Element {
-  const [jobsQuery, setJobsQuery] = useState<Scheduler.IListJobsQuery>({});
+export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
+  const [jobsQuery, setJobsQuery] = useState<Scheduler.IListJobsQuery>(
+    props.jobDefinitionId
+      ? {
+          job_definition_id: props.jobDefinitionId
+        }
+      : {}
+  );
   const [deletedRows, setDeletedRows] = useState<
     Set<Scheduler.IDescribeJob['job_id']>
   >(new Set());
@@ -58,7 +65,11 @@ function ListJobsTable(props: IListJobsTableProps): JSX.Element {
 
   const reloadButton = (
     <Cluster justifyContent="flex-end">
-      <Button variant="contained" size="small" onClick={() => setJobsQuery({})}>
+      <Button
+        variant="contained"
+        size="small"
+        onClick={() => setJobsQuery(query => ({ ...query }))}
+      >
         {trans.__('Reload')}
       </Button>
     </Cluster>
@@ -125,7 +136,7 @@ function ListJobsTable(props: IListJobsTableProps): JSX.Element {
       props.showCreateJob,
       deleteRow,
       translateStatus,
-      props.showDetailView
+      props.showJobDetail
     );
 
   const rowFilter = (job: Scheduler.IDescribeJob) =>
@@ -151,6 +162,7 @@ function ListJobsTable(props: IListJobsTableProps): JSX.Element {
         columns={columns}
         emptyRowMessage={emptyRowMessage}
         rowFilter={rowFilter}
+        height={props.height}
       />
     </>
   );
@@ -209,7 +221,7 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
       <Button
         variant="contained"
         size="small"
-        onClick={() => setJobDefsQuery({})}
+        onClick={() => setJobDefsQuery(query => ({ ...query }))}
       >
         {trans.__('Reload')}
       </Button>
@@ -295,7 +307,7 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
             <ListJobsTable
               app={props.app}
               showCreateJob={props.showCreateJob}
-              showDetailView={props.showJobDetail}
+              showJobDetail={props.showJobDetail}
             />
           </>
         )}

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -108,6 +108,8 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
               setListJobsView={view => {
                 this.model.listJobsModel.listJobsView = view;
               }}
+              showCreateJob={showCreateJob}
+              showJobDetail={this.showDetailView.bind(this)}
               advancedOptions={this._advancedOptions}
             />
           )}


### PR DESCRIPTION
- adds (jobSize?: number) prop to `ListJobsTable` to control page size of the table
- adds `ListJobsTable` table to `JobDefinition` with page size of 5 (please see preview below as well as previews of alternative page sizes 3 and 10)

Closes #134.

Preview:
![page_size_5](https://user-images.githubusercontent.com/26686070/195918939-30197c99-3c34-4618-bc97-05c59ac789fd.gif)

Alternative page size 3:
![page_size_3](https://user-images.githubusercontent.com/26686070/195918978-1dc613a3-2fdd-42c7-934d-85c0cee79e86.gif)

Alternative page size 10:
![job_size_10](https://user-images.githubusercontent.com/26686070/195919012-0fcbf884-f3a4-41a6-8989-4a044044beca.gif)
