### PR TITLE
Support backends without `total_count` in list views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ dmypy.json
 
 # vs code
 .vscode
+
+# job outputs in local development env
+dev/jobs

--- a/dev/templates/1.ipynb
+++ b/dev/templates/1.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d986335d-177b-47dd-bb08-a4398e87a8ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/dev/templates/2.ipynb
+++ b/dev/templates/2.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d057221b-8a0c-4f5a-9cab-c8dbf15444e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/dev/templates/3.ipynb
+++ b/dev/templates/3.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11bc5156-32b0-454f-afff-d2d06f0f57b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(3)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -175,8 +175,8 @@ export function AdvancedTable<
           return trans.__('%1–%2 of %3', from, loadedRows, loadedRows);
         } else {
           return (
-            trans.__('%1–%2 of %3', from, to, loadedRows) +
-            (nextToken === undefined ? '' : '+')
+            trans.__('%1–%2 of %3', from, to,
+              loadedRows + (nextToken === undefined ? '' : '+'))
           );
         }
       } else {

--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -11,6 +11,7 @@ import Paper from '@mui/material/Paper';
 
 import { Scheduler } from '../../handler';
 import { AdvancedTableHeader } from './advanced-table-header';
+import { useTranslator } from '../../hooks';
 
 const PAGE_SIZE = 25;
 
@@ -75,6 +76,7 @@ export function AdvancedTable<
   const [page, setPage] = useState<number>(0);
   const [maxPage, setMaxPage] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);
+  const trans = useTranslator('jupyterlab');
   const theme = useTheme();
 
   const pageSize = props.pageSize ?? PAGE_SIZE;
@@ -168,20 +170,20 @@ export function AdvancedTable<
         const loadedRows = rows?.length ?? 0;
         if (onLastPage) {
           // for some reason `to` is set incorrectly on the last page in
-          // server-side pagination, so we need a custom template literal for
-          // this case.
-          return `${from}-${loadedRows} of ${loadedRows}`;
+          // server-side pagination, so we need to build the string differently
+          // in this case.
+          return trans.__('%1–%2 of %3', from, loadedRows, loadedRows);
         } else {
           return (
-            `${from}-${to} of ${loadedRows}` +
+            trans.__('%1–%2 of %3', from, to, loadedRows) +
             (nextToken === undefined ? '' : '+')
           );
         }
       } else {
-        return `${from}-${to} of ${count}`;
+        return trans.__('%1–%2 of %3', from, to, count);
       }
     },
-    [rows, onLastPage]
+    [rows, onLastPage, trans]
   );
 
   return (

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -460,7 +460,7 @@ export namespace Scheduler {
   export interface IListJobsResponse {
     jobs: IDescribeJob[];
     next_token?: string;
-    total_count: number;
+    total_count?: number;
   }
 
   export interface IListJobDefinitionsQuery {
@@ -472,7 +472,7 @@ export namespace Scheduler {
   export interface IListJobDefinitionsResponse {
     job_definitions: IDescribeJobDefinition[];
     next_token?: string;
-    total_count: number;
+    total_count?: number;
   }
 
   export interface IUpdateJob {

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -202,12 +202,10 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
           ))}
           {props.model.status === 'COMPLETED' && (
             <>
-              <FormLabel component="legend">
-                {trans.__('Job files')}
-              </FormLabel>
+              <FormLabel component="legend">{trans.__('Job files')}</FormLabel>
               {props.model.job_files.map(
                 jobFile =>
-                jobFile['file_path'] && (
+                  jobFile['file_path'] && (
                     <JobFile
                       jobFile={convertJsonToJobFile(jobFile)}
                       app={props.app}


### PR DESCRIPTION
- correctly renders row count label even when `total_count` is not implemented by the backend
- fixes seed script and uses real input files (ported from #175)
- fixes lint

## Expected behavior

- until last page is reached, the total row count should be rendered with a '+' to indicate more rows may be present
- upon reaching the last page, '+' should disappear and the next button should be disabled
- going back after reaching the last page should keep the '+' hidden as we now know the total count

## To reproduce

Run the seed script. It's intended to have JupyterLab served from `dev/`.

```
cd dev/
python seed.py
jupyter lab
```

Then change the body of `SchedulerService.getJobs()` in `handler.ts`:

```
    ...
    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
    // @ts-ignore
    delete data.total_count;
    return data as Scheduler.IListJobsResponse;
```

## Demo

https://user-images.githubusercontent.com/44106031/197866246-a83454e8-5549-4415-8f78-866043cb668c.mov

## Issues closed

- Closes #182.