### PR TITLE
Advanced options errors

### DIFF
--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -15,6 +15,8 @@ import { useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, ListJobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 
+import WarningIcon from '@mui/icons-material/Warning';
+
 import Button from '@mui/material/Button';
 import Box from '@mui/system/Box';
 import Stack from '@mui/system/Stack';
@@ -71,6 +73,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   // If an error message is "truthy" (i.e., not null or ''), we should display the
   // input in an error state and block form submission.
   const [errors, setErrors] = useState<SchedulerTokens.ErrorsType>({});
+  // Errors for the advanced options
+  const [advancedOptionsErrors, setAdvancedOptionsErrors] =
+    useState<SchedulerTokens.ErrorsType>({});
 
   const api = useMemo(() => new SchedulerService({}), []);
 
@@ -84,7 +89,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   }, []);
 
   // If any error message is "truthy" (not null or empty), the form should not be submitted.
-  const anyErrors = Object.keys(errors).some(key => !!errors[key]);
+  const anyAdvancedErrors = Object.keys(advancedOptionsErrors).some(
+    key => !!advancedOptionsErrors[key]
+  );
+  const anyErrors =
+    Object.keys(errors).some(key => !!errors[key]) || anyAdvancedErrors;
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const target = event.target;
@@ -726,6 +735,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
               id="panel-header"
             >
               <FormLabel component="legend">
+                {anyAdvancedErrors && (
+                  <WarningIcon color="warning" aria-label="warning">
+                    {trans.__('There is an error in the advanced options')}
+                  </WarningIcon>
+                )}
                 {trans.__('Additional options')}
               </FormLabel>
             </AccordionSummary>
@@ -734,8 +748,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                 jobsView={'CreateJob'}
                 model={props.model}
                 handleModelChange={props.handleModelChange}
-                errors={errors}
-                handleErrorsChange={setErrors}
+                errors={advancedOptionsErrors}
+                handleErrorsChange={setAdvancedOptionsErrors}
               />
             </AccordionDetails>
           </Accordion>

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -15,7 +15,7 @@ import { useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, ListJobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 
-import WarningIcon from '@mui/icons-material/Warning';
+import ErrorIcon from '@mui/icons-material/Error';
 
 import Button from '@mui/material/Button';
 import Box from '@mui/system/Box';
@@ -735,12 +735,14 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
               id="panel-header"
             >
               <FormLabel component="legend">
-                {anyAdvancedErrors && (
-                  <WarningIcon color="warning" aria-label="warning">
-                    {trans.__('There is an error in the advanced options')}
-                  </WarningIcon>
-                )}
-                {trans.__('Additional options')}
+                <Cluster>
+                  {anyAdvancedErrors && (
+                    <ErrorIcon color="error" aria-label="error">
+                      {trans.__('There is an error in the advanced options')}
+                    </ErrorIcon>
+                  )}
+                  {trans.__('Additional options')}
+                </Cluster>
               </FormLabel>
             </AccordionSummary>
             <AccordionDetails id={`${formPrefix}create-panel-content`}>


### PR DESCRIPTION
Fixes #101. If at least one input in the advanced options section has an error, mark the "Advanced options" header with an error icon to indicate that some input in this section has an error, even if the section is collapsed.

Demo video:

https://user-images.githubusercontent.com/93281816/195898814-0411f0a2-bc7c-4bfe-a50b-560c475c1c49.mov

Screen shot:

![image (5)](https://user-images.githubusercontent.com/93281816/195898988-0988e954-ddeb-4bb8-a507-13ebb2eab50c.png)

