### PR TITLE
Fix for create job UI when error is returned from backend

### DIFF
--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -595,8 +595,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         // Switch to the list view with "Job List" active
         props.showListView('Job');
       })
-      .catch((error: string) => {
-        props.handleModelChange({ ...props.model, createError: error });
+      .catch((error: Error) => {
+        props.handleModelChange({ ...props.model, createError: error.message });
       });
   };
 


### PR DESCRIPTION
Current create job UI is unstable if an error is returned from backend after form submit. The cause of this error was incorrect type in the error handler code. This PR fixes this code, so that correct error message is passed on to the model for rendering.