### PR TITLE
Async support, configurable staging path, tar file support

### DIFF
--- a/jupyter_scheduler/executors.py
+++ b/jupyter_scheduler/executors.py
@@ -157,7 +157,7 @@ class DefaultExecutionManager(ExecutionManager):
         }
 
 
-class ArchiveExportingExecutionManager(DefaultExecutionManager):
+class ArchivingExecutionManager(DefaultExecutionManager):
     """Execution manager that archives the output
     files to a compressed tar file.
 

--- a/jupyter_scheduler/executors.py
+++ b/jupyter_scheduler/executors.py
@@ -1,4 +1,6 @@
+import io
 import os
+import tarfile
 import traceback
 from abc import ABC, abstractmethod
 from typing import Dict
@@ -6,7 +8,7 @@ from typing import Dict
 import fsspec
 import nbconvert
 import nbformat
-from nbconvert.preprocessors import ExecutePreprocessor
+from nbconvert.preprocessors import CellExecutionError, ExecutePreprocessor
 
 from jupyter_scheduler.models import DescribeJob, JobFeature, Status
 from jupyter_scheduler.orm import Job, create_session
@@ -126,13 +128,16 @@ class DefaultExecutionManager(ExecutionManager):
             store_widget_state=True,
         )
 
-        ep.preprocess(nb)
-
-        for output_format in job.output_formats:
-            cls = nbconvert.get_exporter(output_format)
-            output, resources = cls().from_notebook_node(nb)
-            with fsspec.open(self.staging_paths[output_format], "w", encoding="utf-8") as f:
-                f.write(output)
+        try:
+            ep.preprocess(nb)
+        except CellExecutionError as e:
+            pass
+        finally:
+            for output_format in job.output_formats:
+                cls = nbconvert.get_exporter(output_format)
+                output, resources = cls().from_notebook_node(nb)
+                with fsspec.open(self.staging_paths[output_format], "w", encoding="utf-8") as f:
+                    f.write(output)
 
     def supported_features(cls) -> Dict[JobFeature, bool]:
         return {
@@ -150,3 +155,48 @@ class DefaultExecutionManager(ExecutionManager):
             JobFeature.stop_job: True,
             JobFeature.delete_job: True,
         }
+
+
+class ArchiveExportingExecutionManager(DefaultExecutionManager):
+    """Execution manager that archives the output
+    files to a compressed tar file.
+
+    Notes
+    -----
+    Should be used along with :class:`~jupyter_scheduler.scheduler.ArchiveDownloadingScheduler`
+    as the `scheduler_class` during jupyter server start.
+    """
+
+    def execute(self):
+        job = self.model
+
+        with open(resolve_path(job.input_uri, self.root_dir)) as f:
+            nb = nbformat.read(f, as_version=4)
+
+        if job.parameters:
+            nb = add_parameters(nb, job.parameters)
+
+        ep = ExecutePreprocessor(
+            kernel_name=nb.metadata.kernelspec["name"],
+            store_widget_state=True,
+        )
+
+        try:
+            ep.preprocess(nb)
+        except CellExecutionError as e:
+            pass
+        finally:
+            fh = io.BytesIO()
+            with tarfile.open(fileobj=fh, mode="w:gz") as tar:
+                for output_format in job.output_formats:
+                    cls = nbconvert.get_exporter(output_format)
+                    output, resources = cls().from_notebook_node(nb)
+                    data = bytes(output, "utf-8")
+                    source_f = io.BytesIO(initial_bytes=data)
+                    info = tarfile.TarInfo(self.staging_paths[output_format])
+                    info.size = len(data)
+                    tar.addfile(info, source_f)
+
+            archive_filepath = self.staging_paths["tar.gz"]
+            with fsspec.open(archive_filepath, "wb") as f:
+                f.write(fh.getvalue())

--- a/jupyter_scheduler/handlers.py
+++ b/jupyter_scheduler/handlers.py
@@ -272,7 +272,7 @@ class OutputsDownloadHandler(ExtensionHandlerMixin, APIHandler):
     @tornado.web.authenticated
     async def get(self, job_id):
         redownload = self.get_query_argument("redownload", False)
-        self.output_files_manager.copy_from_staging(job_id=job_id, redownload=redownload)
+        await self.output_files_manager.copy_from_staging(job_id=job_id, redownload=redownload)
 
         self.set_status(204)
         self.finish()

--- a/jupyter_scheduler/output_files_manager.py
+++ b/jupyter_scheduler/output_files_manager.py
@@ -64,7 +64,6 @@ class Downloader:
             if not os.path.exists(output_filepath) or self.redownload:
                 yield input_filepath, output_filepath
 
-
     def download_tar(self, archive_format: str = "tar"):
         archive_filepath = self.staging_paths[archive_format]
         read_mode = "r:gz" if archive_format == "tar.gz" else "tar"
@@ -73,9 +72,8 @@ class Downloader:
                 filepaths = self.generate_filepaths()
                 for input_filepath, output_filepath in filepaths:
                     input_file = tar.extractfile(member=input_filepath)
-                    with fsspec.open(output_filepath, mode='wb') as output_file:
+                    with fsspec.open(output_filepath, mode="wb") as output_file:
                         output_file.write(input_file.read())
-
 
     def download(self):
         if not self.staging_paths:

--- a/jupyter_scheduler/output_files_manager.py
+++ b/jupyter_scheduler/output_files_manager.py
@@ -1,7 +1,7 @@
 import os
 import tarfile
 from multiprocessing import Process
-from typing import List, Optional, Type
+from typing import Dict, List, Optional, Type
 
 import fsspec
 from jupyter_server.utils import ensure_async
@@ -19,11 +19,13 @@ class OutputFilesManager:
     async def copy_from_staging(self, job_id: str, redownload: Optional[bool] = False):
         staging_paths = await ensure_async(self.scheduler.get_staging_paths(job_id))
         job = await ensure_async(self.scheduler.get_job(job_id))
+        output_filenames = self.scheduler.get_output_filenames(job)
 
         p = Process(
             target=Downloader(
                 output_formats=job.output_formats,
                 output_prefix=job.output_prefix,
+                output_filenames=output_filenames,
                 staging_paths=staging_paths,
                 root_dir=self.scheduler.root_dir,
                 redownload=redownload,
@@ -37,31 +39,40 @@ class Downloader:
         self,
         output_formats: List[str],
         output_prefix: str,
-        staging_paths: str,
+        output_filenames: Dict[str, str],
+        staging_paths: Dict[str, str],
         root_dir: str,
         redownload: bool,
     ):
         self.output_formats = output_formats
         self.output_prefix = output_prefix
+        self.output_filenames = output_filenames
         self.staging_paths = staging_paths
         self.root_dir = root_dir
         self.redownload = redownload
 
+    def generate_filepaths(self):
+        """A generator that produces filepaths"""
+        output_dir = resolve_path(self.output_prefix, self.root_dir)
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        for output_format in self.output_formats:
+            input_filepath = self.staging_paths[output_format]
+            output_filename = self.output_filenames[output_format]
+            output_filepath = os.path.join(output_dir, output_filename)
+            if not os.path.exists(output_filepath) or self.redownload:
+                yield input_filepath, output_filepath, output_dir
+
+
     def download_tar(self, archive_format: str = "tar"):
-        input_filepath = self.staging_paths[archive_format]
+        archive_filepath = self.staging_paths[archive_format]
         read_mode = "r:gz" if archive_format == "tar.gz" else "tar"
-        with fsspec.open(input_filepath) as f:
+        with fsspec.open(archive_filepath) as f:
             with tarfile.open(fileobj=f, mode=read_mode) as tar:
-
-                output_dir = resolve_path(self.output_prefix, self.root_dir)
-                if not os.path.exists(output_dir):
-                    os.makedirs(output_dir)
-
-                for output_format in self.output_formats:
-                    filepath = self.staging_paths[output_format]
-                    output_filepath = os.path.join(output_dir, filepath)
-                    if not os.path.exists(output_filepath) or self.redownload:
-                        tar.extract(member=filepath, path=output_dir)
+                filepaths = self.generate_filepaths()
+                for input_filepath, output_filepath, output_dir in filepaths:
+                    tar.extract(member=input_filepath, path=output_dir)
 
     def download(self):
         if not self.staging_paths:
@@ -72,18 +83,8 @@ class Downloader:
         elif "tar.gz" in self.staging_paths:
             self.download_tar("tar.gz")
         else:
-            for output_format in self.output_formats:
-                output_dir = resolve_path(self.output_prefix, self.root_dir)
-                if not os.path.exists(output_dir):
-                    os.makedirs(output_dir)
-
-                input_filepath = self.staging_paths[output_format]
-                output_filename = os.path.basename(input_filepath)
-                output_filepath = os.path.join(output_dir, output_filename)
-
-                if os.path.exists(output_filepath) and not self.redownload:
-                    continue
-
+            filepaths = self.generate_filepaths()
+            for input_filepath, output_filepath, output_dir in filepaths:
                 with fsspec.open(input_filepath) as input_file:
                     with fsspec.open(output_filepath, mode="wb") as output_file:
                         output_file.write(input_file.read())

--- a/jupyter_scheduler/output_files_manager.py
+++ b/jupyter_scheduler/output_files_manager.py
@@ -1,8 +1,10 @@
 import os
+import tarfile
 from multiprocessing import Process
 from typing import List, Optional, Type
 
 import fsspec
+from jupyter_server.utils import ensure_async
 
 from jupyter_scheduler.scheduler import BaseScheduler
 from jupyter_scheduler.utils import resolve_path
@@ -14,9 +16,9 @@ class OutputFilesManager:
     def __init__(self, scheduler: Type[BaseScheduler]):
         self.scheduler = scheduler
 
-    def copy_from_staging(self, job_id: str, redownload: Optional[bool] = False):
-        staging_paths = self.scheduler.get_staging_paths(job_id)
-        job = self.scheduler.get_job(job_id)
+    async def copy_from_staging(self, job_id: str, redownload: Optional[bool] = False):
+        staging_paths = await ensure_async(self.scheduler.get_staging_paths(job_id))
+        job = await ensure_async(self.scheduler.get_job(job_id))
 
         p = Process(
             target=Downloader(
@@ -45,15 +47,46 @@ class Downloader:
         self.root_dir = root_dir
         self.redownload = redownload
 
+    def download_tar(self, read_mode: str = "r"):
+        input_filepath = next(iter(self.staging_paths.values()))
+        with fsspec.open(input_filepath) as f:
+            with tarfile.open(fileobj=f, mode=read_mode) as tar:
+
+                output_dir = resolve_path(self.output_prefix, self.root_dir)
+                if not os.path.exists(output_dir):
+                    os.makedirs(output_dir)
+
+                filenames = tar.getnames()
+                for filename in filenames:
+                    fileformat = os.path.splitext(filename)[-1][1:]
+                    output_filepath = os.path.join(output_dir, filename)
+                    if fileformat in self.output_formats and (
+                        self.redownload or not os.path.exists(output_filepath)
+                    ):
+                        tar.extract(member=filename, path=output_dir)
+
     def download(self):
-        for output_format in self.output_formats:
-            input_filepath = self.staging_paths[output_format]
-            output_filename = os.path.basename(input_filepath)
-            output_dir = resolve_path(self.output_prefix, self.root_dir)
-            if not os.path.exists(output_dir):
-                os.makedirs(output_dir)
-            output_filepath = os.path.join(output_dir, output_filename)
-            if self.redownload or not os.path.exists(output_filepath):
+        if not self.staging_paths:
+            return
+
+        first_filepath = next(iter(self.staging_paths.values()))
+        if first_filepath.endswith("tar"):
+            self.download_tar()
+        elif first_filepath.endswith("tar.gz"):
+            self.download_tar("r:gz")
+        else:
+            for output_format in self.output_formats:
+                output_dir = resolve_path(self.output_prefix, self.root_dir)
+                if not os.path.exists(output_dir):
+                    os.makedirs(output_dir)
+
+                input_filepath = self.staging_paths[output_format]
+                output_filename = os.path.basename(input_filepath)
+                output_filepath = os.path.join(output_dir, output_filename)
+
+                if os.path.exists(output_filepath) and not self.redownload:
+                    continue
+
                 with fsspec.open(input_filepath) as input_file:
                     with fsspec.open(output_filepath, mode="wb") as output_file:
                         output_file.write(input_file.read())

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -43,13 +43,14 @@ class BaseScheduler(LoggingConfigurable):
     """
 
     staging_path = Unicode(
+        config=True,
         help=_i18n(
             """Full path to staging location, where output
         files will be stored after job execution completes. This
         could be a local or remote path including cloud storage.
         Default value is jupyter data directory.
         """
-        )
+        ),
     )
 
     @default("staging_path")

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -1,5 +1,5 @@
-from logging import NOTSET
 import os
