### PR TITLE
Create job from job definition - UI

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -184,7 +184,7 @@ export class SchedulerService {
     return data as Scheduler.ICreateJobResponse;
   }
 
-  async createJobFromJobDefinition(
+  async createJobFromDefinition(
     definition_id: string,
     parameters: { [key: string]: any }
   ): Promise<Scheduler.ICreateJobResponse> {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -186,7 +186,7 @@ export class SchedulerService {
 
   async createJobFromDefinition(
     definition_id: string,
-    parameters: { [key: string]: any }
+    model: Scheduler.ICreateJobFromDefinition
   ): Promise<Scheduler.ICreateJobResponse> {
     let data;
     try {
@@ -195,7 +195,7 @@ export class SchedulerService {
         `job_definitions/${definition_id}/jobs`,
         {
           method: 'POST',
-          body: JSON.stringify(parameters)
+          body: JSON.stringify(model)
         }
       );
     } catch (e: any) {
@@ -407,6 +407,10 @@ export namespace Scheduler {
     output_filename_template?: string;
     output_formats?: string[];
     compute_type?: string;
+  }
+
+  export interface ICreateJobFromDefinition {
+    parameters?: Parameters;
   }
 
   export type Status =

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -184,6 +184,26 @@ export class SchedulerService {
     return data as Scheduler.ICreateJobResponse;
   }
 
+  async createJobFromJobDefinition(
+    definition_id: string,
+    parameters: { [key: string]: any }
+  ): Promise<Scheduler.ICreateJobResponse> {
+    let data;
+    try {
+      data = await requestAPI(
+        this.serverSettings,
+        `job_definitions/${definition_id}/jobs`,
+        {
+          method: 'POST',
+          body: JSON.stringify(parameters)
+        }
+      );
+    } catch (e: any) {
+      return Promise.reject(e);
+    }
+    return data as Scheduler.ICreateJobResponse;
+  }
+
   async setJobStatus(job_id: string, status: Scheduler.Status): Promise<void> {
     try {
       await requestAPI(this.serverSettings, `jobs/${job_id}`, {

--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -3,7 +3,7 @@ import React, { ChangeEvent, useMemo, useState } from 'react';
 import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
 import { ParametersPicker } from '../components/parameters-picker';
-import { SchedulerService } from '../handler';
+import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
@@ -118,9 +118,11 @@ export function CreateJobFromDefinition(
       return;
     }
 
-    let parameters = {};
+    const createJobFromDefinitionModel: Scheduler.ICreateJobFromDefinition = {};
     if (props.model.parameters !== undefined) {
-      parameters = serializeParameters(props.model.parameters);
+      createJobFromDefinitionModel.parameters = serializeParameters(
+        props.model.parameters
+      );
     }
 
     props.handleModelChange({
@@ -130,7 +132,10 @@ export function CreateJobFromDefinition(
     });
 
     api
-      .createJobFromDefinition(props.model.jobDefinitionId, parameters)
+      .createJobFromDefinition(
+        props.model.jobDefinitionId,
+        createJobFromDefinitionModel
+      )
       .then(response => {
         // Switch to the list view with "Job List" active
         props.showListView(JobsView.ListJobs);

--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -14,7 +14,7 @@ import { Box, Stack } from '@mui/system';
 
 import { LabeledValue } from '../components/labeled-value';
 
-export interface ICreateJobFromJobDefinitionProps {
+export interface ICreateJobFromDefinitionProps {
   model: ICreateJobModel;
   handleModelChange: (model: ICreateJobModel) => void;
   showListView: (
@@ -44,8 +44,8 @@ function parameterValueMatch(elementName: string): number | null {
   return parseInt(parameterValueMatch[1]);
 }
 
-export function CreateJobFromJobDefinition(
-  props: ICreateJobFromJobDefinitionProps
+export function CreateJobFromDefinition(
+  props: ICreateJobFromDefinitionProps
 ): JSX.Element {
   const trans = useTranslator('jupyterlab');
 
@@ -130,7 +130,7 @@ export function CreateJobFromJobDefinition(
     });
 
     api
-      .createJobFromJobDefinition(props.model.jobDefinitionId, parameters)
+      .createJobFromDefinition(props.model.jobDefinitionId, parameters)
       .then(response => {
         // Switch to the list view with "Job List" active
         props.showListView(JobsView.ListJobs);

--- a/src/mainviews/create-job-from-job-definition.tsx
+++ b/src/mainviews/create-job-from-job-definition.tsx
@@ -8,19 +8,9 @@ import { useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Alert,
-  Button,
-  CircularProgress,
-  FormLabel
-} from '@mui/material';
+import { Alert, Button, CircularProgress } from '@mui/material';
 
 import { Box, Stack } from '@mui/system';
-
-import { caretDownIcon } from '@jupyterlab/ui-components';
 
 import { LabeledValue } from '../components/labeled-value';
 
@@ -59,16 +49,10 @@ export function CreateJobFromJobDefinition(
 ): JSX.Element {
   const trans = useTranslator('jupyterlab');
 
-  const [advancedOptionsExpanded, setAdvancedOptionsExpanded] =
-    useState<boolean>(false);
-
   // A mapping from input names to error messages.
   // If an error message is "truthy" (i.e., not null or ''), we should display the
   // input in an error state and block form submission.
   const [errors, setErrors] = useState<SchedulerTokens.ErrorsType>({});
-  // Errors for the advanced options
-  const [advancedOptionsErrors, setAdvancedOptionsErrors] =
-    useState<SchedulerTokens.ErrorsType>({});
 
   const api = useMemo(() => new SchedulerService({}), []);
 
@@ -93,15 +77,6 @@ export function CreateJobFromJobDefinition(
       const name = target.name;
       props.handleModelChange({ ...props.model, [name]: value });
     }
-  };
-
-  const submitForm = async (event: React.MouseEvent) => {
-    // Collapse the "Advanced Options" section so that users can see
-    // errors at the top, if there are any.
-    setAdvancedOptionsExpanded(false);
-
-    // This form only supports creating a job, not a job definition.
-    return submitCreateJobRequest(event);
   };
 
   // Convert an array of parameters (as used for display) to an object
@@ -241,32 +216,6 @@ export function CreateJobFromJobDefinition(
             errors={errors}
             handleErrorsChange={setErrors}
           />
-          <Accordion
-            defaultExpanded={false}
-            expanded={advancedOptionsExpanded}
-            onChange={(_: React.SyntheticEvent, expanded: boolean) =>
-              setAdvancedOptionsExpanded(expanded)
-            }
-          >
-            <AccordionSummary
-              expandIcon={<caretDownIcon.react />}
-              aria-controls="panel-content"
-              id="panel-header"
-            >
-              <FormLabel component="legend">
-                {trans.__('Additional options')}
-              </FormLabel>
-            </AccordionSummary>
-            <AccordionDetails id={`${formPrefix}create-panel-content`}>
-              <props.advancedOptions
-                jobsView={JobsView.CreateForm}
-                model={props.model}
-                handleModelChange={props.handleModelChange}
-                errors={advancedOptionsErrors}
-                handleErrorsChange={setAdvancedOptionsErrors}
-              />
-            </AccordionDetails>
-          </Accordion>
           <Cluster gap={3} justifyContent="flex-end">
             {props.model.createInProgress || (
               <>
@@ -280,7 +229,7 @@ export function CreateJobFromJobDefinition(
                 <Button
                   variant="contained"
                   onClick={(e: React.MouseEvent) => {
-                    submitForm(e);
+                    submitCreateJobRequest(e);
                     return false;
                   }}
                   disabled={anyErrors}

--- a/src/mainviews/create-job-from-job-definition.tsx
+++ b/src/mainviews/create-job-from-job-definition.tsx
@@ -1,0 +1,304 @@
+import React, { ChangeEvent, useMemo, useState } from 'react';
+
+import { Heading } from '../components/heading';
+import { Cluster } from '../components/cluster';
+import { ParametersPicker } from '../components/parameters-picker';
+import { Scheduler, SchedulerService } from '../handler';
+import { useTranslator } from '../hooks';
+import { ICreateJobModel, IJobParameter, JobsView } from '../model';
+import { Scheduler as SchedulerTokens } from '../tokens';
+
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Button,
+  CircularProgress,
+  FormLabel
+} from '@mui/material';
+
+import { Box, Stack } from '@mui/system';
+
+import { caretDownIcon } from '@jupyterlab/ui-components';
+
+import { LabeledValue } from '../components/labeled-value';
+
+export interface ICreateJobFromJobDefinitionProps {
+  model: ICreateJobModel;
+  handleModelChange: (model: ICreateJobModel) => void;
+  showListView: (
+    list: JobsView.ListJobs | JobsView.ListJobDefinitions
+  ) => unknown;
+  // Extension point: optional additional component
+  advancedOptions: React.FunctionComponent<SchedulerTokens.IAdvancedOptionsProps>;
+}
+
+function parameterNameMatch(elementName: string): number | null {
+  const parameterNameMatch = elementName.match(/^parameter-(\d+)-name$/);
+
+  if (parameterNameMatch === null) {
+    return null;
+  }
+
+  return parseInt(parameterNameMatch[1]);
+}
+
+function parameterValueMatch(elementName: string): number | null {
+  const parameterValueMatch = elementName.match(/^parameter-(\d+)-value$/);
+
+  if (parameterValueMatch === null) {
+    return null;
+  }
+
+  return parseInt(parameterValueMatch[1]);
+}
+
+export function CreateJobFromJobDefinition(
+  props: ICreateJobFromJobDefinitionProps
+): JSX.Element {
+  const trans = useTranslator('jupyterlab');
+
+  const [advancedOptionsExpanded, setAdvancedOptionsExpanded] =
+    useState<boolean>(false);
+
+  // A mapping from input names to error messages.
+  // If an error message is "truthy" (i.e., not null or ''), we should display the
+  // input in an error state and block form submission.
+  const [errors, setErrors] = useState<SchedulerTokens.ErrorsType>({});
+  // Errors for the advanced options
+  const [advancedOptionsErrors, setAdvancedOptionsErrors] =
+    useState<SchedulerTokens.ErrorsType>({});
+
+  const api = useMemo(() => new SchedulerService({}), []);
+
+  // Advanced options are not editable; do not block submission on them
+  const anyErrors = Object.keys(errors).some(key => !!errors[key]);
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const target = event.target;
+
+    const parameterNameIdx = parameterNameMatch(target.name);
+    const parameterValueIdx = parameterValueMatch(target.name);
+    const newParams = props.model.parameters || [];
+
+    if (parameterNameIdx !== null) {
+      newParams[parameterNameIdx].name = target.value;
+      props.handleModelChange({ ...props.model, parameters: newParams });
+    } else if (parameterValueIdx !== null) {
+      newParams[parameterValueIdx].value = target.value;
+      props.handleModelChange({ ...props.model, parameters: newParams });
+    } else {
+      const value = target.type === 'checkbox' ? target.checked : target.value;
+      const name = target.name;
+      props.handleModelChange({ ...props.model, [name]: value });
+    }
+  };
+
+  const submitForm = async (event: React.MouseEvent) => {
+    // Collapse the "Advanced Options" section so that users can see
+    // errors at the top, if there are any.
+    setAdvancedOptionsExpanded(false);
+
+    // This form only supports creating a job, not a job definition.
+    return submitCreateJobRequest(event);
+  };
+
+  // Convert an array of parameters (as used for display) to an object
+  // (for submission to the API)
+  const serializeParameters = (parameters: IJobParameter[]) => {
+    const jobParameters: { [key: string]: any } = {};
+
+    parameters.forEach(param => {
+      const { name, value } = param;
+      if (jobParameters[name] !== undefined) {
+        console.error(
+          'Parameter ' +
+            name +
+            ' already set to ' +
+            jobParameters[name] +
+            ' and is about to be set again to ' +
+            value
+        );
+      } else {
+        jobParameters[name] = value;
+      }
+    });
+
+    return jobParameters;
+  };
+
+  const submitCreateJobRequest = async (event: React.MouseEvent) => {
+    if (anyErrors) {
+      console.error(
+        'User attempted to submit a createJob request; button should have been disabled'
+      );
+      return;
+    }
+
+    // Serialize parameters as an object.
+    const jobOptions: Scheduler.ICreateJob = {
+      name: props.model.jobName,
+      input_uri: props.model.inputFile,
+      runtime_environment_name: props.model.environment,
+      output_formats: props.model.outputFormats,
+      compute_type: props.model.computeType,
+      tags: props.model.tags,
+      runtime_environment_parameters: props.model.runtimeEnvironmentParameters,
+      job_definition_id: props.model.jobDefinitionId
+    };
+
+    if (props.model.parameters !== undefined) {
+      jobOptions.parameters = serializeParameters(props.model.parameters);
+    }
+
+    props.handleModelChange({
+      ...props.model,
+      createError: undefined,
+      createInProgress: true
+    });
+
+    // TODO: Call the "Create job from job definition ID" API
+    api
+      .createJob(jobOptions)
+      .then(response => {
+        // Switch to the list view with "Job List" active
+        props.showListView(JobsView.ListJobs);
+      })
+      .catch((error: Error) => {
+        props.handleModelChange({
+          ...props.model,
+          createError: error.message,
+          createInProgress: false
+        });
+      });
+  };
+
+  const removeParameter = (idx: number) => {
+    const newParams = props.model.parameters || [];
+    newParams.splice(idx, 1);
+
+    const newErrors: Record<string, string> = {};
+    for (const formKey in errors) {
+      const paramMatch = formKey.match(/^parameter-(\d+)/);
+      const paramIdx =
+        paramMatch && paramMatch.length >= 2 ? parseInt(paramMatch[1]) : -1;
+
+      if (paramIdx === -1 || paramIdx < idx) {
+        // restore errors associated with params before deleted param and all
+        // other form fields
+        newErrors[formKey] = errors[formKey];
+        continue;
+      }
+      if (paramIdx === idx) {
+        // ignore errors associated with deleted param
+        continue;
+      }
+
+      // otherwise, restore errors with params after deleted param by offsetting
+      // their index by -1
+      newErrors[`parameter-${paramIdx - 1}-name`] =
+        errors[`parameter-${paramIdx}-name`];
+    }
+
+    props.handleModelChange({ ...props.model, parameters: newParams });
+    setErrors(newErrors);
+  };
+
+  const addParameter = () => {
+    const newParams = props.model.parameters || [];
+    newParams.push({ name: '', value: '' });
+
+    props.handleModelChange({ ...props.model, parameters: newParams });
+  };
+
+  const formPrefix = 'jp-create-job-';
+
+  const cantSubmit = trans.__('One or more of the fields has an error.');
+  const createError: string | undefined = props.model.createError;
+
+  return (
+    <Box sx={{ p: 4 }}>
+      <form className={`${formPrefix}form`} onSubmit={e => e.preventDefault()}>
+        <Stack spacing={4}>
+          <Heading level={1}>
+            {trans.__('Create Job from Job Definition')}
+          </Heading>
+          {createError && <Alert severity="error">{createError}</Alert>}
+          <LabeledValue
+            label={trans.__('Job definition ID')}
+            value={props.model.jobDefinitionId}
+          />
+          <ParametersPicker
+            label={trans.__('Parameters')}
+            name={'parameters'}
+            id={`${formPrefix}parameters`}
+            value={props.model.parameters || []}
+            onChange={handleInputChange}
+            addParameter={addParameter}
+            removeParameter={removeParameter}
+            formPrefix={formPrefix}
+            errors={errors}
+            handleErrorsChange={setErrors}
+          />
+          <Accordion
+            defaultExpanded={false}
+            expanded={advancedOptionsExpanded}
+            onChange={(_: React.SyntheticEvent, expanded: boolean) =>
+              setAdvancedOptionsExpanded(expanded)
+            }
+          >
+            <AccordionSummary
+              expandIcon={<caretDownIcon.react />}
+              aria-controls="panel-content"
+              id="panel-header"
+            >
+              <FormLabel component="legend">
+                {trans.__('Additional options')}
+              </FormLabel>
+            </AccordionSummary>
+            <AccordionDetails id={`${formPrefix}create-panel-content`}>
+              <props.advancedOptions
+                jobsView={JobsView.CreateForm}
+                model={props.model}
+                handleModelChange={props.handleModelChange}
+                errors={advancedOptionsErrors}
+                handleErrorsChange={setAdvancedOptionsErrors}
+              />
+            </AccordionDetails>
+          </Accordion>
+          <Cluster gap={3} justifyContent="flex-end">
+            {props.model.createInProgress || (
+              <>
+                <Button
+                  variant="outlined"
+                  onClick={e => props.showListView(JobsView.ListJobs)}
+                >
+                  {trans.__('Cancel')}
+                </Button>
+
+                <Button
+                  variant="contained"
+                  onClick={(e: React.MouseEvent) => {
+                    submitForm(e);
+                    return false;
+                  }}
+                  disabled={anyErrors}
+                  title={anyErrors ? cantSubmit : ''}
+                >
+                  {trans.__('Create')}
+                </Button>
+              </>
+            )}
+            {props.model.createInProgress && (
+              <>
+                {trans.__('Creating job …')}
+                <CircularProgress size="30px" />
+              </>
+            )}
+          </Cluster>
+        </Stack>
+      </form>
+    </Box>
+  );
+}

--- a/src/mainviews/create-job-from-job-definition.tsx
+++ b/src/mainviews/create-job-from-job-definition.tsx
@@ -3,7 +3,7 @@ import React, { ChangeEvent, useMemo, useState } from 'react';
 import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
 import { ParametersPicker } from '../components/parameters-picker';
-import { Scheduler, SchedulerService } from '../handler';
+import { SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
@@ -106,25 +106,21 @@ export function CreateJobFromJobDefinition(
   const submitCreateJobRequest = async (event: React.MouseEvent) => {
     if (anyErrors) {
       console.error(
-        'User attempted to submit a createJob request; button should have been disabled'
+        'User attempted to submit a submitCreateJobRequest request; button should have been disabled'
       );
       return;
     }
 
-    // Serialize parameters as an object.
-    const jobOptions: Scheduler.ICreateJob = {
-      name: props.model.jobName,
-      input_uri: props.model.inputFile,
-      runtime_environment_name: props.model.environment,
-      output_formats: props.model.outputFormats,
-      compute_type: props.model.computeType,
-      tags: props.model.tags,
-      runtime_environment_parameters: props.model.runtimeEnvironmentParameters,
-      job_definition_id: props.model.jobDefinitionId
-    };
+    if (!props.model.jobDefinitionId) {
+      console.error(
+        'User did not provide a job definition ID to submitCreateJobRequest request'
+      );
+      return;
+    }
 
+    let parameters = {};
     if (props.model.parameters !== undefined) {
-      jobOptions.parameters = serializeParameters(props.model.parameters);
+      parameters = serializeParameters(props.model.parameters);
     }
 
     props.handleModelChange({
@@ -133,9 +129,8 @@ export function CreateJobFromJobDefinition(
       createInProgress: true
     });
 
-    // TODO: Call the "Create job from job definition ID" API
     api
-      .createJob(jobOptions)
+      .createJobFromJobDefinition(props.model.jobDefinitionId, parameters)
       .then(response => {
         // Switch to the list view with "Job List" active
         props.showListView(JobsView.ListJobs);

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -756,7 +756,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     <Box sx={{ p: 4 }}>
       <form className={`${formPrefix}form`} onSubmit={e => e.preventDefault()}>
         <Stack spacing={4}>
-          <Heading level={1}>Create Job</Heading>
+          <Heading level={1}>{trans.__('Create Job')}</Heading>
           {createError && <Alert severity="error">{createError}</Alert>}
           <TextField
             label={trans.__('Job name')}

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { IJobDefinitionModel, JobsView, ICreateJobModel } from '../../model';
+import { IJobDefinitionModel, JobsView, ICreateJobModel, emptyCreateJobModel } from '../../model';
 import { useTranslator } from '../../hooks';
 import { timestampLocalize } from './job-detail';
 import { SchedulerService } from '../../handler';
@@ -45,6 +45,23 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
     props.refresh();
   };
 
+  const runJobDefinition = () => {
+    const initialState: ICreateJobModel = {
+      ...emptyCreateJobModel(),
+      inputFile: props.model.inputFile,
+      outputPath: props.model.outputPrefix ?? '',
+      environment: props.model.environment,
+      computeType: props.model.computeType,
+      runtimeEnvironmentParameters: props.model.runtimeEnvironmentParameters,
+      parameters: props.model.parameters,
+      outputFormats: props.model.outputFormats,
+      jobDefinitionId: props.model.definitionId
+    };
+
+    props.showCreateJob(initialState);
+    props.setJobsView(JobsView.CreateFromJobDescriptionForm);
+  };
+
   let cronString;
   try {
     if (props.model.schedule !== undefined) {
@@ -56,6 +73,9 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
 
   const DefinitionButtonBar = (
     <Stack direction="row" gap={2} justifyContent="flex-end" flexWrap={'wrap'}>
+      <Button variant="outlined" onClick={runJobDefinition}>
+        {trans.__('Run Job')}
+      </Button>
       {props.model.active ? (
         <Button variant="outlined" onClick={pauseJobDefinition}>
           {trans.__('Pause')}

--- a/src/model.ts
+++ b/src/model.ts
@@ -10,6 +10,7 @@ import { VDomModel } from '@jupyterlab/apputils';
 export enum JobsView {
   // assignment ensures any enum value is always truthy
   CreateForm = 1,
+  CreateFromJobDescriptionForm,
   ListJobs,
   ListJobDefinitions,
   JobDetail,
@@ -34,6 +35,8 @@ export interface ICreateJobModel extends PartialJSONObject {
   jobName: string;
   inputFile: string;
   environment: string;
+  // If creating a job from a job definition, the job definition ID to use.
+  jobDefinitionId?: string;
   // A "job" runs now; a "job definition" runs on a schedule
   createType: 'Job' | 'JobDefinition';
   // Errors from creation

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -15,7 +15,7 @@ import { ICreateJobModel, JobsModel, JobsView } from './model';
 import { getJupyterLabTheme } from './theme-provider';
 import { Scheduler } from './tokens';
 import { DetailView } from './mainviews/detail-view';
-import { CreateJobFromJobDefinition } from './mainviews/create-job-from-job-definition';
+import { CreateJobFromDefinition } from './mainviews/create-job-from-definition';
 
 export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   readonly _title?: string;
@@ -85,7 +85,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
             />
           )}
           {this.model.jobsView === JobsView.CreateFromJobDescriptionForm && (
-            <CreateJobFromJobDefinition
+            <CreateJobFromDefinition
               key={this.model.createJobModel.key}
               model={this.model.createJobModel}
               handleModelChange={newModel =>

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -15,6 +15,7 @@ import { ICreateJobModel, JobsModel, JobsView } from './model';
 import { getJupyterLabTheme } from './theme-provider';
 import { Scheduler } from './tokens';
 import { DetailView } from './mainviews/detail-view';
+import { CreateJobFromJobDefinition } from './mainviews/create-job-from-job-definition';
 
 export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   readonly _title?: string;
@@ -74,6 +75,17 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
         <TranslatorContext.Provider value={this._translator}>
           {this.model.jobsView === JobsView.CreateForm && (
             <CreateJob
+              key={this.model.createJobModel.key}
+              model={this.model.createJobModel}
+              handleModelChange={newModel =>
+                (this.model.createJobModel = newModel)
+              }
+              showListView={this.showListView.bind(this)}
+              advancedOptions={this._advancedOptions}
+            />
+          )}
+          {this.model.jobsView === JobsView.CreateFromJobDescriptionForm && (
+            <CreateJobFromJobDefinition
               key={this.model.createJobModel.key}
               model={this.model.createJobModel}
               handleModelChange={newModel =>


### PR DESCRIPTION
Fixes #209 and #225.

On the Job Definition Detail page, adds a "Run Job" button that brings the user to a minimal version of the Create Job form that displays only the job definition ID and lets the user edit parameters. The API to create a job this way was added in #228.

Demo video:

https://user-images.githubusercontent.com/93281816/198753293-50c90be5-7e93-4307-879a-0ccb52816195.mov


