### PR TITLE
API and handler for creating job from definition

### DIFF
--- a/jupyter_scheduler/extension.py
+++ b/jupyter_scheduler/extension.py
@@ -13,6 +13,7 @@ from .handlers import (
     ConfigHandler,
     FilesDownloadHandler,
     JobDefinitionHandler,
+    JobFromDefinitionHandler,
     JobHandler,
     JobsCountHandler,
     RuntimeEnvironmentsHandler,
@@ -32,6 +33,7 @@ class SchedulerApp(ExtensionApp):
         (r"scheduler/batch/jobs", BatchJobHandler),
         (r"scheduler/job_definitions", JobDefinitionHandler),
         (r"scheduler/job_definitions/%s" % JOB_DEFINITION_ID_REGEX, JobDefinitionHandler),
+        (r"scheduler/job_definitions/%s/jobs" % JOB_DEFINITION_ID_REGEX, JobFromDefinitionHandler),
         (r"scheduler/runtime_environments", RuntimeEnvironmentsHandler),
         (r"scheduler/config", ConfigHandler),
     ]

--- a/jupyter_scheduler/handlers.py
+++ b/jupyter_scheduler/handlers.py
@@ -213,7 +213,9 @@ class JobFromDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandl
         payload = self.get_json_body()
         try:
             model = CreateJobFromDefinition(**payload)
-            job_id = await ensure_async(self.scheduler.create_job_from_definition(job_definition_id, model=model))
+            job_id = await ensure_async(
+                self.scheduler.create_job_from_definition(job_definition_id, model=model)
+            )
         except SchedulerError as e:
             self.log.exception(e)
             raise tornado.web.HTTPError(500, str(e)) from e
@@ -223,7 +225,7 @@ class JobFromDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandl
                 500, "Unexpected error occurred during creation of job."
             ) from e
         else:
-            self.finish(json.dumps(dict(job_id=job_id)))    
+            self.finish(json.dumps(dict(job_id=job_id)))
 
 
 class BatchJobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):

--- a/jupyter_scheduler/handlers.py
+++ b/jupyter_scheduler/handlers.py
@@ -18,6 +18,7 @@ from jupyter_scheduler.models import (
     CountJobsQuery,
     CreateJob,
     CreateJobDefinition,
+    CreateJobFromDefinition,
     ListJobDefinitionsQuery,
     ListJobsQuery,
     SortDirection,
@@ -110,7 +111,7 @@ class JobDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
         except Exception as e:
             self.log.exception(e)
             raise tornado.web.HTTPError(
-                500, "Unexpected error occurred during creation of Job."
+                500, "Unexpected error occurred during creation of job."
             ) from e
         else:
             self.finish(json.dumps(dict(job_definition_id=job_definition_id)))
@@ -172,7 +173,7 @@ class JobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
         except Exception as e:
             self.log.exception(e)
             raise tornado.web.HTTPError(
-                500, "Unexpected error occurred during creation of Job."
+                500, "Unexpected error occurred during creation of job."
             ) from e
         else:
             self.finish(json.dumps(dict(job_id=job_id)))
@@ -204,6 +205,25 @@ class JobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
 
         self.set_status(204)
         self.finish()
+
+
+class JobFromDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+    @tornado.web.authenticated
+    async def post(self, job_definition_id: str):
+        payload = self.get_json_body()
+        try:
+            model = CreateJobFromDefinition(**payload)
+            job_id = await ensure_async(self.scheduler.create_job_from_definition(job_definition_id, model=model))
+        except SchedulerError as e:
+            self.log.exception(e)
+            raise tornado.web.HTTPError(500, str(e)) from e
+        except Exception as e:
+            self.log.exception(e)
+            raise tornado.web.HTTPError(
+                500, "Unexpected error occurred during creation of job."
+            ) from e
+        else:
+            self.finish(json.dumps(dict(job_id=job_id)))    
 
 
 class BatchJobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -272,6 +272,7 @@ class ListJobDefinitionsResponse(BaseModel):
 class CreateJobFromDefinition(BaseModel):
     parameters: Optional[Dict[str, ParameterValues]] = None
 
+
 class JobFeature(str, Enum):
     job_name = "job_name"
     parameters = "parameters"

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -269,6 +269,9 @@ class ListJobDefinitionsResponse(BaseModel):
     next_token: Optional[str] = None
 
 
+class CreateJobFromDefinition(BaseModel):
+    parameters: Optional[Dict[str, ParameterValues]] = None
+
 class JobFeature(str, Enum):
     job_name = "job_name"
     parameters = "parameters"

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -620,9 +620,7 @@ class Scheduler(BaseScheduler):
             input_uri = self.get_staging_paths(definition)["input"]
             attributes = definition.dict(exclude={"schedule", "timezone"}, exclude_none=True)
             attributes = {**attributes, **model.dict(exclude_none=True), "input_uri": input_uri}
-            job_id = self.create_job(
-                CreateJob(**attributes)
-            )
+            job_id = self.create_job(CreateJob(**attributes))
 
         return job_id
 

--- a/jupyter_scheduler/tests/test_handlers.py
+++ b/jupyter_scheduler/tests/test_handlers.py
@@ -102,7 +102,7 @@ async def test_post_jobs_for_unexpected_error(jp_fetch):
         mock_create_job.side_effect = Exception("Unexpected error")
         with pytest.raises(HTTPClientError) as e:
             await jp_fetch("scheduler", "jobs", method="POST", body=json.dumps(payload))
-        assert expected_http_error(e, 500, "Unexpected error occurred during creation of Job.")
+        assert expected_http_error(e, 500, "Unexpected error occurred during creation of job.")
 
 
 async def test_get_jobs_for_single_job(jp_fetch):


### PR DESCRIPTION
Fixes #209 

Added a new API and handler to create job from job definition. 

#### Scheduler API
```py
def create_job_from_definition(self, job_definition_id: str, model: CreateJobFromDefinition):
        """Creates a new job based on a job definition"""
        raise NotImplementedError("must be implemented by subclass")
```

#### Handler
```
POST /scheduler/job_definitions/<job_definition_id>/jobs
```