### PR TITLE
Limits maximum size of compute type dropdown

### DIFF
--- a/src/components/compute-type-picker.tsx
+++ b/src/components/compute-type-picker.tsx
@@ -37,6 +37,13 @@ export function ComputeTypePicker(
         id={props.id}
         onChange={props.onChange}
         value={props.value}
+        MenuProps={{
+          PaperProps: {
+            sx: {
+              maxHeight: '20em'
+            }
+          }
+        }}
       >
         {computeTypes.map((ct, idx) => (
           <MenuItem value={ct} key={idx}>

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -158,7 +158,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   const handleSelectChange = (event: SelectChangeEvent<string>) => {
     const target = event.target;
 
-    // if setting the environment, default the compute type to its first value (if any are presnt)
+    // if setting the environment, default the compute type to its first value (if any are present)
     if (target.name === 'environment') {
       const envObj = environmentList.find(env => env.name === target.value);
       props.handleModelChange({


### PR DESCRIPTION
Partial fix for #177. Prevents compute type dropdown from taking over nearly the full height of the viewport.

Compute type with no max-height:

![image](https://user-images.githubusercontent.com/93281816/197309630-236a45ba-e870-4a5a-87e2-a993b1083664.png)


Compute type with a `20em` max-height:

![image](https://user-images.githubusercontent.com/93281816/197309567-c36e8736-4870-4980-b538-2dead6ff4635.png)
