### PR TITLE
Adds default compute type to runtime env model, uses it

### DIFF
--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -24,7 +24,7 @@ class RuntimeEnvironment(BaseModel):
     output_formats: List[str]  # Supported output formats
     metadata: Optional[Dict[str, str]]  # Optional metadata
     compute_types: Optional[List[str]]
-    default_compute_type: Optional[str] # Should be a member of the compute_types list
+    default_compute_type: Optional[str]  # Should be a member of the compute_types list
 
     def __str__(self):
         return self.json()

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -24,6 +24,7 @@ class RuntimeEnvironment(BaseModel):
     output_formats: List[str]  # Supported output formats
     metadata: Optional[Dict[str, str]]  # Optional metadata
     compute_types: Optional[List[str]]
+    default_compute_type: Optional[str] # Should be a member of the compute_types list
 
     def __str__(self):
         return self.json()

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -466,6 +466,7 @@ export namespace Scheduler {
     output_formats: IOutputFormat[];
     metadata: { [key: string]: string };
     compute_types: string[] | null;
+    default_compute_type: string | null;
   }
 
   export interface IOutputFormat {

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -96,7 +96,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         if (
           envList[0].default_compute_type &&
           envList[0].compute_types &&
-          envList[0].default_compute_type in envList[0].compute_types
+          envList[0].compute_types.indexOf(envList[0].default_compute_type) >= 0
         ) {
           newComputeType = envList[0].default_compute_type;
         }
@@ -181,7 +181,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         envObj &&
         envObj.default_compute_type &&
         envObj.compute_types &&
-        envObj.default_compute_type in envObj.compute_types
+        envObj.compute_types.indexOf(envObj.default_compute_type) >= 0
       ) {
         newComputeType = envObj.default_compute_type;
       }

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -89,12 +89,22 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       const envList = await api.getRuntimeEnvironments();
       setEnvironmentList(envList);
       if (envList.length === 1) {
+        // If no default compute type is specified, show the first one by default
+        let newComputeType = envList[0].compute_types?.[0];
+
+        // Validate that the default compute type is in fact in the list
+        if (
+          envList[0].default_compute_type &&
+          envList[0].compute_types &&
+          envList[0].default_compute_type in envList[0].compute_types
+        ) {
+          newComputeType = envList[0].default_compute_type;
+        }
+
         props.handleModelChange({
           ...props.model,
           environment: envList[0].name,
-          // If no default compute type is specified, show the first one by default
-          computeType:
-            envList[0].default_compute_type || envList[0].compute_types?.[0]
+          computeType: newComputeType
         });
       }
     };
@@ -165,10 +175,20 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     // if setting the environment, default the compute type to its default value or its first value
     if (target.name === 'environment') {
       const envObj = environmentList.find(env => env.name === target.value);
+      // Validate that the default compute type is in fact in the list
+      let newComputeType = envObj?.compute_types?.[0];
+      if (
+        envObj &&
+        envObj.default_compute_type &&
+        envObj.compute_types &&
+        envObj.default_compute_type in envObj.compute_types
+      ) {
+        newComputeType = envObj.default_compute_type;
+      }
       props.handleModelChange({
         ...props.model,
         environment: target.value,
-        computeType: envObj?.default_compute_type || envObj?.compute_types?.[0]
+        computeType: newComputeType
       });
     } else {
       // otherwise, just set the model

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -178,10 +178,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       // Validate that the default compute type is in fact in the list
       let newComputeType = envObj?.compute_types?.[0];
       if (
-        envObj &&
-        envObj.default_compute_type &&
-        envObj.compute_types &&
-        envObj.compute_types.includes(envObj.default_compute_type)
+        envObj?.default_compute_type &&
+        envObj?.compute_types &&
+        envObj?.compute_types.includes(envObj?.default_compute_type)
       ) {
         newComputeType = envObj.default_compute_type;
       }

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -96,7 +96,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         if (
           envList[0].default_compute_type &&
           envList[0].compute_types &&
-          envList[0].compute_types.indexOf(envList[0].default_compute_type) >= 0
+          envList[0].compute_types.includes(envList[0].default_compute_type)
         ) {
           newComputeType = envList[0].default_compute_type;
         }
@@ -181,7 +181,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         envObj &&
         envObj.default_compute_type &&
         envObj.compute_types &&
-        envObj.compute_types.indexOf(envObj.default_compute_type) >= 0
+        envObj.compute_types.includes(envObj.default_compute_type)
       ) {
         newComputeType = envObj.default_compute_type;
       }

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -92,7 +92,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         props.handleModelChange({
           ...props.model,
           environment: envList[0].name,
-          computeType: envList[0].compute_types?.[0]
+          // If no default compute type is specified, show the first one by default
+          computeType:
+            envList[0].default_compute_type || envList[0].compute_types?.[0]
         });
       }
     };
@@ -160,13 +162,13 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   const handleSelectChange = (event: SelectChangeEvent<string>) => {
     const target = event.target;
 
-    // if setting the environment, default the compute type to its first value (if any are present)
+    // if setting the environment, default the compute type to its default value or its first value
     if (target.name === 'environment') {
       const envObj = environmentList.find(env => env.name === target.value);
       props.handleModelChange({
         ...props.model,
         environment: target.value,
-        computeType: envObj?.compute_types?.[0]
+        computeType: envObj?.default_compute_type || envObj?.compute_types?.[0]
       });
     } else {
       // otherwise, just set the model


### PR DESCRIPTION
Fixes #188. Modifies the backend Python code to add a `default_compute_type` compute type to the `RuntimeEnvironment` model. If a `default_compute_type` is present in the model returned by the Python backend, the front-end code will default to it when an environment is selected. If no default compute type is present in the model, the UI will continue to select the first compute type (see #187).

In the demo below, a custom handler creates three compute types, suffixed `-a`, `-b`, and `-c`, in that order. The default compute type ends in `-b`.

https://user-images.githubusercontent.com/93281816/197642760-53f186e3-9a34-4a1e-bdbd-719e3541a246.mov


