### PR TITLE
Refactors JobFileLink into its own function

### DIFF
--- a/src/components/job-file-link.tsx
+++ b/src/components/job-file-link.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { Scheduler } from '../handler';
+import { useTranslator } from '../hooks';
+
+import { JupyterFrontEnd } from '@jupyterlab/application';
+
+import { Link } from '@mui/material';
+
+export interface IJobFileLinkProps {
+  jobFile: Scheduler.IJobFile;
+  app: JupyterFrontEnd;
+}
+
+export function JobFileLink(props: IJobFileLinkProps): JSX.Element | null {
+  const trans = useTranslator('jupyterlab');
+
+  return (
+    <Link
+      key={props.jobFile.file_format}
+      href={`/lab/tree/${props.jobFile.file_path}`}
+      title={trans.__('Open "%1"', props.jobFile.file_path)}
+      onClick={(
+        e:
+          | React.MouseEvent<HTMLSpanElement, MouseEvent>
+          | React.MouseEvent<HTMLAnchorElement, MouseEvent>
+      ) => {
+        e.preventDefault();
+        props.app.commands.execute('docmanager:open', {
+          path: props.jobFile.file_path
+        });
+      }}
+      style={{ paddingRight: '1em' }}
+    >
+      {props.jobFile.display_name}
+    </Link>
+  );
+}

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -8,11 +8,12 @@ import IconButton from '@mui/material/IconButton';
 import { Stack, TableCell, TableRow } from '@mui/material';
 
 import { ConfirmDeleteIcon } from './confirm-delete-icon';
+import { JobFileLink } from './job-file-link';
 
+import { CommandIDs } from '..';
 import { Scheduler } from '../handler';
 import { useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
-import { CommandIDs } from '..';
 
 function StopButton(props: {
   job: Scheduler.IDescribeJob;
@@ -47,33 +48,19 @@ function Timestamp(props: { job: Scheduler.IDescribeJob }): JSX.Element | null {
 
 function JobFiles(props: {
   job: Scheduler.IDescribeJob;
-  openOnClick: (e: any, output_uri: string) => void;
+  app: JupyterFrontEnd;
 }): JSX.Element | null {
   if (props.job.status !== 'COMPLETED') {
     return null;
   }
 
-  const trans = useTranslator('jupyterlab');
-
   return (
     <>
-      {props.job.job_files.map(
-        ({ file_format, display_name, file_path = null }) => {
-          return (
-            file_path && (
-              <a
-                key={file_format}
-                href={`/lab/tree/${file_path}`}
-                title={trans.__('Open "%1"', file_path)}
-                onClick={e => props.openOnClick(e, file_path)}
-                style={{ paddingRight: '1em' }}
-              >
-                {display_name}
-              </a>
-            )
-          );
-        }
-      )}
+      {props.job.job_files.map(jobFile => {
+        return (
+          jobFile.file_path && <JobFileLink jobFile={jobFile} app={props.app} />
+        );
+      })}
     </>
   );
 }
@@ -125,13 +112,7 @@ export function buildJobRow(
       {!job.downloaded && job.status === 'COMPLETED' && (
         <DownloadFilesButton app={app} job={job} reload={reload} />
       )}
-      <JobFiles
-        job={job}
-        openOnClick={(e: Event, output_uri: string) => {
-          e.preventDefault();
-          app.commands.execute('docmanager:open', { path: output_uri });
-        }}
-      />
+      <JobFiles job={job} app={app} />
     </>,
     <Timestamp job={job} />,
     translateStatus(job.status),

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -1,16 +1,18 @@
 import React, { useState } from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
+
+import { ConfirmDeleteButton } from '../../components/confirm-delete-button';
+import { JobFileLink } from '../../components/job-file-link';
+import { Scheduler, SchedulerService } from '../../handler';
+import { useTranslator } from '../../hooks';
 import {
   ICreateJobModel,
   IJobDetailModel,
   JobsView,
   ListJobsView
 } from '../../model';
-import { useTranslator } from '../../hooks';
-import { Scheduler, SchedulerService } from '../../handler';
 import { Scheduler as SchedulerTokens } from '../../tokens';
-import { ConfirmDeleteButton } from '../../components/confirm-delete-button';
 
 import {
   Alert,
@@ -18,7 +20,6 @@ import {
   Card,
   CardContent,
   FormLabel,
-  Link,
   Stack,
   TextField,
   TextFieldProps
@@ -150,32 +151,6 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     ]
   ];
 
-  function JobFile(props: {
-    jobFile: Scheduler.IJobFile;
-    app: JupyterFrontEnd;
-  }) {
-    return (
-      <Link
-        key={props.jobFile.file_format}
-        href={`/lab/tree/${props.jobFile.file_path}`}
-        title={trans.__('Open "%1"', props.jobFile.file_path)}
-        onClick={(
-          e:
-            | React.MouseEvent<HTMLSpanElement, MouseEvent>
-            | React.MouseEvent<HTMLAnchorElement, MouseEvent>
-        ) => {
-          e.preventDefault();
-          props.app.commands.execute('docmanager:open', {
-            path: props.jobFile.file_path
-          });
-        }}
-        style={{ paddingRight: '1em' }}
-      >
-        {props.jobFile.display_name}
-      </Link>
-    );
-  }
-
   const convertJsonToJobFile = (jobFile: { [key: string]: string }) => {
     return {
       display_name: jobFile['display_name'],
@@ -202,13 +177,11 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
           ))}
           {props.model.status === 'COMPLETED' && (
             <>
-              <FormLabel component="legend">
-                {trans.__('Job files')}
-              </FormLabel>
+              <FormLabel component="legend">{trans.__('Job files')}</FormLabel>
               {props.model.job_files.map(
                 jobFile =>
-                jobFile['file_path'] && (
-                    <JobFile
+                  jobFile['file_path'] && (
+                    <JobFileLink
                       jobFile={convertJsonToJobFile(jobFile)}
                       app={props.app}
                     />


### PR DESCRIPTION
Creates a new component `JobFileLink` to generate a link to one job file. Uses it in the job details view and in the job row in list view for completed job runs. Appearance and behavior are consistent. Fixes #75.

List view:

![image](https://user-images.githubusercontent.com/93281816/197906943-71ac677e-b415-4013-8ac8-d6b94fd01749.png)

Detail view:

![image](https://user-images.githubusercontent.com/93281816/197906974-28168be6-190b-4bff-be5b-c3c130083aea.png)
