### PR TITLE
Creates directory based on job name, not based on timestamp

### DIFF
--- a/jupyter_scheduler/orm.py
+++ b/jupyter_scheduler/orm.py
@@ -8,7 +8,7 @@ from sqlalchemy import Boolean, Column, Integer, String, create_engine
 from sqlalchemy.orm import declarative_base, declarative_mixin, registry, sessionmaker
 
 from jupyter_scheduler.models import EmailNotifications, Status
-from jupyter_scheduler.utils import create_output_filename, get_utc_timestamp
+from jupyter_scheduler.utils import get_utc_timestamp
 
 Base = declarative_base()
 

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -32,7 +32,7 @@ from jupyter_scheduler.models import (
     UpdateJobDefinition,
 )
 from jupyter_scheduler.orm import Job, JobDefinition, create_session
-from jupyter_scheduler.utils import create_output_filename
+from jupyter_scheduler.utils import create_output_directory, create_output_filename
 
 
 class BaseScheduler(LoggingConfigurable):
@@ -310,7 +310,7 @@ class BaseScheduler(LoggingConfigurable):
         where all the job files will be downloaded
         from the staging location.
         """
-        output_dir_name = create_output_filename(model.input_filename, model.create_time)
+        output_dir_name = create_output_directory(model.input_filename, model.job_id)
         return os.path.join(self.root_dir, self.output_directory, output_dir_name)
 
 

--- a/jupyter_scheduler/utils.py
+++ b/jupyter_scheduler/utils.py
@@ -26,10 +26,12 @@ def timestamp_to_int(timestamp: str) -> int:
     dt = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
     return int(dt.timestamp())
 
+
 def create_output_directory(input_filename: str, job_id: str) -> str:
     """Creates output directory from input_filename and job_id"""
     basefilename = os.path.splitext(input_filename)[0]
     return f"{basefilename}-{job_id}"
+
 
 def create_output_filename(input_filename: str, create_time: int, output_format: str = None) -> str:
     """Creates output filename from input_filename, create_time and output_format"""

--- a/jupyter_scheduler/utils.py
+++ b/jupyter_scheduler/utils.py
@@ -26,9 +26,13 @@ def timestamp_to_int(timestamp: str) -> int:
     dt = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
     return int(dt.timestamp())
 
+def create_output_directory(input_filename: str, job_id: str) -> str:
+    """Creates output directory from input_filename and job_id"""
+    basefilename = os.path.splitext(input_filename)[0]
+    return f"{basefilename}-{job_id}"
 
 def create_output_filename(input_filename: str, create_time: int, output_format: str = None) -> str:
-    """Creates output filename from input_uri, create_time and output_format"""
+    """Creates output filename from input_filename, create_time and output_format"""
     basefilename = os.path.splitext(input_filename)[0]
     timestamp = datetime.fromtimestamp(create_time / 1e3).strftime("%Y-%m-%d-%I-%M%-S-%p")
     if output_format:

--- a/jupyter_scheduler/utils.py
+++ b/jupyter_scheduler/utils.py
@@ -36,7 +36,7 @@ def create_output_directory(input_filename: str, job_id: str) -> str:
 def create_output_filename(input_filename: str, create_time: int, output_format: str = None) -> str:
     """Creates output filename from input_filename, create_time and output_format"""
     basefilename = os.path.splitext(input_filename)[0]
-    timestamp = datetime.fromtimestamp(create_time / 1e3).strftime("%Y-%m-%d-%I-%M%-S-%p")
+    timestamp = datetime.fromtimestamp(create_time / 1e3).strftime("%Y-%m-%d-%I-%M-%S-%p")
     if output_format:
         return f"{basefilename}-{timestamp}.{output_format}"
     else:


### PR DESCRIPTION
Fixes #201.

Old file structure, using the filename "stem" and the run timestamp:

`jobs/plot-2022-10-26-12-0813-PM/plot.ipynb`

New file structure, using the filename stem and the job ID:

`jobs/plot-6d56ab09-da11-4599-a503-7c3b43c7e3e1/plot.ipynb`

This change also introduces a `-` delimiter between minutes and seconds above.