### PR TITLE
Handle create error in create form

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -94,7 +94,7 @@ export class SchedulerService {
         body: JSON.stringify(definition)
       });
     } catch (e: any) {
-      console.error(e);
+      return Promise.reject(e);
     }
     return data as Scheduler.IDescribeJobDefinition;
   }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -179,7 +179,7 @@ export class SchedulerService {
         body: JSON.stringify(model)
       });
     } catch (e) {
-      console.error(e);
+      return Promise.reject(e);
     }
     return data as Scheduler.ICreateJobResponse;
   }
@@ -303,9 +303,10 @@ export namespace SchedulerService {
 }
 
 export namespace Scheduler {
-
-  export type RuntimeEnvironmentParameters = { [key: string]: number | string | boolean}
-  export type Parameters = { [key: string]: number | string | boolean}
+  export type RuntimeEnvironmentParameters = {
+    [key: string]: number | string | boolean;
+  };
+  export type Parameters = { [key: string]: number | string | boolean };
 
   export interface ICreateJobDefinition {
     input_uri: string;
@@ -323,20 +324,20 @@ export namespace Scheduler {
   }
 
   export interface IUpdateJobDefinition {
-    input_uri?: string
-    output_prefix?: string
-    runtime_environment_name?: string
-    runtime_environment_parameters?: RuntimeEnvironmentParameters
-    output_formats?: string[]
-    parameters?: Parameters
+    input_uri?: string;
+    output_prefix?: string;
+    runtime_environment_name?: string;
+    runtime_environment_parameters?: RuntimeEnvironmentParameters;
+    output_formats?: string[];
+    parameters?: Parameters;
     tags?: string[];
     name?: string;
     output_filename_template?: string;
     compute_type?: string;
     schedule?: string;
     timezone?: string;
-    url?: string
-    active?: boolean
+    url?: string;
+    active?: boolean;
   }
 
   export interface IDescribeJobDefinition extends ICreateJobDefinition {
@@ -437,9 +438,9 @@ export namespace Scheduler {
   }
 
   export interface IUpdateJob {
-    status?: Status
-    name?: string
-    compute_type?: string
+    status?: Status;
+    name?: string;
+    compute_type?: string;
   }
 
   export interface IRuntimeEnvironment {

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -103,20 +103,17 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     const parameterValueIdx = parameterValueMatch(target.name);
     const newParams = props.model.parameters || [];
 
-    let newModel = { ...props.model, createError: undefined };
     if (parameterNameIdx !== null) {
       newParams[parameterNameIdx].name = target.value;
-      newModel.parameters = newParams;
+      props.handleModelChange({ ...props.model, parameters: newParams });
     } else if (parameterValueIdx !== null) {
       newParams[parameterValueIdx].value = target.value;
-      newModel.parameters = newParams;
+      props.handleModelChange({ ...props.model, parameters: newParams });
     } else {
       const value = target.type === 'checkbox' ? target.checked : target.value;
       const name = target.name;
-      newModel = { ...newModel, [name]: value };
+      props.handleModelChange({ ...props.model, [name]: value });
     }
-
-    props.handleModelChange(newModel);
   };
 
   const validateSchedule = (schedule: string) => {
@@ -145,27 +142,24 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   const handleTimezoneChange = (value: string | null) => {
     props.handleModelChange({
       ...props.model,
-      timezone: value ?? '',
-      createError: undefined
+      timezone: value ?? ''
     });
   };
 
   const handleSelectChange = (event: SelectChangeEvent<string>) => {
     const target = event.target;
 
-    const newModel = { ...props.model, createError: undefined };
-
     // if setting the environment, default the compute type to its first value (if any are presnt)
     if (target.name === 'environment') {
       const envObj = environmentList.find(env => env.name === target.value);
       props.handleModelChange({
-        ...newModel,
+        ...props.model,
         environment: target.value,
         computeType: envObj?.compute_types?.[0]
       });
     } else {
       // otherwise, just set the model
-      props.handleModelChange({ ...newModel, [target.name]: target.value });
+      props.handleModelChange({ ...props.model, [target.name]: target.value });
     }
   };
 
@@ -177,8 +171,6 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     if (outputFormatsList === null) {
       return; // No data about output formats; give up
     }
-
-    const newModel = { ...props.model, createError: undefined };
 
     const formatName = event.target.value;
     const isChecked = event.target.checked;
@@ -195,7 +187,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       const newFormat = outputFormatsList.find(of => of.name === formatName);
       if (newFormat) {
         props.handleModelChange({
-          ...newModel,
+          ...props.model,
           outputFormats: [...oldOutputFormats, newFormat.name]
         });
       }
@@ -203,7 +195,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     // Go from checked to unchecked
     else if (!isChecked && wasChecked) {
       props.handleModelChange({
-        ...newModel,
+        ...props.model,
         outputFormats: oldOutputFormats.filter(of => of !== formatName)
       });
     }
@@ -285,8 +277,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       schedule: schedule,
       scheduleTimeInput: value,
       scheduleHour: hours,
-      scheduleMinute: minutes,
-      createError: undefined
+      scheduleMinute: minutes
     });
   };
 
@@ -334,8 +325,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       ...props.model,
       schedule: schedule,
       scheduleMinuteInput: value,
-      scheduleHourMinute: minutes,
-      createError: undefined
+      scheduleHourMinute: minutes
     });
   };
 