+from logging import NOTSET
 from multiprocessing import Process
 from typing import Dict, Optional, Type
 
@@ -104,7 +104,7 @@ class BaseScheduler(LoggingConfigurable):
 
     def get_job(self, job_id: str, outputs: Optional[bool] = True) -> DescribeJob:
         """Returns job record for a single job.
-        
+
         Parameters
         ----------
         job_id : str
@@ -113,7 +113,7 @@ class BaseScheduler(LoggingConfigurable):
         outputs : bool, optional
             If True, checks for outputs in local path
             and populates the outputs property. When
-            False, `add_outputs` should not be called. 
+            False, `add_outputs` should not be called.
         """
         raise NotImplementedError("must be implemented by subclass")
 
@@ -128,7 +128,7 @@ class BaseScheduler(LoggingConfigurable):
         API with status update to STOPPED, which will
         call the stop_job method.
         """
-        
+
         raise NotImplementedError("must be implemented by subclass")
 
     def create_job_definition(self, model: CreateJobDefinition) -> str:
@@ -236,10 +236,12 @@ class BaseScheduler(LoggingConfigurable):
 
         filenames = {}
         for output_format in model.output_formats:
-            filenames[output_format] = create_output_filename(model.input_uri, model.create_time, output_format)
+            filenames[output_format] = create_output_filename(
+                model.input_uri, model.create_time, output_format
+            )
 
         return filenames
-    
+
     def add_outputs(self, model: DescribeJob):
         """Adds outputs to the model, ensures output
         files are present in the local workspace. These
