### PR TITLE
When one environment is present, selects first compute type; propagates compute type on rerun

### DIFF
--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -73,6 +73,7 @@ function RefillButton(props: {
       outputPath: props.job.output_prefix,
       environment: props.job.runtime_environment_name,
       runtimeEnvironmentParameters: props.job.runtime_environment_parameters,
+      computeType: props.job.compute_type,
       parameters: jobParameters
     };
 

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -90,7 +90,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       if (envList.length === 1) {
         props.handleModelChange({
           ...props.model,
-          environment: envList[0].name
+          environment: envList[0].name,
+          computeType: envList[0].compute_types?.[0]
         });
       }
     };

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -72,6 +72,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       inputFile: props.model.inputFile,
       outputPath: props.model.outputPrefix ?? '',
       environment: props.model.environment,
+      computeType: props.model.computeType,
       runtimeEnvironmentParameters: props.model.runtimeEnvironmentParameters,
       parameters: props.model.parameters,
       outputFormats: props.model.outputFormats


### PR DESCRIPTION
Fixes remaining tasks of #177.

When only one environment is present, selects the only environment and, if this environment has multiple compute types, selects the first compute type.

In the demo below, I have overridden the "get runtime environments" API to return only one environment with three compute types in it.

https://user-images.githubusercontent.com/93281816/197359247-65b86900-a5cf-401c-b767-be645ee7e3a5.mov


This change also propagates the compute type when the user reruns a job from the job list view or the job detail view.