### PR TITLE
fix pagination in AdvancedTable

### DIFF
--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -140,7 +140,7 @@ export function AdvancedTable<
         .slice(page * pageSize, (page + 1) * pageSize)
         .filter(row => (props.rowFilter ? props.rowFilter(row) : true))
         .map(row => props.renderRow(row)),
-    [rows, props.rowFilter, props.renderRow]
+    [rows, props.rowFilter, props.renderRow, page, pageSize]
   );
 
   const handlePageChange = async (e: unknown, newPage: number) => {


### PR DESCRIPTION
Pagination was broken by #212, as the list of rendered rows would not be updated after changing the page.