### PR TITLE
Chooses the first environment in the create form

### DIFF
--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -93,7 +93,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     const setList = async () => {
       const envList = await api.getRuntimeEnvironments();
       setEnvironmentList(envList);
-      if (envList.length === 1) {
+
+      // Choose the first environment if none was selected before
+      // (this would happen if the create form is used for editing)
+      if (props.model.environment === '') {
         // If no default compute type is specified, show the first one by default
         let newComputeType = envList[0].compute_types?.[0];
 


### PR DESCRIPTION
Fixes #231 by selecting the first environment in the create form unless an existing environment was already selected. (This is to accommodate future use of the create form for editing.) 

In the screen shot below, there are two available environments. The first one is automatically selected and there is no blank option.


https://user-images.githubusercontent.com/93281816/199131430-16077189-d258-4ecd-8aa5-7ab0b08b1318.mov


