### PR TITLE
Fixed bug with resuming/pausing scheduled jobs

### DIFF
--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -145,14 +145,6 @@ class BaseScheduler(LoggingConfigurable):
         """Returns list of all job definitions filtered by query"""
         raise NotImplementedError("must be implemented by subclass")
 
-    def pause_jobs(self, job_definition_id: str):
-        """Pauses all future jobs for a job definition"""
-        raise NotImplementedError("must be implemented by subclass")
-
-    def resume_jobs(self, job_definition_id: str):
-        """Resumes future jobs for a job definition"""
-        raise NotImplementedError("must be implemented by subclass")
-
     def get_staging_paths(self, job_id: str) -> Dict[str, str]:
         """Returns full staging paths for all job outputs"""
         raise NotImplementedError("must be implemented by subclass")
@@ -476,38 +468,6 @@ class Scheduler(BaseScheduler):
         )
 
         return list_response
-
-    def pause_jobs(self, job_definition_id: str):
-        schedule = None
-        with self.db_session() as session:
-            job_definition = (
-                session.query(JobDefinition)
-                .filter(JobDefinition.job_definition_id == job_definition_id)
-                .one()
-            )
-            job_definition.active = False
-            session.commit()
-
-            schedule = job_definition.schedule
-
-        if self.task_runner and schedule:
-            self.task_runner.pause_jobs(job_definition_id)
-
-    def resume_jobs(self, job_definition_id: str):
-        schedule = None
-        with self.db_session() as session:
-            job_definition = (
-                session.query(JobDefinition)
-                .filter(JobDefinition.job_definition_id == job_definition_id)
-                .one()
-            )
-            job_definition.active = True
-            session.commit()
-
-            schedule = job_definition.schedule
-
-        if self.task_runner and schedule:
-            self.task_runner.resume_jobs(job_definition_id)
 
     def get_staging_paths(self, job_id: str) -> Dict[str, str]:
         model = self.get_job(job_id)

--- a/jupyter_scheduler/tests/test_scheduler.py
+++ b/jupyter_scheduler/tests/test_scheduler.py
@@ -134,7 +134,8 @@ def test_get_job_definition(jp_scheduler, load_job_definitions):
 
 def test_pause_jobs(jp_scheduler, load_job_definitions, jp_scheduler_db):
     job_definition_id = job_definition_2["job_definition_id"]
-    jp_scheduler.pause_jobs(job_definition_id)
+    with patch("jupyter_scheduler.scheduler.Scheduler.task_runner") as mock_task_runner:
+        jp_scheduler.update_job_definition(job_definition_id, UpdateJobDefinition(active=False))
 
     with jp_scheduler_db() as session:
         active = (
@@ -149,7 +150,7 @@ def test_pause_jobs(jp_scheduler, load_job_definitions, jp_scheduler_db):
 def test_resume_jobs(jp_scheduler, load_job_definitions, jp_scheduler_db):
     job_definition_id = job_definition_3["job_definition_id"]
     with patch("jupyter_scheduler.scheduler.Scheduler.task_runner") as mock_task_runner:
-        jp_scheduler.resume_jobs(job_definition_id)
+        jp_scheduler.update_job_definition(job_definition_id, UpdateJobDefinition(active=True))
 
     with jp_scheduler_db() as session:
         active = (


### PR DESCRIPTION
1. Removed pause/resume methods for job definition apis. These were found redundant to `update_job_definition` api.
2. Fixed logic for task runner when a job_definition was resumed, this was causing scheduled jobs not to start in certain scenarios.