### PR TITLE
Add confirmation when deleting a job or job definition in List view

### DIFF
--- a/src/components/confirm-delete-button.tsx
+++ b/src/components/confirm-delete-button.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material';
 import { useTranslator } from '../hooks';
 
-export const DeleteWithConfirmationButton = (props: {
+export const ConfirmDeleteButton = (props: {
   handleDelete: () => Promise<void>;
   title: string;
   text?: string;

--- a/src/components/confirm-delete-icon.tsx
+++ b/src/components/confirm-delete-icon.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { useTranslator } from '../hooks';
 import CloseIcon from '@mui/icons-material/Close';
 
-export function DeleteWithConfirmationIcon(props: {
+export function ConfirmDeleteIcon(props: {
   name: string | undefined;
   clickHandler: () => void;
 }): JSX.Element | null {

--- a/src/components/delete-with-confirmation-icon.tsx
+++ b/src/components/delete-with-confirmation-icon.tsx
@@ -16,7 +16,7 @@ export function DeleteWithConfirmationIcon(props: {
     : trans.__('Delete job');
 
   return (
-    <Box sx={{ width: '5em' }}>
+    <Box sx={{ width: '6em' }}>
       {clicked ? (
         <Button
           variant="contained"

--- a/src/components/delete-with-confirmation-icon.tsx
+++ b/src/components/delete-with-confirmation-icon.tsx
@@ -1,0 +1,39 @@
+import { Box, Button, IconButton } from '@mui/material';
+import React, { useState } from 'react';
+import { useTranslator } from '../hooks';
+import CloseIcon from '@mui/icons-material/Close';
+
+export function DeleteWithConfirmationIcon(props: {
+  name: string | undefined;
+  clickHandler: () => void;
+}): JSX.Element | null {
+  const [clicked, setClicked] = useState(false);
+
+  const trans = useTranslator('jupyterlab');
+
+  const buttonTitle = props.name
+    ? trans.__('Delete "%1"', props.name)
+    : trans.__('Delete job');
+
+  return (
+    <Box sx={{ width: '5em' }}>
+      {clicked ? (
+        <Button
+          variant="contained"
+          color="error"
+          title={buttonTitle}
+          onClick={props.clickHandler}
+          onBlur={_ => setClicked(false)}
+          style={{ visibility: clicked ? 'visible' : 'hidden' }}
+          autoFocus
+        >
+          {trans.__('Delete')}
+        </Button>
+      ) : (
+        <IconButton title={buttonTitle} onClick={_ => setClicked(true)}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      )}
+    </Box>
+  );
+}

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -129,9 +129,11 @@ export function buildJobDefinitionRow(
   ];
 
   return (
-    <TableRow>
+    <TableRow key={jobDef.job_definition_id}>
       {cellContents.map((cellContent, idx) => (
-        <TableCell key={idx}>{cellContent}</TableCell>
+        <TableCell key={`${jobDef.job_definition_id}-${idx}`}>
+          {cellContent}
+        </TableCell>
       ))}
     </TableRow>
   );

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -15,7 +15,7 @@ import TableCell from '@mui/material/TableCell';
 import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
 import { TranslationBundle } from '@jupyterlab/translation';
-import { DeleteWithConfirmationIcon } from './delete-with-confirmation-icon';
+import { ConfirmDeleteIcon } from './confirm-delete-icon';
 
 function CreatedAt(props: {
   job: Scheduler.IDescribeJobDefinition;
@@ -117,7 +117,7 @@ export function buildJobDefinitionRow(
           forceReload();
         }}
       />
-      <DeleteWithConfirmationIcon
+      <ConfirmDeleteIcon
         name={jobDef.name}
         clickHandler={async () => {
           await ss.deleteJobDefinition(jobDef.job_definition_id);

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -5,7 +5,6 @@ import cronstrue from 'cronstrue';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { PathExt } from '@jupyterlab/coreutils';
 
-import CloseIcon from '@mui/icons-material/Close';
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import { IconButton } from '@mui/material';
@@ -16,6 +15,7 @@ import TableCell from '@mui/material/TableCell';
 import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
 import { TranslationBundle } from '@jupyterlab/translation';
+import { DeleteWithConfirmationIcon } from './delete-with-confirmation-icon';
 
 function CreatedAt(props: {
   job: Scheduler.IDescribeJobDefinition;
@@ -82,23 +82,6 @@ function ResumeButton(props: {
   );
 }
 
-function DeleteButton(props: {
-  jobDef: Scheduler.IDescribeJobDefinition;
-  clickHandler: () => void;
-}): JSX.Element | null {
-  const trans = useTranslator('jupyterlab');
-
-  const buttonTitle = props.jobDef.name
-    ? trans.__('Delete "%1"', props.jobDef.name)
-    : trans.__('Delete job definition');
-
-  return (
-    <IconButton onClick={props.clickHandler} title={buttonTitle}>
-      <CloseIcon fontSize="small" />
-    </IconButton>
-  );
-}
-
 export function buildJobDefinitionRow(
   jobDef: Scheduler.IDescribeJobDefinition,
   app: JupyterFrontEnd,
@@ -134,8 +117,8 @@ export function buildJobDefinitionRow(
           forceReload();
         }}
       />
-      <DeleteButton
-        jobDef={jobDef}
+      <DeleteWithConfirmationIcon
+        name={jobDef.name}
         clickHandler={async () => {
           await ss.deleteJobDefinition(jobDef.job_definition_id);
 

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -15,7 +15,7 @@ import { Scheduler } from '../handler';
 import { useTranslator } from '../hooks';
 import { IJobParameter, ICreateJobModel } from '../model';
 import { CommandIDs } from '..';
-import { DeleteWithConfirmationIcon } from './delete-with-confirmation-icon';
+import { ConfirmDeleteIcon } from './confirm-delete-icon';
 
 function get_file_from_path(path: string): string {
   return PathExt.basename(path);
@@ -180,7 +180,7 @@ export function buildJobRow(
         environmentList={environmentList}
         showCreateJob={showCreateJob}
       />
-      <DeleteWithConfirmationIcon
+      <ConfirmDeleteIcon
         name={job.name}
         clickHandler={() => {
           // optimistic delete for now, no verification on whether the delete

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { PathExt } from '@jupyterlab/coreutils';
 
-import CloseIcon from '@mui/icons-material/Close';
 import StopIcon from '@mui/icons-material/Stop';
 import ReplayIcon from '@mui/icons-material/Replay';
 
@@ -12,12 +11,11 @@ import Stack from '@mui/material/Stack';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import { outputFormatsForEnvironment } from './output-format-picker';
-import { Box, Button } from '@mui/material';
-
 import { Scheduler } from '../handler';
 import { useTranslator } from '../hooks';
 import { IJobParameter, ICreateJobModel } from '../model';
 import { CommandIDs } from '..';
+import { DeleteWithConfirmationIcon } from './delete-with-confirmation-icon';
 
 function get_file_from_path(path: string): string {
   return PathExt.basename(path);
@@ -40,41 +38,6 @@ function StopButton(props: {
         <StopIcon fontSize="small" />
       </IconButton>
     </div>
-  );
-}
-
-export function DeleteButton(props: {
-  job: Scheduler.IDescribeJob;
-  clickHandler: () => void;
-}): JSX.Element | null {
-  const [clicked, setClicked] = useState(false);
-
-  const trans = useTranslator('jupyterlab');
-
-  const buttonTitle = props.job.name
-    ? trans.__('Delete "%1"', props.job.name)
-    : trans.__('Delete job');
-
-  return (
-    <Box sx={{ width: '5em' }}>
-      {clicked ? (
-        <Button
-          variant="contained"
-          color="error"
-          title={buttonTitle}
-          onClick={props.clickHandler}
-          onBlur={_ => setClicked(false)}
-          style={{ visibility: clicked ? 'visible' : 'hidden' }}
-          autoFocus
-        >
-          {'Delete'}
-        </Button>
-      ) : (
-        <IconButton title={buttonTitle} onClick={_ => setClicked(true)}>
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      )}
-    </Box>
   );
 }
 
@@ -217,8 +180,8 @@ export function buildJobRow(
         environmentList={environmentList}
         showCreateJob={showCreateJob}
       />
-      <DeleteButton
-        job={job}
+      <DeleteWithConfirmationIcon
+        name={job.name}
         clickHandler={() => {
           // optimistic delete for now, no verification on whether the delete
           // succeeded

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { PathExt } from '@jupyterlab/coreutils';
@@ -11,13 +11,13 @@ import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
+import { outputFormatsForEnvironment } from './output-format-picker';
+import { Box, Button } from '@mui/material';
 
 import { Scheduler } from '../handler';
 import { useTranslator } from '../hooks';
 import { IJobParameter, ICreateJobModel } from '../model';
 import { CommandIDs } from '..';
-
-import { outputFormatsForEnvironment } from './output-format-picker';
 
 function get_file_from_path(path: string): string {
   return PathExt.basename(path);
@@ -43,19 +43,38 @@ function StopButton(props: {
   );
 }
 
-function DeleteButton(props: {
+export function DeleteButton(props: {
   job: Scheduler.IDescribeJob;
   clickHandler: () => void;
 }): JSX.Element | null {
+  const [clicked, setClicked] = useState(false);
+
   const trans = useTranslator('jupyterlab');
+
   const buttonTitle = props.job.name
     ? trans.__('Delete "%1"', props.job.name)
     : trans.__('Delete job');
 
   return (
-    <IconButton onClick={props.clickHandler} title={buttonTitle}>
-      <CloseIcon fontSize="small" />
-    </IconButton>
+    <Box sx={{ width: '5em' }}>
+      {clicked ? (
+        <Button
+          variant="contained"
+          color="error"
+          title={buttonTitle}
+          onClick={props.clickHandler}
+          onBlur={_ => setClicked(false)}
+          style={{ visibility: clicked ? 'visible' : 'hidden' }}
+          autoFocus
+        >
+          {'Delete'}
+        </Button>
+      ) : (
+        <IconButton title={buttonTitle} onClick={_ => setClicked(true)}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      )}
+    </Box>
   );
 }
 
@@ -193,6 +212,11 @@ export function buildJobRow(
           })
         }
       />
+      <RefillButton
+        job={job}
+        environmentList={environmentList}
+        showCreateJob={showCreateJob}
+      />
       <DeleteButton
         job={job}
         clickHandler={() => {
@@ -203,11 +227,6 @@ export function buildJobRow(
           });
           deleteRow(job.job_id);
         }}
-      />
-      <RefillButton
-        job={job}
-        environmentList={environmentList}
-        showCreateJob={showCreateJob}
       />
     </Stack>
   ];

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -195,9 +195,9 @@ export function buildJobRow(
   ];
 
   return (
-    <TableRow>
+    <TableRow key={job.job_id}>
       {cellContents.map((cellContent, idx) => (
-        <TableCell key={idx}>{cellContent}</TableCell>
+        <TableCell key={`${job.job_id}-${idx}`}>{cellContent}</TableCell>
       ))}
     </TableRow>
   );

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -18,7 +18,7 @@ import {
   Stack,
   TextFieldProps
 } from '@mui/material';
-import { DeleteWithConfirmationButton } from '../../components/delete-with-confirmation-button';
+import { ConfirmDeleteButton } from '../../components/confirm-delete-button';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 
 export interface IJobDefinitionProps {
@@ -72,7 +72,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
           {trans.__('Resume')}
         </Button>
       )}
-      <DeleteWithConfirmationButton
+      <ConfirmDeleteButton
         handleDelete={handleDeleteJobDefinition}
         title={trans.__('Delete Job Definition')}
         text={trans.__(

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -10,7 +10,7 @@ import {
 import { useTranslator } from '../../hooks';
 import { SchedulerService } from '../../handler';
 import { Scheduler as SchedulerTokens } from '../../tokens';
-import { DeleteWithConfirmationButton } from '../../components/delete-with-confirmation-button';
+import { ConfirmDeleteButton } from '../../components/confirm-delete-button';
 
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
@@ -102,7 +102,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       <Button variant="outlined" onClick={handleRerunJob}>
         {trans.__('Rerun Job')}
       </Button>
-      <DeleteWithConfirmationButton
+      <ConfirmDeleteButton
         handleDelete={handleDeleteJob}
         title={trans.__('Delete Job')}
         text={trans.__('Are you sure that you want to delete this job?')}


### PR DESCRIPTION
## Description

- Adds `DeleteWithConfirmationIcon`, a delete icon that is replaced with delete button on click; delete button turns back into delete icon `onBlur` / when it looses focus
- Replaces `DeleteButton` in `job-row` and `job-definition-row` with single `DeleteWithConfirmationIcon` element
- Fixes #142 

## Expected behavior
"single button that is two-stage delete. The first click on the "X" would turn that button into a more prominent (and red) delete button, which when clicked would actually delete the job. iOS does this in places and it is a bit more lightweight than a full dialog, which would get cumbersome for in situations where you are deleting jobs often, but not using (the yet to be built) multi-selection batch actions." -https://github.com/jupyter-server/jupyter-scheduler/issues/107#issuecomment-1273905744

## Latest preview
![fixed_delete_icon](https://user-images.githubusercontent.com/26686070/196236645-ae7d4141-7bff-4a1e-9c40-0914f624847d.gif)

