### PR TITLE
Hides Output Format picker when no output formats are present

### DIFF
--- a/src/components/output-format-picker.tsx
+++ b/src/components/output-format-picker.tsx
@@ -38,7 +38,8 @@ export function OutputFormatPicker(
     props.environment
   );
 
-  if (outputFormats === null) {
+  // Don't display anything, not even the label, if there are no output formats
+  if (outputFormats === null || outputFormats.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
Fixes #222. Hides the Output Formats picker entirely, not even showing the header, when there are no output formats for the selected environment.

In the screen shots below, a custom handler overrides the output formats list to `[]` for the `miniconda3` environment.

![miniconda3 environment: no output formats label appears](https://user-images.githubusercontent.com/93281816/199295517-a46885da-8906-4f65-8156-54d845df5233.png)

![jupyterlab environment: output formats label and checkboxes appear](https://user-images.githubusercontent.com/93281816/199295562-60c0b230-4c90-4fd5-b7b3-582ee252a835.png)
