### PR TITLE
Adds notebook toolbar button to create job

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -3,14 +3,15 @@
   "title": "Notebook Scheduling",
   "description": "JupyterLab notebook scheduling settings.",
   "jupyter.lab.menus": {
+    "Notebook": [
+      {
+        "command": "scheduling:create-from-notebook",
+        "rank": 36
+      }
+    ],
     "context": [
       {
-        "command": "scheduling:schedule-notebook",
-        "selector": ".jp-DirListing-item[data-file-type=\"notebook\"]",
-        "rank": 3.8
-      },
-      {
-        "command": "scheduling:run-notebook",
+        "command": "scheduling:create-from-filebrowser",
         "selector": ".jp-DirListing-item[data-file-type=\"notebook\"]",
         "rank": 3.9
       }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -5,8 +5,9 @@
   "jupyter.lab.menus": {
     "Notebook": [
       {
+        "name": "create-job",
         "command": "scheduling:create-from-notebook",
-        "rank": 36
+        "rank": 46
       }
     ],
     "context": [

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -3,18 +3,20 @@
   "title": "Notebook Scheduling",
   "description": "JupyterLab notebook scheduling settings.",
   "jupyter.lab.menus": {
-    "Notebook": [
-      {
-        "name": "create-job",
-        "command": "scheduling:create-from-notebook",
-        "rank": 46
-      }
-    ],
     "context": [
       {
         "command": "scheduling:create-from-filebrowser",
         "selector": ".jp-DirListing-item[data-file-type=\"notebook\"]",
         "rank": 3.9
+      }
+    ]
+  },
+  "jupyter.lab.toolbars": {
+    "Notebook": [
+      {
+        "name": "create-job",
+        "command": "scheduling:create-from-notebook",
+        "rank": 46
       }
     ]
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  createSemanticCommand,
   ILayoutRestorer,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -219,16 +218,6 @@ async function activatePlugin(
   });
 
   commands.addCommand(CommandIDs.createJobCurrentNotebook, {
-    ...createSemanticCommand(
-      app,
-      menu.codeRunners.run,
-      {
-        label: trans.__('Create Notebook Job'),
-        caption: trans.__('Create Notebook Job')
-      },
-      trans
-    ),
-
     execute: async () => {
       await showJobsPane('CreateJob');
 
@@ -237,9 +226,8 @@ async function activatePlugin(
         return;
       }
 
-      const widget = tracker.currentWidget;
-      const filePath = getSelectedFilePath(widget) ?? '';
-      const fileName = getSelectedFileName(widget) ?? '';
+      const filePath = 'path/foo.ipynb';
+      const fileName = 'foo.ipynb';
 
       // Update the job form inside the notebook jobs widget
       const newModel: ICreateJobModel = {
@@ -256,11 +244,6 @@ async function activatePlugin(
     },
     label: trans.__('Create Notebook Job'),
     icon: calendarAddOnIcon
-
-
-
-    icon: args => (args.toolbar ? runIcon : undefined)
-
   });
 
   commands.addCommand(CommandIDs.stopJob, {

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -132,11 +132,7 @@ function ListJobsTable(props: IListJobsTableProps): JSX.Element {
     !deletedRows.has(job.job_id);
 
   const emptyRowMessage = useMemo(
-    () =>
-      trans.__(
-        'There are no notebook jobs. ' +
-          'Right-click on a file in the file browser to run or schedule a notebook as a job.'
-      ),
+    () => trans.__('There are no notebook jobs.'),
     [trans]
   );
 


### PR DESCRIPTION
Fixes #96. Adds a new toolbar button in notebooks, to the right of the cell type dropdown, to create a new notebook job:

![image](https://user-images.githubusercontent.com/93281816/195728611-6c1e2cc7-862b-4818-8684-ba9a69ad1f35.png)

As is the case with jobs created from the file browser's context menu, the default job name is the filename and the default input path is the full input path.