### PR TITLE
Add (readonly?: boolean) prop to AdvancedOptions, use LabeledValue for Idempotency Token and Tags if readonly is set

### DIFF
--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -7,6 +7,7 @@ import { AddButton, DeleteButton } from './components/icon-buttons';
 import { useTranslator } from './hooks';
 import { JobsView } from './model';
 import { Scheduler } from './tokens';
+import { LabeledValue } from './components/labeled-value';
 
 const AdvancedOptions = (
   props: Scheduler.IAdvancedOptionsProps
@@ -124,14 +125,11 @@ const AdvancedOptions = (
     return (
       <Stack spacing={2}>
         {tags.map((tag, idx) => (
-          <TextField
+          <LabeledValue
             label={trans.__('Tag %1', idx + 1)}
             id={`${formPrefix}tag-${idx}`}
             name={`tag-${idx}`}
             value={tag}
-            InputProps={{
-              readOnly: true
-            }}
           />
         ))}
       </Stack>
@@ -149,13 +147,11 @@ const AdvancedOptions = (
   return (
     <Stack spacing={4}>
       {props.jobsView === JobsView.JobDetail && (
-        <TextField
+        <LabeledValue
           label={idemTokenLabel}
-          variant="outlined"
           value={props.model.idempotencyToken}
           id={`${formPrefix}idempotencyToken`}
           name={idemTokenName}
-          InputProps={{ readOnly: true }}
         />
       )}
       {props.jobsView === JobsView.CreateForm &&

--- a/src/advanced-options.tsx
+++ b/src/advanced-options.tsx
@@ -146,7 +146,7 @@ const AdvancedOptions = (
   const idemTokenId = `${formPrefix}${idemTokenName}`;
   return (
     <Stack spacing={4}>
-      {props.jobsView === JobsView.JobDetail && (
+      {props.readonly && props.jobsView === JobsView.JobDetail && (
         <LabeledValue
           label={idemTokenLabel}
           value={props.model.idempotencyToken}

--- a/src/components/labeled-value.tsx
+++ b/src/components/labeled-value.tsx
@@ -9,6 +9,7 @@ export interface ILabeledValueProps {
     startAdornment: JSX.Element;
   };
   helperText?: string;
+  name?: string;
 }
 
 export const LabeledValue = (props: ILabeledValueProps): JSX.Element => {

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -158,6 +158,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
             handleErrorsChange={(_: any) => {
               return;
             }}
+            readonly
           />
         </Stack>
       </CardContent>

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -240,6 +240,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             handleErrorsChange={(_: any) => {
               return;
             }}
+            readonly
           />
         </Stack>
       </CardContent>

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -14,6 +14,7 @@ export namespace Scheduler {
   interface IAdvancedOptionsSharedProps {
     errors: ErrorsType;
     handleErrorsChange: (errors: ErrorsType) => void;
+    readonly?: boolean;
   }
 
   interface IAdvancedOptionsCreateProps extends IAdvancedOptionsSharedProps {


### PR DESCRIPTION
## Description 

- Add `readonly?: boolean` to `IAdvancedOptionsSharedProps` interface s.t. `IAdvancedOptionsSharedProps` component could be aware if user expects fields to be editable without coupling itself to implementation of the particular view
- Render Idempotency Token and Tags as `LabeledValue` instead of `TextField` in `advancedOptions` if `readonly` prop is set 
- Set `readonly` (truthy) prop to `advancedOptions` in `JobDetail` and `JobDefinitionDetail` 

Fixes #165 
CC @awaisabir on this non-breaking UI change to keep him in the loop

## Preview
![readonly_adbanced_options](https://user-images.githubusercontent.com/26686070/198744633-e9189f8f-992a-4680-a24e-f57c4260bd36.gif)

