### PR TITLE
Expose Advanced Options in Job Definition Detail 

### DIFF
--- a/src/mainviews/detail-view/detail-view.tsx
+++ b/src/mainviews/detail-view/detail-view.tsx
@@ -141,7 +141,6 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
               setListJobsView={props.setListJobsView}
               // Extension point: optional additional component
               advancedOptions={props.advancedOptions}
-              outputFormatsStrings={outputFormatStrings ?? []}
             />
           )}
           {props.model.detailType === 'JobDefinition' && jobDefinitionModel && (

--- a/src/mainviews/detail-view/detail-view.tsx
+++ b/src/mainviews/detail-view/detail-view.tsx
@@ -148,6 +148,8 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
               refresh={fetchJobDefinitionModel}
               showCreateJob={props.showCreateJob}
               showJobDetail={props.showJobDetail}
+              // Extension point: optional additional component
+              advancedOptions={props.advancedOptions}
             />
           )}
           {!jobModel && !jobDefinitionModel && (

--- a/src/mainviews/detail-view/detail-view.tsx
+++ b/src/mainviews/detail-view/detail-view.tsx
@@ -57,9 +57,6 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
   const [jobModel, setJobsModel] = useState<IJobDetailModel | null>(null);
   const [jobDefinitionModel, setJobDefinitionModel] =
     useState<IJobDefinitionModel | null>(null);
-  const [outputFormatStrings, setOutputFormatStrings] = useState<
-    string[] | null
-  >(null);
 
   const trans = useTranslator('jupyterlab');
 
@@ -67,7 +64,6 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
 
   const fetchJobDetailModel = async () => {
     const jobFromService = await ss.getJob(props.model.id);
-    setOutputFormatStrings(jobFromService.output_formats ?? []);
     const jobDetailModel = convertDescribeJobtoJobDetail(jobFromService);
     setJobsModel(jobDetailModel);
   };

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -10,11 +10,13 @@ import { TextFieldStyled, timestampLocalize } from './job-detail';
 import { SchedulerService } from '../../handler';
 import cronstrue from 'cronstrue';
 import { ListJobsTable } from '../list-jobs';
+import { Scheduler as SchedulerTokens } from '../../tokens';
 
 import {
   Button,
   Card,
   CardContent,
+  FormLabel,
   Stack,
   TextFieldProps
 } from '@mui/material';
@@ -29,6 +31,7 @@ export interface IJobDefinitionProps {
   setListJobsView: (view: ListJobsView) => void;
   showJobDetail: (jobId: string) => void;
   showCreateJob: (state: ICreateJobModel) => void;
+  advancedOptions: React.FunctionComponent<SchedulerTokens.IAdvancedOptionsProps>;
 }
 
 export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
@@ -148,6 +151,29 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
     </Card>
   );
 
+  const AdvancedOptions = (
+    <Card>
+      <CardContent>
+        <Stack component="form" spacing={4}>
+          <FormLabel component="legend">
+            {trans.__('Advanced Options')}
+          </FormLabel>
+          <props.advancedOptions
+            jobsView={'JobDetail'}
+            model={props.model}
+            handleModelChange={(_: any) => {
+              return;
+            }}
+            errors={{}}
+            handleErrorsChange={(_: any) => {
+              return;
+            }}
+          />
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+
   const JobsList = (
     <Card>
       <CardContent>
@@ -169,6 +195,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
       {DefinitionButtonBar}
       {JobDefinition}
       {JobsList}
+      {AdvancedOptions}
     </>
   );
 }

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -287,11 +287,11 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
           <props.advancedOptions
             jobsView={'JobDetail'}
             model={props.model}
-            handleModelChange={model => {
+            handleModelChange={(_: any) => {
               return;
             }}
             errors={{}}
-            handleErrorsChange={errors => {
+            handleErrorsChange={(_: any) => {
               return;
             }}
           />

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -42,7 +42,6 @@ export interface IJobDetailProps {
   setListJobsView: (view: ListJobsView) => void;
   // Extension point: optional additional component
   advancedOptions: React.FunctionComponent<SchedulerTokens.IAdvancedOptionsProps>;
-  outputFormatsStrings?: string[];
 }
 
 export const timestampLocalize = (time: number | ''): string => {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,5 +1,10 @@
 import { Token } from '@lumino/coreutils';
-import { ICreateJobModel, IJobDetailModel, JobsView } from './model';
+import {
+  ICreateJobModel,
+  IJobDefinitionModel,
+  IJobDetailModel,
+  JobsView
+} from './model';
 
 export namespace Scheduler {
   export type EnvironmentParameterValue = string | number | boolean;
@@ -8,7 +13,7 @@ export namespace Scheduler {
 
   export interface IAdvancedOptionsProps {
     jobsView: JobsView;
-    model: ICreateJobModel | IJobDetailModel;
+    model: ICreateJobModel | IJobDetailModel | IJobDefinitionModel;
     handleModelChange: (model: ICreateJobModel) => void;
     errors: ErrorsType;
     handleErrorsChange: (errors: ErrorsType) => void;


### PR DESCRIPTION
Fixes #160 

## Description

This PR exposes and renders `AdvancedOptions` in `JobDefinitionDetail`. To achieve that, `AdditionalOptions` now also optionally accept `IJobDefinitionModel` in addition to `ICreateJobModel | IJobDetailModel` as a `model`. To minimize changes to how `AdvancedOptions` already work in `Job Detail`, I added 'AdvancedOptions' to `JobDefinitionDetail` vs pulling it up into `JobDetailView`

## Issue Description
Currently Advanced Options are only shown at the bottom of Job Detail page. At the same time, as mentioned by @3coins, fields provided to Advanced Options might be / are meaningful for Job Definition Detail page too, especially if Job Definition can be edited as user might need to edit Advanced Options for Job Definition too

## Expected behavior
Needs confirmation: Advanced Options are available and shown in Job Definition Detail

## Preview
![jpb_def_adv_options_below_list](https://user-images.githubusercontent.com/26686070/196567502-e57f37a2-55ae-49b2-8d48-767c92f6b30e.gif)