@@ -560,7 +562,7 @@ class ArchivingScheduler(Scheduler):
     execution_manager_class = TType(
         klass="jupyter_scheduler.executors.ExecutionManager",
         default_value="jupyter_scheduler.executors.ArchivingExecutionManager",
-        config=True
+        config=True,
     )
 
     def get_staging_paths(self, job_id: str) -> Dict[str, str]:
@@ -571,7 +573,7 @@ class ArchivingScheduler(Scheduler):
         staging_paths = {}
         if not model:
             return staging_paths
-        
+
         for output_format in model.output_formats:
             filename = create_output_filename(model.input_uri, model.create_time, output_format)
             staging_paths[output_format] = filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,7 @@ dependencies = [
     "pytz",
     "fsspec",
     "s3fs",
-    "psutil",
-    ""
+    "psutil"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ dependencies = [
     "croniter",
     "pytz",
     "fsspec",
-    "s3fs"
+    "s3fs",
+    "psutil",
+    ""
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Updates

1. Slight optimization on `get_staging_paths` method to avoid calling `add_outputs`
2. Added docs for `get_staging_paths`
3. Made `staging_path` a configurable attribute
4. Updated `OutputFilesManager` to support async method calls to Scheduler apis
5. Updated `Downloader` to extract output files from tar and compressed tar files, tested this with staging path set to both local file and S3