### PR TITLE
Basic layout restoration

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@jupyterlab/ui-components": "^3.4.2",
     "@lumino/polling": "^1.9.0",
     "@lumino/signaling": "^1.10.0",
+    "@lumino/coreutils": "^1.12.0",
     "@lumino/widgets": "^1.32.0",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.6",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,6 @@ import { RunningJobsIndicator } from './components/running-jobs-indicator';
 
 import { SchedulerService } from './handler';
 import {
-  ICreateJobModel,
   NotebookJobsListingModel,
   IJobsModel,
   emptyCreateJobModel

--- a/src/model.ts
+++ b/src/model.ts
@@ -181,10 +181,14 @@ export class JobsModel extends VDomModel {
   }
 
   fromJson(data: IJobsModel): void {
-    this.jobsView = data.jobsView ?? 'ListJobs';
-    this.createJobModel = data.createJobModel ?? emptyCreateJobModel();
-    this.listJobsModel = data.listJobsModel ?? emptyListJobsModel();
-    this.jobDetailModel = data.jobDetailModel ?? emptyDetailViewModel();
+    this._jobsView = data.jobsView ?? 'ListJobs';
+    this._createJobModel = data.createJobModel ?? emptyCreateJobModel();
+    this._listJobsModel = data.listJobsModel ?? emptyListJobsModel();
+    this._jobDetailModel = data.jobDetailModel ?? emptyDetailViewModel();
+
+    // emit state changed signal
+    this._onModelUpdate?.();
+    this.stateChanged.emit(void 0);
   }
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -181,7 +181,7 @@ export class JobsModel extends VDomModel {
   }
 
   fromJson(data: IJobsModel): void {
-    this.jobsView = data.jobsView ?? 'List';
+    this.jobsView = data.jobsView ?? 'ListJobs';
     this.createJobModel = data.createJobModel ?? emptyCreateJobModel();
     this.listJobsModel = data.listJobsModel ?? emptyListJobsModel();
     this.jobDetailModel = data.jobDetailModel ?? emptyDetailViewModel();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2319,7 +2319,7 @@
     "@lumino/signaling" "^1.10.2"
     "@lumino/virtualdom" "^1.14.2"
 
-"@lumino/coreutils@^1.11.0", "@lumino/coreutils@^1.12.1":
+"@lumino/coreutils@^1.11.0", "@lumino/coreutils@^1.12.0", "@lumino/coreutils@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@lumino/coreutils/-/coreutils-1.12.1.tgz#79860c9937483ddf6cda87f6c2b9da8eb1a5d768"
   integrity sha512-JLu3nTHzJk9N8ohZ85u75YxemMrmDzJdNgZztfP7F7T7mxND3YVNCkJG35a6aJ7edu1sIgCjBxOvV+hv27iYvQ==


### PR DESCRIPTION
This PR hooks up everything for the JupyterLab layout restoration to save/restore the state of the notebook jobs panel when the application is reloaded. This will serialize the top-level JobsModel to JSON, so should work for all view state.

Fixes #121.