@@ -388,8 +378,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       ...props.model,
       schedule: schedule,
       scheduleMonthDayInput: value,
-      scheduleMonthDay: monthDay,
-      createError: undefined
+      scheduleMonthDay: monthDay
     });
   };
 
@@ -406,8 +395,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     props.handleModelChange({
       ...props.model,
       schedule: schedule,
-      scheduleWeekDay: value,
-      createError: undefined
+      scheduleWeekDay: value
     });
   };
 
@@ -504,8 +492,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       ...props.model,
       schedule: schedule,
       scheduleInterval: event.target.value,
-      scheduleWeekDay: dayOfWeek,
-      createError: undefined
+      scheduleWeekDay: dayOfWeek
     });
   };
 
@@ -532,11 +519,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       }
     }
 
-    props.handleModelChange({
-      ...props.model,
-      createError: undefined,
-      [name]: value
-    });
+    props.handleModelChange({ ...props.model, [name]: value });
   };
 
   const submitForm = async (event: React.MouseEvent) => {
@@ -677,11 +660,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         errors[`parameter-${paramIdx}-name`];
     }
 
-    props.handleModelChange({
-      ...props.model,
-      createError: undefined,
-      parameters: newParams
-    });
+    props.handleModelChange({ ...props.model, parameters: newParams });
     setErrors(newErrors);
   };
 
@@ -689,11 +668,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     const newParams = props.model.parameters || [];
     newParams.push({ name: '', value: '' });
 
-    props.handleModelChange({
-      ...props.model,
-      createError: undefined,
-      parameters: newParams
-    });
+    props.handleModelChange({ ...props.model, parameters: newParams });
   };
 
   const formPrefix = 'jp-create-job-';

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -17,6 +17,7 @@ import { Scheduler as SchedulerTokens } from '../tokens';
 
 import ErrorIcon from '@mui/icons-material/Error';
 
+import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import Box from '@mui/system/Box';
 import Stack from '@mui/system/Stack';
@@ -576,10 +577,15 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       jobOptions.parameters = serializeParameters(props.model.parameters);
     }
 
-    api.createJob(jobOptions).then(response => {
-      // Switch to the list view with "Job List" active
-      props.showListView('Job');
-    });
+    api
+      .createJob(jobOptions)
+      .then(response => {
+        // Switch to the list view with "Job List" active
+        props.showListView('Job');
+      })
+      .catch((error: string) => {
+        props.handleModelChange({ ...props.model, createError: error });
+      });
   };
 
   const submitCreateJobDefinitionRequest = async (event: React.MouseEvent) => {
@@ -656,12 +662,14 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   const formPrefix = 'jp-create-job-';
 
   const cantSubmit = trans.__('One or more of the fields has an error.');
+  const createError: string | undefined = props.model.createError;
 
   return (
     <Box sx={{ p: 4 }}>
       <form className={`${formPrefix}form`} onSubmit={e => e.preventDefault()}>
         <Stack spacing={4}>
           <Heading level={1}>Create Job</Heading>
+          {createError && <Alert severity="error">{createError}</Alert>}
           <TextField
             label={trans.__('Job name')}
             variant="outlined"

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -700,7 +700,6 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
   const cantSubmit = trans.__('One or more of the fields has an error.');
   const createError: string | undefined = props.model.createError;
-  console.log('createError is ' + createError);
 
   return (
     <Box sx={{ p: 4 }}>

--- a/src/model.ts
+++ b/src/model.ts
@@ -27,6 +27,8 @@ export interface ICreateJobModel extends PartialJSONObject {
   environment: string;
   // A "job" runs now; a "job definition" runs on a schedule
   createType: 'Job' | 'JobDefinition';
+  // Errors from creation
+  createError?: string;
   runtimeEnvironmentParameters?: { [key: string]: number | string | boolean };
   parameters?: IJobParameter[];
   // List of values for output formats; labels are specified by the environment


### PR DESCRIPTION
Partial fix for #147. If the `createJob` or `createJobDefinition` request results in a rejection for some reason, the user remains on the create form and an error alert is displayed on top.

After the user attempts to resubmit the form or modify one of the inputs, the error alert is cleared.

Also runs prettier on all files in repo.

Behavior when the `createJob` handler is overridden to return an error all the time:


https://user-images.githubusercontent.com/93281816/195953166-cf84ad98-05cc-4fd8-8aac-a1c21f8bb20a.mov

