### PR TITLE
Sets initial crontab for schedule

### DIFF
--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -6,10 +6,10 @@ import { Cluster } from './components/cluster';
 import { AddButton, DeleteButton } from './components/icon-buttons';
 import { useTranslator } from './hooks';
 import { ICreateJobModel, IJobDetailModel } from './model';
-import { Scheduler as SchedulerTokens } from './tokens';
+import { Scheduler } from './tokens';
 
 const AdvancedOptions = (
-  props: SchedulerTokens.IAdvancedOptionsProps
+  props: Scheduler.IAdvancedOptionsProps
 ): JSX.Element => {
   const formPrefix = 'jp-create-job-advanced-';
 

--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -27,8 +27,6 @@ const AdvancedOptions = (
       return; // Read-only mode
     }
 
-    const createModel = props.model as ICreateJobModel;
-
     const { name, value } = event.target;
     const tagIdxMatch = name.match(/^tag-(\d+)$/);
 
@@ -39,20 +37,27 @@ const AdvancedOptions = (
     const newTags = props.model.tags ?? [];
     newTags[parseInt(tagIdxMatch[1])] = value;
 
-    props.handleModelChange({ ...createModel, tags: newTags });
+    props.handleModelChange({
+      ...(props.model as ICreateJobModel),
+      tags: newTags
+    });
   };
 
   const addTag = () => {
     const newTags = [...(props.model.tags ?? []), ''];
-    const createModel = props.model as ICreateJobModel;
-    props.handleModelChange({ ...createModel, tags: newTags });
+    props.handleModelChange({
+      ...(props.model as ICreateJobModel),
+      tags: newTags
+    });
   };
 
   const deleteTag = (idx: number) => {
     const newTags = props.model.tags ?? [];
     newTags.splice(idx, 1);
-    const createModel = props.model as ICreateJobModel;
-    props.handleModelChange({ ...createModel, tags: newTags });
+    props.handleModelChange({
+      ...(props.model as ICreateJobModel),
+      tags: newTags
+    });
   };
 
   const tags = props.model.tags ?? [];

--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -5,10 +5,11 @@ import { FormLabel, Stack, TextField } from '@mui/material';
 import { Cluster } from './components/cluster';
 import { AddButton, DeleteButton } from './components/icon-buttons';
 import { useTranslator } from './hooks';
-import { Scheduler } from './tokens';
+import { ICreateJobModel, IJobDetailModel } from './model';
+import { Scheduler as SchedulerTokens } from './tokens';
 
 const AdvancedOptions = (
-  props: Scheduler.IAdvancedOptionsProps
+  props: SchedulerTokens.IAdvancedOptionsProps
 ): JSX.Element => {
   const formPrefix = 'jp-create-job-advanced-';
 
@@ -16,7 +17,8 @@ const AdvancedOptions = (
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) =>
     props.handleModelChange({
-      ...props.model,
+      // Only the create-job model can change, not the detail model
+      ...(props.model as ICreateJobModel),
       [e.target.name]: e.target.value
     });
 
@@ -24,6 +26,8 @@ const AdvancedOptions = (
     if (props.jobsView !== 'CreateJob') {
       return; // Read-only mode
     }
+
+    const createModel = props.model as ICreateJobModel;
 
     const { name, value } = event.target;
     const tagIdxMatch = name.match(/^tag-(\d+)$/);
@@ -35,18 +39,20 @@ const AdvancedOptions = (
     const newTags = props.model.tags ?? [];
     newTags[parseInt(tagIdxMatch[1])] = value;
 
-    props.handleModelChange({ ...props.model, tags: newTags });
+    props.handleModelChange({ ...createModel, tags: newTags });
   };
 
   const addTag = () => {
     const newTags = [...(props.model.tags ?? []), ''];
-    props.handleModelChange({ ...props.model, tags: newTags });
+    const createModel = props.model as ICreateJobModel;
+    props.handleModelChange({ ...createModel, tags: newTags });
   };
 
   const deleteTag = (idx: number) => {
     const newTags = props.model.tags ?? [];
     newTags.splice(idx, 1);
-    props.handleModelChange({ ...props.model, tags: newTags });
+    const createModel = props.model as ICreateJobModel;
+    props.handleModelChange({ ...createModel, tags: newTags });
   };
 
   const tags = props.model.tags ?? [];
@@ -120,19 +126,32 @@ const AdvancedOptions = (
     props.jobsView === 'CreateJob' ? createTags() : showTags();
 
   // The idempotency token is only used for jobs, not for job definitions
+  const idemTokenLabel = trans.__('Idempotency token');
+  const idemTokenName = 'idempotencyToken';
+  const idemTokenId = `${formPrefix}${idemTokenName}`;
   return (
     <Stack spacing={4}>
-      {props.model.createType === 'Job' && (
+      {props.jobsView === 'JobDetail' && 'idempotencyToken' in props.model && (
         <TextField
-          label={trans.__('Idempotency token')}
+          label={idemTokenLabel}
           variant="outlined"
-          onChange={handleInputChange}
-          value={props.model.idempotencyToken}
+          value={(props.model as IJobDetailModel).idempotencyToken}
           id={`${formPrefix}idempotencyToken`}
-          name="idempotencyToken"
-          InputProps={{ readOnly: props.jobsView !== 'CreateJob' }}
+          name={idemTokenName}
+          InputProps={{ readOnly: true }}
         />
       )}
+      {props.jobsView === 'CreateJob' &&
+        (props.model as ICreateJobModel).createType === 'Job' && (
+          <TextField
+            label={idemTokenLabel}
+            variant="outlined"
+            onChange={handleInputChange}
+            value={(props.model as ICreateJobModel).idempotencyToken}
+            id={idemTokenId}
+            name={idemTokenName}
+          />
+        )}
       <FormLabel component="legend">{trans.__('Tags')}</FormLabel>
       {tagsDisplay}
     </Stack>

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -11,7 +11,11 @@ import Stack from '@mui/material/Stack';
 import { outputFormatsForEnvironment } from './output-format-picker';
 import { Scheduler } from '../handler';
 import { useTranslator } from '../hooks';
-import { IJobParameter, ICreateJobModel } from '../model';
+import {
+  IJobParameter,
+  ICreateJobModel,
+  InitialScheduleOptions
+} from '../model';
 import { CommandIDs } from '..';
 import { ConfirmDeleteIcon } from './confirm-delete-icon';
 import TableRow from '@mui/material/TableRow';
@@ -74,8 +78,7 @@ function RefillButton(props: {
       runtimeEnvironmentParameters: props.job.runtime_environment_parameters,
       parameters: jobParameters,
       createType: 'Job',
-      scheduleInterval: 'weekday',
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+      ...InitialScheduleOptions
     };
 
     // Convert the list of output formats, if any, into a list for the initial state

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -7,19 +7,15 @@ import DownloadIcon from '@mui/icons-material/Download';
 import StopIcon from '@mui/icons-material/Stop';
 import ReplayIcon from '@mui/icons-material/Replay';
 import IconButton from '@mui/material/IconButton';
-import Stack from '@mui/material/Stack';
+import { Stack, TableCell, TableRow } from '@mui/material';
+
+import { ConfirmDeleteIcon } from './confirm-delete-icon';
 import { outputFormatsForEnvironment } from './output-format-picker';
+
 import { Scheduler } from '../handler';
 import { useTranslator } from '../hooks';
-import {
-  IJobParameter,
-  ICreateJobModel,
-  InitialScheduleOptions
-} from '../model';
+import { IJobParameter, ICreateJobModel, emptyCreateJobModel } from '../model';
 import { CommandIDs } from '..';
-import { ConfirmDeleteIcon } from './confirm-delete-icon';
-import TableRow from '@mui/material/TableRow';
-import { TableCell } from '@mui/material';
 
 function get_file_from_path(path: string): string {
   return PathExt.basename(path);
@@ -71,14 +67,13 @@ function RefillButton(props: {
 
   const clickHandler = (): void => {
     const newModel: ICreateJobModel = {
+      ...emptyCreateJobModel(),
       inputFile: props.job.input_uri,
       jobName: props.job.name ?? '',
       outputPath: props.job.output_prefix,
       environment: props.job.runtime_environment_name,
       runtimeEnvironmentParameters: props.job.runtime_environment_parameters,
-      parameters: jobParameters,
-      createType: 'Job',
-      ...InitialScheduleOptions
+      parameters: jobParameters
     };
 
     // Convert the list of output formats, if any, into a list for the initial state

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import {
+  emptyCreateJobModel,
   ICreateJobModel,
   IJobDetailModel,
-  InitialScheduleOptions,
   JobsView,
   ListJobsView
 } from '../../model';
@@ -67,15 +67,14 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   const handleRerunJob = () => {
     const initialState: ICreateJobModel = {
+      ...emptyCreateJobModel(),
       jobName: props.model.jobName,
       inputFile: props.model.inputFile,
       outputPath: props.model.outputPrefix ?? '',
       environment: props.model.environment,
       runtimeEnvironmentParameters: props.model.runtimeEnvironmentParameters,
       parameters: props.model.parameters,
-      outputFormats: props.model.outputFormats,
-      createType: 'Job',
-      ...InitialScheduleOptions
+      outputFormats: props.model.outputFormats
     };
 
     props.setCreateJobModel(initialState);

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -4,6 +4,7 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import {
   ICreateJobModel,
   IJobDetailModel,
+  InitialScheduleOptions,
   JobsView,
   ListJobsView
 } from '../../model';
@@ -74,8 +75,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       parameters: props.model.parameters,
       outputFormats: props.model.outputFormats,
       createType: 'Job',
-      scheduleInterval: 'weekday',
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+      ...InitialScheduleOptions
     };
 
     props.setCreateJobModel(initialState);

--- a/src/model.ts
+++ b/src/model.ts
@@ -59,6 +59,12 @@ export interface ICreateJobModel extends PartialJSONObject {
   scheduleWeekDay?: string;
 }
 
+export const InitialScheduleOptions = {
+  scheduleInterval: 'weekday',
+  schedule: '0 0 * * MON-FRI',
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+};
+
 export function emptyCreateJobModel(): ICreateJobModel {
   return {
     key: Math.random(),
@@ -67,8 +73,7 @@ export function emptyCreateJobModel(): ICreateJobModel {
     outputPath: '',
     environment: '',
     createType: 'Job',
-    scheduleInterval: 'weekday',
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+    ...InitialScheduleOptions
   };
 }
 
@@ -279,8 +284,8 @@ export function convertDescribeJobtoJobDetail(
     updateTime: describeJob.update_time,
     startTime: describeJob.start_time,
     endTime: describeJob.end_time,
-    scheduleInterval: 'weekday',
-    downloaded: describeJob.downloaded
+    downloaded: describeJob.downloaded,
+    ...InitialScheduleOptions
   };
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -59,12 +59,6 @@ export interface ICreateJobModel extends PartialJSONObject {
   scheduleWeekDay?: string;
 }
 
-export const InitialScheduleOptions = {
-  scheduleInterval: 'weekday',
-  schedule: '0 0 * * MON-FRI',
-  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
-};
-
 export function emptyCreateJobModel(): ICreateJobModel {
   return {
     key: Math.random(),
@@ -73,7 +67,9 @@ export function emptyCreateJobModel(): ICreateJobModel {
     outputPath: '',
     environment: '',
     createType: 'Job',
-    ...InitialScheduleOptions
+    scheduleInterval: 'weekday',
+    schedule: '0 0 * * MON-FRI',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
   };
 }
 
@@ -264,7 +260,7 @@ export function convertDescribeJobtoJobDetail(
   };
 
   return {
-    createType: 'Job',
+    ...emptyCreateJobModel(),
     jobId: describeJob.job_id,
     jobName: describeJob.name ?? '',
     inputFile: describeJob.input_uri,
@@ -284,8 +280,7 @@ export function convertDescribeJobtoJobDetail(
     updateTime: describeJob.update_time,
     startTime: describeJob.start_time,
     endTime: describeJob.end_time,
-    downloaded: describeJob.downloaded,
-    ...InitialScheduleOptions
+    downloaded: describeJob.downloaded
   };
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -208,7 +208,20 @@ export interface IJobsModelOptions {
  * Describe and Detail models
  */
 
-export interface IJobDetailModel extends ICreateJobModel {
+export interface IJobDetailModel {
+  jobName: string;
+  inputFile: string;
+  outputPath: string;
+  environment: string;
+  // Errors from creation
+  createError?: string;
+  runtimeEnvironmentParameters?: { [key: string]: number | string | boolean };
+  parameters?: IJobParameter[];
+  // List of values for output formats; labels are specified by the environment
+  outputFormats?: string[];
+  computeType?: string;
+  idempotencyToken?: string;
+  tags?: string[];
   jobId: string;
   status?: Scheduler.Status;
   statusMessage?: string;
@@ -221,7 +234,22 @@ export interface IJobDetailModel extends ICreateJobModel {
   downloaded: boolean;
 }
 
-export interface IJobDefinitionModel extends ICreateJobModel {
+export interface IJobDefinitionModel {
+  inputFile: string;
+  outputPath: string;
+  environment: string;
+  // Errors from creation
+  createError?: string;
+  runtimeEnvironmentParameters?: { [key: string]: number | string | boolean };
+  parameters?: IJobParameter[];
+  // List of values for output formats; labels are specified by the environment
+  outputFormats?: string[];
+  computeType?: string;
+  tags?: string[];
+  // String for schedule in cron format
+  schedule?: string;
+  // String for timezone in tz database format
+  timezone?: string;
   definitionId: string;
   name?: string;
   active?: boolean;
@@ -294,9 +322,7 @@ export function convertDescribeDefinitiontoDefinition(
 
   return {
     name: describeDefinition.name ?? '',
-    jobName: '',
     inputFile: describeDefinition.input_uri,
-    createType: 'JobDefinition',
     definitionId: describeDefinition.job_definition_id,
     outputPath: describeDefinition.output_filename_template ?? '',
     outputPrefix: describeDefinition.output_prefix,
@@ -311,8 +337,7 @@ export function convertDescribeDefinitiontoDefinition(
     createTime: describeDefinition.create_time,
     updateTime: describeDefinition.update_time,
     schedule: describeDefinition.schedule,
-    timezone: describeDefinition.timezone,
-    scheduleInterval: 'custom'
+    timezone: describeDefinition.timezone
   };
 }
 


### PR DESCRIPTION
Fixes #180. When the user sets up an initial schedule with "Weekday" mode, there is now an initial value for the cron expression, which is used when the user switches to custom scheduling.

https://user-images.githubusercontent.com/93281816/197264307-88b565e8-c364-45a6-8fca-2704697c4bc9.mov

