### PR TITLE
Add additional styling of backgound and paper to handle dark mode.

### DIFF
--- a/src/theme-provider.ts
+++ b/src/theme-provider.ts
@@ -79,6 +79,10 @@ export function getJupyterLabTheme(): Theme {
       }
     },
     palette: {
+      background: {
+        paper: getCSSVariable('--jp-layout-color1'),
+        default: getCSSVariable('--jp-layout-color1')
+      },
       mode: light === 'true' ? 'light' : 'dark',
       primary: {
         main: getCSSVariable('--jp-brand-color1'),


### PR DESCRIPTION
This fixes #154 

This sets the background and paper theme variables in MUI to ensure that cards, accordians, tables, etc. get the right background color from the JupyterLab theme. This only shows up in dark themes whose default JupyterLab layout color isn't black. Here it is in a nice calm brown theme :-) 

![Screen Shot 2022-10-29 at 1 02 28 PM](https://user-images.githubusercontent.com/27600/198850659-8bb75b1f-f656-40a7-a786-ab8dcf0a71dd.png)

![Screen Shot 2022-10-29 at 1 02 40 PM](https://user-images.githubusercontent.com/27600/198850665-59571545-ca7e-4d43-a8ef-5ab6ce22d0d2.png)

![Screen Shot 2022-10-29 at 1 03 18 PM](https://user-images.githubusercontent.com/27600/198850667-5789b2a0-ba3e-4e0d-9bcc-a6356cf0fe7d.png)
