### PR TITLE
Removes environment picker from UI when exactly one environment is present

### DIFF
--- a/src/components/environment-picker.tsx
+++ b/src/components/environment-picker.tsx
@@ -5,8 +5,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
-  SelectChangeEvent,
-  TextField
+  SelectChangeEvent
 } from '@mui/material';
 
 import { Scheduler } from '../handler';
@@ -21,7 +20,9 @@ export type EnvironmentPickerProps = {
   value: string;
 };
 
-export function EnvironmentPicker(props: EnvironmentPickerProps): JSX.Element {
+export function EnvironmentPicker(
+  props: EnvironmentPickerProps
+): JSX.Element | null {
   const trans = useTranslator('jupyterlab');
 
   if (props.environmentList.length === 0) {
@@ -30,15 +31,12 @@ export function EnvironmentPicker(props: EnvironmentPickerProps): JSX.Element {
 
   const labelId = `${props.id}-label`;
 
-  return props.environmentList.length === 1 ? (
-    <TextField
-      label={props.label}
-      variant="outlined"
-      value={props.value}
-      name={props.name}
-      InputProps={{ readOnly: true }}
-    />
-  ) : (
+  // If exactly one environment is present, do not display an environment UI element.
+  if (props.environmentList.length === 1) {
+    return null;
+  }
+
+  return (
     <FormControl>
       <InputLabel id={labelId}>{props.label}</InputLabel>
       <Select


### PR DESCRIPTION
Fixes #191. When multiple environments are present, we continue to show the environment picker:

![Screen Shot 2022-10-24 at 12 17 39 PM](https://user-images.githubusercontent.com/93281816/197609862-cb632648-a785-453f-810c-775b3b659b6c.png)

When one environment is present, we do not show the environment picker. We **still keep the environment selected** and we show output types and compute types (if present) for the environment.

The environment list is loaded asynchronously, so users will see a "Loading …" message followed by output types and/or compute types, without an environment picker. See video example below.

https://user-images.githubusercontent.com/93281816/197610029-1699b297-d489-4c12-a13f-b8a39eab9ab2.mov

