### PR TITLE
Update release doc

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -6,12 +6,14 @@ on:
   pull_request:
     branches:
       - main
+    types: [closed]
 
 permissions:
   contents: write
 
 jobs:
   check_release:
+    if: ${{ github.event.pull_request.merged }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
           architecture: 'x64'
       - name: Install node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '16.x'
 
 
       - name: Get pip cache dir

--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,0 +1,13 @@
+name: Enforce PR label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: enforce-triage-label
+        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,20 @@
 
 The extension can be published to `PyPI` and `npm` manually or using the [Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser).
 
+## Automated releases with the Jupyter Releaser
+
+The extension repository should already be compatible with the Jupyter Releaser.
+
+Check out the [workflow documentation](https://github.com/jupyter-server/jupyter_releaser#typical-workflow) for more information.
+
+Here is a summary of the steps to cut a new release:
+
+- Fork the [`jupyter-releaser` repo](https://github.com/jupyter-server/jupyter_releaser)
+- Add `ADMIN_GITHUB_TOKEN`, `PYPI_TOKEN` and `NPM_TOKEN` to the Github Secrets in the fork
+- Go to the Actions panel
+- Run the "Step 1: Prep Release" workflow, this will create a draft release in github for review
+- Run the "Step 2: Publish Release" workflow
+
 ## Manual release
 
 ### Python package
@@ -15,10 +29,37 @@ Python package. Before generating a package, we first need to install `build`.
 pip install build twine tbump
 ```
 
+Make sure you have checked out the `main` branch updated from remote.
+
+```bash
+git checkout main
+git remote update
+git pull upstream main
+```
+
 Bump the version using `tbump`. By default this will create a tag.
 
 ```bash
-tbump <new-version>
+tbump --no-push <new-version>
+```
+
+Push the bump version commit and tag to main upstream branch.
+
+```bash
+git push upstream main
+git push upstream <new-version-tag>
+```
+
+Checkout the new tagged commit.
+
+```bash
+git checkout <new-version-tag>
+```
+
+Build the extension
+
+```bash
+jlpm run build:prod
 ```
 
 To create a Python source package (`.tar.gz`) and the binary package (`.whl`) in the `dist/` directory, do:
@@ -43,22 +84,6 @@ To publish the frontend part of the extension as a NPM package, do:
 npm login
 npm publish --access public
 ```
-
-## Automated releases with the Jupyter Releaser
-
-The extension repository should already be compatible with the Jupyter Releaser.
-
-Check out the [workflow documentation](https://github.com/jupyter-server/jupyter_releaser#typical-workflow) for more information.
-
-Here is a summary of the steps to cut a new release:
-
-- Fork the [`jupyter-releaser` repo](https://github.com/jupyter-server/jupyter_releaser)
-- Add `ADMIN_GITHUB_TOKEN`, `PYPI_TOKEN` and `NPM_TOKEN` to the Github Secrets in the fork
-- Go to the Actions panel
-- Run the "Draft Changelog" workflow
-- Merge the Changelog PR
-- Run the "Draft Release" workflow
-- Run the "Publish Release" workflow
 
 ## Publishing to `conda-forge`
 


### PR DESCRIPTION
1. Updated instructions for automated and manual release workflows.
2. Added a new CI workflow that will flag PRs with no labels, this is useful to categorize issues in changelog.
3. Updated check-release workflow to run only on `main` branch after merge. This will help speed up the PR review/merge as check-release takes ~30 mins during some runs.