### PR TITLE
Integrate with file ID manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ dmypy.json
 
 # vs code
 .vscode
+
+# seed script output files
+dev/outputs

--- a/.gitignore
+++ b/.gitignore
@@ -120,5 +120,5 @@ dmypy.json
 # vs code
 .vscode
 
-# seed script output files
-dev/outputs
+# directory reserved for local development
+dev

--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,7 @@ from jupyter_scheduler.orm import create_session, create_tables
 from jupyter_scheduler.scheduler import Scheduler
 from jupyter_scheduler.tests.mocks import MockEnvironmentManager
 
-pytest_plugins = ("jupyter_server.pytest_plugin",)
+pytest_plugins = ("jupyter_server.pytest_plugin", "jupyter_server_fileid.pytest_plugin")
 
 HERE = Path(__file__).parent.resolve()
 DB_FILE_PATH = f"{HERE}/jupyter_scheduler/tests/testdb.sqlite"
@@ -15,9 +15,12 @@ DB_URL = f"sqlite:///{DB_FILE_PATH}"
 
 
 @pytest.fixture
-def jp_server_config(jp_server_config):
+def jp_server_config(jp_server_config, jp_root_dir, fid_db_path):
     return {
-        "ServerApp": {"jpserver_extensions": {"jupyter_scheduler": True}},
+        "ServerApp": {
+            "root_dir": str(jp_root_dir),
+            "jpserver_extensions": {"jupyter_scheduler": True, "jupyter_server_fileid": True},
+        },
         "SchedulerApp": {
             "db_url": DB_URL,
             "drop_tables": True,
@@ -27,6 +30,7 @@ def jp_server_config(jp_server_config):
             "execution_manager_class": "jupyter_scheduler.tests.mocks.MockExecutionManager"
         },
         "Scheduler": {"task_runner_class": "jupyter_scheduler.tests.mocks.MockTaskRunner"},
+        "FileIdManager": {"db_path": str(fid_db_path)},
     }
 
 
@@ -44,7 +48,14 @@ def jp_scheduler_db():
 
 
 @pytest.fixture
-def jp_scheduler(jp_data_dir):
+def jp_scheduler(jp_root_dir, fid_manager):
+    # root_dir should be identical to fid_manager.root_dir
+    fid_manager.log.error(fid_manager.root_dir)
+    parent = Path(fid_manager.root_dir).parent
+    fid_manager.log.error(os.path.exists(parent))
     return Scheduler(
-        db_url=DB_URL, root_dir=str(jp_data_dir), environments_manager=MockEnvironmentManager()
+        db_url=DB_URL,
+        root_dir=str(jp_root_dir),
+        environments_manager=MockEnvironmentManager(),
+        file_id_manager=fid_manager,
     )

--- a/conftest.py
+++ b/conftest.py
@@ -50,9 +50,6 @@ def jp_scheduler_db():
 @pytest.fixture
 def jp_scheduler(jp_root_dir, fid_manager):
     # root_dir should be identical to fid_manager.root_dir
