### PR TITLE
Allow user to create a job with no output formats

### DIFF
--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -375,7 +375,7 @@ class Scheduler(BaseScheduler):
                     raise IdempotencyTokenError(model.idempotency_token)
 
             if not model.output_formats:
-                model.output_formats = ["ipynb"]
+                model.output_formats = []
 
             job = Job(**model.dict(exclude_none=True, exclude={"input_uri"}))
             session.add(job)


### PR DESCRIPTION
## Description

Allows a user to create a job with no output formats selected. As a result, if user chooses to download a file, only `Input` is downloaded.

Everything seems to work: both jobs created by users directly and jobs created by job definitions are being created successfully when output_formats  are set to []  with file downloaded being only Input. (cc @3coins )

Fixes #196 

## Preview

![create_job_no_input](https://user-images.githubusercontent.com/26686070/197892015-6a5065c0-5312-432f-8331-b8a7ac72eacf.gif)
