### PR TITLE
Disable create on submit

### DIFF
--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -24,6 +24,7 @@ import {
   AccordionSummary,
   Alert,
   Button,
+  CircularProgress,
   FormLabel,
   InputAdornment,
   SelectChangeEvent,
@@ -566,7 +567,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   };
 
   const submitCreateJobRequest = async (event: React.MouseEvent) => {
-    if (anyErrors) {
+    if (props.model.createButtonDisabled || anyErrors) {
       console.error(
         'User attempted to submit a createJob request; button should have been disabled'
       );
@@ -590,7 +591,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       jobOptions.parameters = serializeParameters(props.model.parameters);
     }
 
-    props.handleModelChange({ ...props.model, createError: undefined });
+    props.handleModelChange({
+      ...props.model,
+      createError: undefined,
+      createInProgress: true
+    });
 
     api
       .createJob(jobOptions)
@@ -599,7 +604,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         props.showListView('Job');
       })
       .catch((error: Error) => {
-        props.handleModelChange({ ...props.model, createError: error.message });
+        props.handleModelChange({
+          ...props.model,
+          createError: error.message,
+          createInProgress: false
+        });
       });
   };
 
@@ -820,17 +829,20 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             <Button variant="outlined" onClick={e => props.showListView('Job')}>
               {trans.__('Cancel')}
             </Button>
-            <Button
-              variant="contained"
-              onClick={(e: React.MouseEvent) => {
-                submitForm(e);
-                return false;
-              }}
-              disabled={anyErrors}
-              title={anyErrors ? cantSubmit : ''}
-            >
-              {trans.__('Create')}
-            </Button>
+            {props.model.createInProgress || (
+              <Button
+                variant="contained"
+                onClick={(e: React.MouseEvent) => {
+                  submitForm(e);
+                  return false;
+                }}
+                disabled={anyErrors}
+                title={anyErrors ? cantSubmit : ''}
+              >
+                {trans.__('Create')}
+              </Button>
+            )}
+            {props.model.createInProgress && <CircularProgress size="30px" />}
           </Cluster>
         </Stack>
       </form>

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -567,7 +567,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   };
 
   const submitCreateJobRequest = async (event: React.MouseEvent) => {
-    if (props.model.createButtonDisabled || anyErrors) {
+    if (anyErrors) {
       console.error(
         'User attempted to submit a createJob request; button should have been disabled'
       );

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -639,7 +639,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       );
     }
 
-    props.handleModelChange({ ...props.model, createError: undefined });
+    props.handleModelChange({
+      ...props.model,
+      createError: undefined,
+      createInProgress: true
+    });
 
     api
       .createJobDefinition(jobDefinitionOptions)
@@ -648,7 +652,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         props.showListView('JobDefinition');
       })
       .catch((error: string) => {
-        props.handleModelChange({ ...props.model, createError: error });
+        props.handleModelChange({
+          ...props.model,
+          createError: error,
+          createInProgress: false
+        });
       });
   };
 

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -834,21 +834,27 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             handleErrorsChange={setErrors}
           />
           <Cluster gap={3} justifyContent="flex-end">
-            <Button variant="outlined" onClick={e => props.showListView('Job')}>
-              {trans.__('Cancel')}
-            </Button>
             {props.model.createInProgress || (
-              <Button
-                variant="contained"
-                onClick={(e: React.MouseEvent) => {
-                  submitForm(e);
-                  return false;
-                }}
-                disabled={anyErrors}
-                title={anyErrors ? cantSubmit : ''}
-              >
-                {trans.__('Create')}
-              </Button>
+              <>
+                <Button
+                  variant="outlined"
+                  onClick={e => props.showListView('Job')}
+                >
+                  {trans.__('Cancel')}
+                </Button>
+
+                <Button
+                  variant="contained"
+                  onClick={(e: React.MouseEvent) => {
+                    submitForm(e);
+                    return false;
+                  }}
+                  disabled={anyErrors}
+                  title={anyErrors ? cantSubmit : ''}
+                >
+                  {trans.__('Create')}
+                </Button>
+              </>
             )}
             {props.model.createInProgress && <CircularProgress size="30px" />}
           </Cluster>

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -856,7 +856,14 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                 </Button>
               </>
             )}
-            {props.model.createInProgress && <CircularProgress size="30px" />}
+            {props.model.createInProgress && (
+              <>
+                {props.model.createType === 'Job'
+                  ? trans.__('Creating job …')
+                  : trans.__('Creating job definition …')}
+                <CircularProgress size="30px" />
+              </>
+            )}
           </Cluster>
         </Stack>
       </form>

--- a/src/model.ts
+++ b/src/model.ts
@@ -57,6 +57,8 @@ export interface ICreateJobModel extends PartialJSONObject {
   scheduleMonthDayInput?: string;
   scheduleMonthDay?: number;
   scheduleWeekDay?: string;
+  // Is the create button disabled due to a submission in progress?
+  createInProgress?: boolean;
 }
 
 export function emptyCreateJobModel(): ICreateJobModel {


### PR DESCRIPTION
Fixes #179. On submission, replaces the "Create" and "Cancel" buttons with a progress indicator. (Clicking "Cancel" after job creation has started will not actually attempt to cancel the job submission request.) If the job succeeds, the user is brought to the list page. If the job fails, the user remains on the create page and the  buttons become visible again.

In the video below, the "Create" handler has been replaced with a stub that introduces a 5-second delay and resolves the promise only if the job name contains `ok`. It does not actually create a job.



https://user-images.githubusercontent.com/93281816/197360026-0928cd9c-a281-4ac2-99c9-5fc07455bb73.mov



