### PR TITLE
merge `ListJobsView` into `JobsView`, re-define `IAdvancedOptionsProps`

### DIFF
--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -5,7 +5,7 @@ import { FormLabel, Stack, TextField } from '@mui/material';
 import { Cluster } from './components/cluster';
 import { AddButton, DeleteButton } from './components/icon-buttons';
 import { useTranslator } from './hooks';
-import { ICreateJobModel, IJobDetailModel } from './model';
+import { JobsView } from './model';
 import { Scheduler } from './tokens';
 
 const AdvancedOptions = (
@@ -15,16 +15,20 @@ const AdvancedOptions = (
 
   const trans = useTranslator('jupyterlab');
 
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) =>
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (props.jobsView !== JobsView.CreateForm) {
+      return;
+    }
+
     props.handleModelChange({
-      // Only the create-job model can change, not the detail model
-      ...(props.model as ICreateJobModel),
+      ...props.model,
       [e.target.name]: e.target.value
     });
+  };
 
   const handleTagChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (props.jobsView !== 'CreateJob') {
-      return; // Read-only mode
+    if (props.jobsView !== JobsView.CreateForm) {
+      return;
     }
 
     const { name, value } = event.target;
@@ -38,24 +42,32 @@ const AdvancedOptions = (
     newTags[parseInt(tagIdxMatch[1])] = value;
 
     props.handleModelChange({
-      ...(props.model as ICreateJobModel),
+      ...props.model,
       tags: newTags
     });
   };
 
   const addTag = () => {
+    if (props.jobsView !== JobsView.CreateForm) {
+      return;
+    }
+
     const newTags = [...(props.model.tags ?? []), ''];
     props.handleModelChange({
-      ...(props.model as ICreateJobModel),
+      ...props.model,
       tags: newTags
     });
   };
 
   const deleteTag = (idx: number) => {
+    if (props.jobsView !== JobsView.CreateForm) {
+      return;
+    }
+
     const newTags = props.model.tags ?? [];
     newTags.splice(idx, 1);
     props.handleModelChange({
-      ...(props.model as ICreateJobModel),
+      ...props.model,
       tags: newTags
     });
   };
@@ -128,7 +140,7 @@ const AdvancedOptions = (
 
   // Tags look different when they're for display or for editing.
   const tagsDisplay: JSX.Element | null =
-    props.jobsView === 'CreateJob' ? createTags() : showTags();
+    props.jobsView === JobsView.CreateForm ? createTags() : showTags();
 
   // The idempotency token is only used for jobs, not for job definitions
   const idemTokenLabel = trans.__('Idempotency token');
@@ -136,23 +148,23 @@ const AdvancedOptions = (
   const idemTokenId = `${formPrefix}${idemTokenName}`;
   return (
     <Stack spacing={4}>
-      {props.jobsView === 'JobDetail' && 'idempotencyToken' in props.model && (
+      {props.jobsView === JobsView.JobDetail && (
         <TextField
           label={idemTokenLabel}
           variant="outlined"
-          value={(props.model as IJobDetailModel).idempotencyToken}
+          value={props.model.idempotencyToken}
           id={`${formPrefix}idempotencyToken`}
           name={idemTokenName}
           InputProps={{ readOnly: true }}
         />
       )}
-      {props.jobsView === 'CreateJob' &&
-        (props.model as ICreateJobModel).createType === 'Job' && (
+      {props.jobsView === JobsView.CreateForm &&
+        props.model.createType === 'Job' && (
           <TextField
             label={idemTokenLabel}
             variant="outlined"
             onChange={handleInputChange}
-            value={(props.model as ICreateJobModel).idempotencyToken}
+            value={props.model.idempotencyToken}
             id={idemTokenId}
             name={idemTokenName}
           />

--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -174,9 +174,11 @@ export function AdvancedTable<
           // in this case.
           return trans.__('%1–%2 of %3', from, loadedRows, loadedRows);
         } else {
-          return (
-            trans.__('%1–%2 of %3', from, to,
-              loadedRows + (nextToken === undefined ? '' : '+'))
+          return trans.__(
+            '%1–%2 of %3',
+            from,
+            to,
+            loadedRows + (nextToken === undefined ? '' : '+')
           );
         }
       } else {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { Contents } from '@jupyterlab/services';
 import { ITranslator } from '@jupyterlab/translation';
 
 import { SchedulerService } from './handler';
-import { IJobsModel, emptyCreateJobModel } from './model';
+import { IJobsModel, emptyCreateJobModel, JobsView } from './model';
 import { NotebookJobsPanel } from './notebook-jobs-panel';
 import {
   calendarAddOnIcon,
@@ -187,7 +187,7 @@ async function activatePlugin(
       newCreateModel.outputPath = getDirectoryFromPath(filePath) ?? '';
 
       await showJobsPanel({
-        jobsView: 'CreateJob',
+        jobsView: JobsView.CreateForm,
         createJobModel: newCreateModel
       });
     },
@@ -210,7 +210,7 @@ async function activatePlugin(
       newCreateModel.outputPath = getDirectoryFromPath(filePath) ?? '';
 
       await showJobsPanel({
-        jobsView: 'CreateJob',
+        jobsView: JobsView.CreateForm,
         createJobModel: newCreateModel
       });
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -257,4 +257,5 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   advancedOptions
 ];
 
+export { JobsView };
 export default plugins;

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -12,7 +12,7 @@ import {
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
-import { ICreateJobModel, IJobParameter, ListJobsView } from '../model';
+import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 
 import ErrorIcon from '@mui/icons-material/Error';
@@ -40,7 +40,9 @@ import cronstrue from 'cronstrue';
 export interface ICreateJobProps {
   model: ICreateJobModel;
   handleModelChange: (model: ICreateJobModel) => void;
-  showListView: (list: ListJobsView) => unknown;
+  showListView: (
+    list: JobsView.ListJobs | JobsView.ListJobDefinitions
+  ) => unknown;
   // Extension point: optional additional component
   advancedOptions: React.FunctionComponent<SchedulerTokens.IAdvancedOptionsProps>;
 }
@@ -632,7 +634,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       .createJob(jobOptions)
       .then(response => {
         // Switch to the list view with "Job List" active
-        props.showListView('Job');
+        props.showListView(JobsView.ListJobs);
       })
       .catch((error: Error) => {
         props.handleModelChange({
@@ -679,7 +681,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       .createJobDefinition(jobDefinitionOptions)
       .then(response => {
         // Switch to the list view with "Job Definition List" active
-        props.showListView('JobDefinition');
+        props.showListView(JobsView.ListJobDefinitions);
       })
       .catch((error: string) => {
         props.handleModelChange({
@@ -824,11 +826,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             </AccordionSummary>
             <AccordionDetails id={`${formPrefix}create-panel-content`}>
               <props.advancedOptions
-                jobsView={'CreateJob'}
+                jobsView={JobsView.CreateForm}
                 model={props.model}
-                handleModelChange={model =>
-                  props.handleModelChange(model as ICreateJobModel)
-                }
+                handleModelChange={model => props.handleModelChange(model)}
                 errors={advancedOptionsErrors}
                 handleErrorsChange={setAdvancedOptionsErrors}
               />
@@ -856,7 +856,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
               <>
                 <Button
                   variant="outlined"
-                  onClick={e => props.showListView('Job')}
+                  onClick={e => props.showListView(JobsView.ListJobs)}
                 >
                   {trans.__('Cancel')}
                 </Button>

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -826,7 +826,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
               <props.advancedOptions
                 jobsView={'CreateJob'}
                 model={props.model}
-                handleModelChange={props.handleModelChange}
+                handleModelChange={model =>
+                  props.handleModelChange(model as ICreateJobModel)
+                }
                 errors={advancedOptionsErrors}
                 handleErrorsChange={setAdvancedOptionsErrors}
               />

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -828,7 +828,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
               <props.advancedOptions
                 jobsView={JobsView.CreateForm}
                 model={props.model}
-                handleModelChange={model => props.handleModelChange(model)}
+                handleModelChange={props.handleModelChange}
                 errors={advancedOptionsErrors}
                 handleErrorsChange={setAdvancedOptionsErrors}
               />

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -1,10 +1,5 @@
 import React, { useMemo } from 'react';
-import {
-  IJobDefinitionModel,
-  JobsView,
-  ListJobsView,
-  ICreateJobModel
-} from '../../model';
+import { IJobDefinitionModel, JobsView, ICreateJobModel } from '../../model';
 import { useTranslator } from '../../hooks';
 import { TextFieldStyled, timestampLocalize } from './job-detail';
 import { SchedulerService } from '../../handler';
@@ -28,7 +23,6 @@ export interface IJobDefinitionProps {
   model: IJobDefinitionModel;
   refresh: () => void;
   setJobsView: (view: JobsView) => void;
-  setListJobsView: (view: ListJobsView) => void;
   showJobDetail: (jobId: string) => void;
   showCreateJob: (state: ICreateJobModel) => void;
   advancedOptions: React.FunctionComponent<SchedulerTokens.IAdvancedOptionsProps>;
@@ -41,8 +35,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
 
   const handleDeleteJobDefinition = async () => {
     await ss.deleteJobDefinition(props.model.definitionId ?? '');
-    props.setJobsView('ListJobs');
-    props.setListJobsView('JobDefinition');
+    props.setJobsView(JobsView.ListJobDefinitions);
   };
 
   const pauseJobDefinition = async () => {
@@ -159,7 +152,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
             {trans.__('Advanced Options')}
           </FormLabel>
           <props.advancedOptions
-            jobsView={'JobDetail'}
+            jobsView={JobsView.JobDefinitionDetail}
             model={props.model}
             handleModelChange={(_: any) => {
               return;

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -59,7 +59,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   const handleDeleteJob = async () => {
     await ss.deleteJob(props.model.jobId ?? '');
-    props.setJobsView(JobsView.JobDetail);
+    props.setJobsView(JobsView.ListJobs);
   };
 
   const handleStopJob = async () => {

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -6,12 +6,7 @@ import { ConfirmDeleteButton } from '../../components/confirm-delete-button';
 import { JobFileLink } from '../../components/job-file-link';
 import { Scheduler, SchedulerService } from '../../handler';
 import { useTranslator } from '../../hooks';
-import {
-  ICreateJobModel,
-  IJobDetailModel,
-  JobsView,
-  ListJobsView
-} from '../../model';
+import { ICreateJobModel, IJobDetailModel, JobsView } from '../../model';
 import { Scheduler as SchedulerTokens } from '../../tokens';
 
 import {
@@ -40,7 +35,6 @@ export interface IJobDetailProps {
   handleModelChange: () => Promise<void>;
   setCreateJobModel: (createModel: ICreateJobModel) => void;
   setJobsView: (view: JobsView) => void;
-  setListJobsView: (view: ListJobsView) => void;
   // Extension point: optional additional component
   advancedOptions: React.FunctionComponent<SchedulerTokens.IAdvancedOptionsProps>;
 }
@@ -65,8 +59,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   const handleDeleteJob = async () => {
     await ss.deleteJob(props.model.jobId ?? '');
-    props.setJobsView('ListJobs');
-    props.setListJobsView('Job');
+    props.setJobsView(JobsView.JobDetail);
   };
 
   const handleStopJob = async () => {
@@ -233,7 +226,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             {trans.__('Advanced Options')}
           </FormLabel>
           <props.advancedOptions
-            jobsView={'JobDetail'}
+            jobsView={JobsView.JobDetail}
             model={props.model}
             handleModelChange={(_: any) => {
               return;

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -11,7 +11,7 @@ import { Heading } from '../components/heading';
 import { useTranslator } from '../hooks';
 import { buildJobRow } from '../components/job-row';
 import { buildJobDefinitionRow } from '../components/job-definition-row';
-import { ICreateJobModel, IListJobsModel, ListJobsView } from '../model';
+import { ICreateJobModel, JobsView } from '../model';
 import { Scheduler, SchedulerService } from '../handler';
 import { Cluster } from '../components/cluster';
 import {
@@ -271,8 +271,8 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
 
 export interface IListJobsProps {
   app: JupyterFrontEnd;
-  model: IListJobsModel;
-  handleModelChange: (model: IListJobsModel) => void;
+  listView: JobsView.ListJobs | JobsView.ListJobDefinitions;
+  showListView: (view: JobsView.ListJobs | JobsView.ListJobDefinitions) => void;
   showCreateJob: (newModel: ICreateJobModel) => void;
   showJobDetail: (jobId: string) => void;
   showJobDefinitionDetail: (jobDefId: string) => void;
@@ -287,24 +287,24 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
     [trans]
   );
 
-  const changeTab = (newTab: ListJobsView) => {
-    const newModel: IListJobsModel = props.model;
-    newModel.listJobsView = newTab;
-    props.handleModelChange(newModel);
-  };
-
   // Retrieve the initial jobs list
   return (
     <Box sx={{ p: 4 }} style={{ height: '100%', boxSizing: 'border-box' }}>
       <Stack spacing={3} style={{ height: '100%' }}>
         <Tabs
-          value={props.model.listJobsView}
-          onChange={(_, newTab) => changeTab(newTab)}
+          value={props.listView}
+          onChange={(
+            _,
+            newTab: JobsView.ListJobs | JobsView.ListJobDefinitions
+          ) => props.showListView(newTab)}
         >
-          <Tab label={jobsHeader} value="Job" />
-          <Tab label={jobDefinitionsHeader} value="JobDefinition" />
+          <Tab label={jobsHeader} value={JobsView.ListJobs} />
+          <Tab
+            label={jobDefinitionsHeader}
+            value={JobsView.ListJobDefinitions}
+          />
         </Tabs>
-        {props.model.listJobsView === 'Job' && (
+        {props.listView === JobsView.ListJobs && (
           <>
             <Heading level={1}>{jobsHeader}</Heading>
             <ListJobsTable
@@ -314,7 +314,7 @@ export function NotebookJobsList(props: IListJobsProps): JSX.Element {
             />
           </>
         )}
-        {props.model.listJobsView === 'JobDefinition' && (
+        {props.listView === JobsView.ListJobDefinitions && (
           <>
             <Heading level={1}>{jobDefinitionsHeader}</Heading>
             <ListJobDefinitionsTable

--- a/src/model.ts
+++ b/src/model.ts
@@ -8,7 +8,8 @@ import { VDomModel } from '@jupyterlab/apputils';
  */
 
 export enum JobsView {
-  CreateForm,
+  // assignment ensures any enum value is always truthy
+  CreateForm = 1,
   ListJobs,
   ListJobDefinitions,
   JobDetail,

--- a/src/model.ts
+++ b/src/model.ts
@@ -7,8 +7,13 @@ import { VDomModel } from '@jupyterlab/apputils';
  * Top-level models
  */
 
-export type JobsView = 'CreateJob' | 'ListJobs' | 'JobDetail';
-export type ListJobsView = 'Job' | 'JobDefinition';
+export enum JobsView {
+  CreateForm,
+  ListJobs,
+  ListJobDefinitions,
+  JobDetail,
+  JobDefinitionDetail
+}
 
 export type IJobParameter = {
   name: string;
@@ -74,24 +79,21 @@ export function emptyCreateJobModel(): ICreateJobModel {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IListJobsModel extends PartialJSONObject {
-  listJobsView: ListJobsView;
+  /* reserved */
 }
 
 export function emptyListJobsModel(): IListJobsModel {
-  return {
-    listJobsView: 'Job'
-  };
+  return {};
 }
 
 export interface IDetailViewModel extends PartialJSONObject {
-  detailType: ListJobsView;
   id: string;
 }
 
 export function emptyDetailViewModel(): IDetailViewModel {
   return {
-    detailType: 'Job',
     id: ''
   };
 }
@@ -103,14 +105,8 @@ export interface IJobsModel extends PartialJSONObject {
   jobDetailModel?: IDetailViewModel;
 }
 
-export function emptyJobsModel(): IJobsModel {
-  return {
-    jobsView: 'CreateJob'
-  };
-}
-
 export class JobsModel extends VDomModel {
-  private _jobsView: JobsView = 'ListJobs';
+  private _jobsView: JobsView = JobsView.ListJobs;
   private _createJobModel: ICreateJobModel;
   private _listJobsModel: IListJobsModel;
   private _jobDetailModel: IDetailViewModel;
@@ -124,7 +120,7 @@ export class JobsModel extends VDomModel {
 
   constructor(options: IJobsModelOptions) {
     super();
-    this._jobsView = 'ListJobs';
+    this._jobsView = JobsView.ListJobs;
     this._createJobModel = emptyCreateJobModel();
     this._listJobsModel = emptyListJobsModel();
     this._jobDetailModel = emptyDetailViewModel();
@@ -138,6 +134,7 @@ export class JobsModel extends VDomModel {
 
   set jobsView(view: JobsView) {
     this._jobsView = view;
+    this._onModelUpdate?.();
     this.stateChanged.emit(void 0);
   }
 
@@ -190,7 +187,7 @@ export class JobsModel extends VDomModel {
   }
 
   fromJson(data: IJobsModel): void {
-    this._jobsView = data.jobsView ?? 'ListJobs';
+    this._jobsView = data.jobsView ?? JobsView.ListJobs;
     this._createJobModel = data.createJobModel ?? emptyCreateJobModel();
     this._listJobsModel = data.listJobsModel ?? emptyListJobsModel();
     this._jobDetailModel = data.jobDetailModel ?? emptyDetailViewModel();

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -11,7 +11,7 @@ import { calendarMonthIcon } from './components/icons';
 import TranslatorContext from './context';
 import { CreateJob } from './mainviews/create-job';
 import { NotebookJobsList } from './mainviews/list-jobs';
-import { ICreateJobModel, JobsModel, ListJobsView } from './model';
+import { ICreateJobModel, JobsModel, JobsView } from './model';
 import { getJupyterLabTheme } from './theme-provider';
 import { Scheduler } from './tokens';
 import { DetailView } from './mainviews/detail-view';
@@ -49,33 +49,30 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     this.node.setAttribute('aria-label', trans.__('Notebook Jobs'));
   }
 
-  showListView(list: ListJobsView): void {
-    this.model.listJobsModel.listJobsView = list;
-    this.model.jobsView = 'ListJobs';
+  showListView(view: JobsView.ListJobs | JobsView.ListJobDefinitions): void {
+    this.model.jobsView = view;
   }
 
   showDetailView(jobId: string): void {
-    this.model.jobsView = 'JobDetail';
-    this.model.jobDetailModel.detailType = 'Job';
+    this.model.jobsView = JobsView.JobDetail;
     this.model.jobDetailModel.id = jobId;
   }
 
   showJobDefinitionDetail(jobDefId: string): void {
-    this.model.jobsView = 'JobDetail';
-    this.model.jobDetailModel.detailType = 'JobDefinition';
+    this.model.jobsView = JobsView.JobDefinitionDetail;
     this.model.jobDetailModel.id = jobDefId;
   }
 
   render(): JSX.Element {
     const showCreateJob = (newModel: ICreateJobModel) => {
       this.model.createJobModel = newModel;
-      this.model.jobsView = 'CreateJob';
+      this.model.jobsView = JobsView.CreateForm;
     };
 
     return (
       <ThemeProvider theme={getJupyterLabTheme()}>
         <TranslatorContext.Provider value={this._translator}>
-          {this.model.jobsView === 'CreateJob' && (
+          {this.model.jobsView === JobsView.CreateForm && (
             <CreateJob
               key={this.model.createJobModel.key}
               model={this.model.createJobModel}
@@ -86,29 +83,27 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
               advancedOptions={this._advancedOptions}
             />
           )}
-          {this.model.jobsView === 'ListJobs' && (
+          {(this.model.jobsView === JobsView.ListJobs ||
+            this.model.jobsView === JobsView.ListJobDefinitions) && (
             <NotebookJobsList
               app={this._app}
-              model={this.model.listJobsModel}
-              handleModelChange={newModel =>
-                (this.model.listJobsModel = newModel)
-              }
+              listView={this.model.jobsView}
+              showListView={this.showListView.bind(this)}
               showCreateJob={showCreateJob}
               showJobDetail={this.showDetailView.bind(this)}
               showJobDefinitionDetail={this.showJobDefinitionDetail.bind(this)}
             />
           )}
-          {this.model.jobsView === 'JobDetail' && (
+          {(this.model.jobsView === JobsView.JobDetail ||
+            this.model.jobsView === JobsView.JobDefinitionDetail) && (
             <DetailView
               app={this._app}
               model={this.model.jobDetailModel}
               setCreateJobModel={newModel =>
                 (this.model.createJobModel = newModel)
               }
+              jobsView={this.model.jobsView}
               setJobsView={view => (this.model.jobsView = view)}
-              setListJobsView={view => {
-                this.model.listJobsModel.listJobsView = view;
-              }}
               showCreateJob={showCreateJob}
               showJobDetail={this.showDetailView.bind(this)}
               advancedOptions={this._advancedOptions}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -11,15 +11,34 @@ export namespace Scheduler {
 
   export type ErrorsType = { [key: string]: string };
 
-  type ModelType = ICreateJobModel | IJobDetailModel | IJobDefinitionModel;
-
-  export interface IAdvancedOptionsProps {
-    jobsView: JobsView;
-    model: ModelType;
-    handleModelChange: (model: ModelType) => void;
+  interface IAdvancedOptionsSharedProps {
     errors: ErrorsType;
     handleErrorsChange: (errors: ErrorsType) => void;
   }
+
+  interface IAdvancedOptionsCreateProps extends IAdvancedOptionsSharedProps {
+    jobsView: JobsView.CreateForm;
+    model: ICreateJobModel;
+    handleModelChange: (model: ICreateJobModel) => void;
+  }
+
+  interface IAdvancedOptionsJobDetailProps extends IAdvancedOptionsSharedProps {
+    jobsView: JobsView.JobDetail;
+    model: IJobDetailModel;
+    handleModelChange: (model: IJobDetailModel) => void;
+  }
+
+  interface IAdvancedOptionsJobDefinitionDetailProps
+    extends IAdvancedOptionsSharedProps {
+    jobsView: JobsView.JobDefinitionDetail;
+    model: IJobDefinitionModel;
+    handleModelChange: (model: IJobDefinitionModel) => void;
+  }
+
+  export type IAdvancedOptionsProps =
+    | IAdvancedOptionsCreateProps
+    | IAdvancedOptionsJobDetailProps
+    | IAdvancedOptionsJobDefinitionDetailProps;
 
   export type IAdvancedOptions = React.FC<IAdvancedOptionsProps>;
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -11,10 +11,12 @@ export namespace Scheduler {
 
   export type ErrorsType = { [key: string]: string };
 
+  type ModelType = ICreateJobModel | IJobDetailModel | IJobDefinitionModel;
+
   export interface IAdvancedOptionsProps {
     jobsView: JobsView;
-    model: ICreateJobModel | IJobDetailModel | IJobDefinitionModel;
-    handleModelChange: (model: ICreateJobModel) => void;
+    model: ModelType;
+    handleModelChange: (model: ModelType) => void;
     errors: ErrorsType;
     handleErrorsChange: (errors: ErrorsType) => void;
   }


### PR DESCRIPTION
## Description

- Merges `ListJobsView` type into `JobsView` type
  - Previously, the variables controlling "which page to render" was split up into three places. Let `model` refer to an instance of `JobsModel`.
  - `model.jobsView`, `model.listJobsModel.listJobsView`, and `model.jobDetailModel.detailType`
- Makes `JobsView` an enum
- Exports `JobsView` enum from package index. i.e. `import { JobsView } from '@jupyterlab/scheduler'`.
- Refactors `IAdvancedOptionsProps` to be a union of types discriminated by the `jobsView` property, which provides the following guarantees:
  - developers writing advanced options form extensions can always narrow the type of `model` to the correct union member by discriminating unions via a simple `if` statement.
    ```ts
    if (props.jobsView === JobsView.CreateForm) {
      // model is guaranteed to be of type `CreateJobModel` here.
      ...
    }
    ```
  - `model` will always have the same type as the argument accepted by `handleModelChange()`, and thus avoids the need for ugly type casting when calling `props.handleModelChange()`.

## Issues closed

- Fixes #205 
- Fixes #105