-    fid_manager.log.error(fid_manager.root_dir)
-    parent = Path(fid_manager.root_dir).parent
-    fid_manager.log.error(os.path.exists(parent))
     return Scheduler(
         db_url=DB_URL,
         root_dir=str(jp_root_dir),

--- a/dev/seed.py
+++ b/dev/seed.py
@@ -1,14 +1,31 @@
 import json
 import os
 import random
+import shutil
 import subprocess
-import zoneinfo
-from uuid import uuid4
+from pathlib import Path
 
 import click
+import pytz
+from jupyter_server_fileid.manager import FileIdManager
 
-from jupyter_scheduler.orm import Job, JobDefinition, create_session, create_tables
+from jupyter_scheduler.environments import CondaEnvironmentManager
+from jupyter_scheduler.models import CreateJob, CreateJobDefinition
+from jupyter_scheduler.orm import create_tables
+from jupyter_scheduler.scheduler import Scheduler
 from jupyter_scheduler.utils import get_utc_timestamp
+
+root_dir = str(Path(__file__).parent.absolute())
+# must be specified relative to root_dir
+TEMPLATE_PATHS = [
+    os.path.join("templates", "1.ipynb"),
+    os.path.join("templates", "2.ipynb"),
+    os.path.join("templates", "3.ipynb"),
+]
+
+
+def pick_random_template():
+    return str(random.choice(TEMPLATE_PATHS))
 
 
 def get_db_path():
@@ -19,29 +36,32 @@ def get_db_path():
     return os.path.join(data[0], "scheduler.sqlite")
 
 
-def create_random_job_def(index: int):
-    name = random.choice(
-        [
-            "definition alpha",
-            "definition beta",
-            "super schedule",
-            "cool definition",
-            "lame definition",
-        ]
+def create_random_job_def(index: int) -> CreateJobDefinition:
+    name = (
+        random.choice(
+            [
+                "definition alpha",
+                "definition beta",
+                "super schedule",
+                "cool definition",
+                "lame definition",
+            ]
+        )
+        + " "
+        + str(index)
     )
-    job_definition_id = str(uuid4())
-    input_uri = "".join(name.split()) + ".ipynb"
-    output_prefix = ""
-    timezone = random.choice(list(zoneinfo.available_timezones()))
+
+    input_uri = pick_random_template()
+    output_prefix = os.path.join("dev", "outputs", name)
+    timezone = random.choice(pytz.all_timezones)
     # random schedules can be generated via https://crontab.guru/
     schedule = random.choice(
         ["0 0,12 1 */2 *", "0 4 8-14 * *", "0 0 1,15 * 3", "5 0 * 8 *", "15 14 1 * *"]
     )
     active = random.choice([True, False])
 
-    return JobDefinition(
-        name=f"{name} {index}",
-        job_definition_id=job_definition_id,
+    return CreateJobDefinition(
+        name=name,
         input_uri=input_uri,
         output_prefix=output_prefix,
         timezone=timezone,
@@ -51,21 +71,25 @@ def create_random_job_def(index: int):
     )
 
 
-def create_random_job(index: int, job_def_id: str):
+def create_random_job(index: int, job_def_id: str) -> CreateJob:
     status = random.choice(["CREATED", "QUEUED", "COMPLETED", "FAILED", "IN_PROGRESS", "STOPPED"])
-    name = random.choice(
-        [
-            "hello world",
-            "lorem ipsum",
-            "job a",
-            "job b",
-            "long running job",
-            "fast job",
-            "random job",
-        ]
+    name = (
+        random.choice(
+            [
+                "hello world",
+                "lorem ipsum",
+                "job a",
+                "job b",
+                "long running job",
+                "fast job",
+                "random job",
+            ]
+        )
+        + " "
+        + str(index)
     )
-    input_uri = "".join(name.split()) + ".ipynb"
-    output_prefix = ""
+    input_uri = pick_random_template()
+    output_prefix = os.path.join("dev", "outputs", name)
     start_time = None
     status_message = None
     end_time = None
@@ -79,8 +103,8 @@ def create_random_job(index: int, job_def_id: str):
     if status == "COMPLETED":
         end_time = get_utc_timestamp()
 
-    return Job(
-        name=f"{name} {index}",
+    return CreateJob(
+        name=name,
         job_definition_id=job_def_id,
         input_uri=input_uri,
         output_prefix=output_prefix,
@@ -99,20 +123,30 @@ def load_data(jobs_count: int, job_defs_count: int, db_path: str):
         os.remove(db_path)
 
     create_tables(db_url, drop_tables=True)
-    db_session = create_session(db_url)
 
-    with db_session() as session:
-        job_def_ids = []
+    file_id_manager = FileIdManager(root_dir=root_dir)
+    scheduler = Scheduler(
+        db_url=db_url,
+        root_dir=root_dir,
+        environments_manager=CondaEnvironmentManager(),
+        task_runner_class=None,
+        file_id_manager=file_id_manager,
+    )
+    job_def_ids = []
 
-        for index in range(1, job_defs_count + 1):
-            job_def = create_random_job_def(index)
-            session.add(job_def)
-            job_def_ids.append(job_def.job_definition_id)
+    # clear existing output files
+    try:
+        shutil.rmtree(os.path.join(root_dir, "outputs"))
+    except:
+        pass
+    os.mkdir(os.path.join(root_dir, "outputs"))
 
-        for index in range(1, jobs_count + 1):
-            session.add(create_random_job(index, random.choice(job_def_ids)))
+    for index in range(1, job_defs_count + 1):
+        job_def_id = scheduler.create_job_definition(create_random_job_def(index))
+        job_def_ids.append(job_def_id)
 
-        session.commit()
+    for index in range(1, jobs_count + 1):
+        scheduler.create_job(create_random_job(index, random.choice(job_def_ids)))
 
     click.echo(
         f"\nCreated {jobs_count} jobs and {job_defs_count} job definitions in the scheduler database"

--- a/dev/templates/1.ipynb
+++ b/dev/templates/1.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.12 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/dev/templates/2.ipynb
+++ b/dev/templates/2.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.12 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/dev/templates/3.ipynb
+++ b/dev/templates/3.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(3)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.12 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/jupyter_scheduler/executors.py
+++ b/jupyter_scheduler/executors.py
@@ -26,17 +26,27 @@ class ExecutionManager(ABC):
     _model = None
     _db_session = None
 
-    def __init__(self, job_id: str, staging_paths: Dict[str, str], root_dir: str, db_url: str):
+    def __init__(
+        self,
+        job_id: str,
+        staging_paths: Dict[str, str],
+        root_dir: str,
+        db_url: str,
+        file_id_manager=None,
+    ):
         self.job_id = job_id
         self.staging_paths = staging_paths
         self.root_dir = root_dir
         self.db_url = db_url
+        self.file_id_manager = file_id_manager
 
     @property
     def model(self):
+        """DescribeJob model for the managed job."""
         if self._model is None:
             with self.db_session() as session:
                 job = session.query(Job).filter(Job.job_id == self.job_id).first()
+                job.input_uri = self.file_id_manager.get_path(job.input_file_id)
                 self._model = DescribeJob.from_orm(job)
         return self._model
 

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -171,10 +171,6 @@ class UpdateJob(BaseModel):
     compute_type: Optional[str] = None
 
 
-class DeleteJob(BaseModel):
-    job_id: str
-
-
 class CreateJobDefinition(BaseModel):
     input_uri: str
     output_prefix: str

--- a/jupyter_scheduler/orm.py
+++ b/jupyter_scheduler/orm.py
@@ -1,5 +1,4 @@
 import json
-import os
 from sqlite3 import OperationalError
 from uuid import uuid4
 
@@ -8,7 +7,7 @@ from sqlalchemy import Boolean, Column, Integer, String, create_engine
 from sqlalchemy.orm import declarative_base, declarative_mixin, registry, sessionmaker
 
 from jupyter_scheduler.models import EmailNotifications, Status
-from jupyter_scheduler.utils import create_output_filename, get_utc_timestamp
+from jupyter_scheduler.utils import get_utc_timestamp
 
 Base = declarative_base()
 
@@ -25,21 +24,6 @@ def generate_jobs_url(context) -> str:
 def generate_job_definitions_url(context) -> str:
     job_definition_id = context.get_current_parameters()["job_definition_id"]
     return f"/job_definitions/{job_definition_id}"
-
-
-def output_uri(context) -> str:
-    input_uri = context.get_current_parameters()["input_uri"]
-    output_prefix = context.get_current_parameters()["output_prefix"]
-    output_formats = context.get_current_parameters()["output_formats"]
-
-    if not output_formats or "ipynb" in output_formats:
-        output_filename = create_output_filename(input_uri)
-    else:
-        output_filename = create_output_filename(
-            os.path.splitext(input_uri)[-2] + "." + output_formats[0]
-        )
-
-    return os.path.join(output_prefix, output_filename)
 
 
 class JsonType(types.TypeDecorator):
@@ -87,7 +71,7 @@ class CommonColumns:
     runtime_environment_name = Column(String(256), nullable=False)
     runtime_environment_parameters = Column(JsonType(1024))
     compute_type = Column(String(256), nullable=True)
-    input_uri = Column(String(256), nullable=False)
+    input_file_id = Column(Integer, nullable=False)
     output_prefix = Column(String(256))
     output_formats = Column(JsonType(512))
     name = Column(String(256))

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -426,9 +426,13 @@ class Scheduler(BaseScheduler):
 
     def update_job_definition(self, job_definition_id: str, model: UpdateJobDefinition):
         with self.db_session() as session:
+            update_kwargs = model.dict(exclude={"input_uri"}, exclude_none=True)
+            if model.input_uri:
+                update_kwargs["input_file_id"] = self.file_id_manager.index(model.input_uri)
+
             session.query(JobDefinition).filter(
                 JobDefinition.job_definition_id == job_definition_id
-            ).update(model.dict(exclude_none=True))
+            ).update(update_kwargs)
             session.commit()
 
             schedule = (

--- a/jupyter_scheduler/task_runner.py
+++ b/jupyter_scheduler/task_runner.py
@@ -137,8 +137,8 @@ class BaseTaskRunner(LoggingConfigurable):
     based on the schedule/timezone in the job definition.
     """
 
-    def __init__(self, config=None, **kwargs):
-        super().__init__(config=config)
+    def __init__(self, config=None, *args, **kwargs):
+        super().__init__(config=config, *args, **kwargs)
 
     poll_interval = traitlets.Integer(
         default_value=10,

--- a/jupyter_scheduler/tests/test_scheduler.py
+++ b/jupyter_scheduler/tests/test_scheduler.py
@@ -198,14 +198,21 @@ def test_resume_jobs(jp_scheduler, load_job_definitions, jp_scheduler_db, job_de
 
 
 def test_update_job_definition(
-    jp_scheduler, load_job_definitions, jp_scheduler_db, job_definition_1
+    jp_scheduler, load_job_definitions, jp_scheduler_db, job_definition_1, fs_helpers
 ):
     job_definition_id = job_definition_1["job_definition_id"]
+    new_input_uri = "new.ipynb"
+    fs_helpers.touch(new_input_uri)
+    new_input_file_id = jp_scheduler.file_id_manager.index(new_input_uri)
     schedule = "*/5 * * * *"
     timezone = "America/New_York"
+
     with patch("jupyter_scheduler.scheduler.Scheduler.task_runner") as mock_task_runner:
         update = UpdateJobDefinition(
-            job_definition_id=job_definition_id, schedule=schedule, timezone=timezone
+            job_definition_id=job_definition_id,
+            schedule=schedule,
+            timezone=timezone,
+            input_uri=new_input_uri,
         )
         jp_scheduler.update_job_definition(job_definition_id, update)
 
@@ -213,6 +220,7 @@ def test_update_job_definition(
         definition = session.get(JobDefinition, job_definition_id)
         assert schedule == definition.schedule
         assert timezone == definition.timezone
+        assert new_input_file_id == definition.input_file_id
 
 
 def test_delete_job_definition(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "jupyter_server>=1.6,<2",
+    # match dependency in jupyter_server_fileid
+    "jupyter_server>=1.15, <3",
+    "jupyter_server_fileid~=0.3.2",
     "traitlets",
     "nbconvert",
     "pydantic",
@@ -42,7 +44,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
-    "jupyter_server[test]"
+    "jupyter_server[test]>=1.15, <3"
 ]
 dev = [
     "click"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     # match dependency in jupyter_server_fileid
     "jupyter_server>=1.15, <3",
-    "jupyter_server_fileid~=0.3.2",
+    "jupyter_server_fileid~=0.4.2",
     "traitlets",
     "nbconvert",
     "pydantic",


### PR DESCRIPTION
Fixes #120.

- Input path is now tracked across file moves.
  - REST API remains identical. Accepts and returns `input_uri` attribute in payloads.
  - However, the DB record now stores `input_file_id` instead of `input_uri`. Scheduler methods invoke `file_id_manager.index()` upon create and invoke `file_id_manager.get_path()` upon describe.
- Adds new seed script in `dev/` directory, which now also accepts real template input files and generates real output files. The intended development flow is as follows:
```
cd dev/
python seed.py
jupyter lab
```

## Open questions

- Does updating the input URI need to be supported ATM? This is not implemented in the UI, so I don't see a pressing need to tackle this in this PR.

- Do we need to support file ID for the output prefix? @ellisonbg had raised this during our morning standup, but frankly I don't think it makes sense, as the output directory may not even exist at job creation. Look at the implementation for `Downloader#download()`:

```python
    def download(self):
        for output_format in self.output_formats:
            input_filepath = self.staging_paths[output_format]
            output_filename = os.path.basename(input_filepath)
            output_dir = resolve_path(self.output_prefix, self.root_dir)
            if not os.path.exists(output_dir):
                # vvvvvvvvvv
                os.makedirs(output_dir)
...
```

The download method creates the directories as needed upon download. Requiring a file ID for the output directory would mean we have to create the output directories on job creation rather than on download. I simply cannot envision a scenario in which a user would create a job, navigate to the newly created output directory, and then move that directory around and expect the files to still be populated there.

Aside from my concerns with the user experience, this also isn't possible with the current version of File ID, because the modified times of the directory will change upon creating new files out-of-band (like the Downloader is doing), which then assigns the output directory a new file ID, and the old file ID no longer can be resolved to a path.

## Notes

- [Without JS2, editing a file assigns it a new file ID and breaks the old one on Linux](https://github.com/jupyter-server/jupyter_server_fileid/issues/15). This means that editing an input file on Linux causes it to be effectively lost (e.g. won't show up in the list jobs table). To ensure this never happens for any user installing scheduler, we would either have to:
  - impose a hard dependency on JS2
  - add support for ext4 creation timestamps in file ID