### PR TITLE
allow arbitrary expressions as job parameters

### DIFF
--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -1,10 +1,11 @@
 import os
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, root_validator
 
 Tags = List[str]
+EnvironmentParameterValues = Union[int, float, bool, str]
 
 EMAIL_RE = ""
 SCHEDULE_RE = ""
@@ -74,7 +75,7 @@ class CreateJob(BaseModel):
     input_uri: str
     input_filename: str = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, Any]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
     output_formats: Optional[List[str]] = None
     idempotency_token: Optional[str] = None
     job_definition_id: Optional[str] = None
@@ -124,7 +125,7 @@ class JobFile(BaseModel):
 class DescribeJob(BaseModel):
     input_filename: str = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, Any]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
     output_formats: Optional[List[str]] = None
     idempotency_token: Optional[str] = None
     job_definition_id: Optional[str] = None
@@ -198,7 +199,7 @@ class CreateJobDefinition(BaseModel):
     input_uri: str
     input_filename: str = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, Any]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
     output_formats: Optional[List[str]] = None
     parameters: Optional[Dict[str, str]] = None
     tags: Optional[Tags] = None
@@ -219,7 +220,7 @@ class CreateJobDefinition(BaseModel):
 class DescribeJobDefinition(BaseModel):
     input_filename: str = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, Any]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
     output_formats: Optional[List[str]] = None
     parameters: Optional[Dict[str, str]] = None
     tags: Optional[Tags] = None
@@ -239,7 +240,7 @@ class DescribeJobDefinition(BaseModel):
 
 class UpdateJobDefinition(BaseModel):
     runtime_environment_name: Optional[str]
-    runtime_environment_parameters: Optional[Dict[str, Any]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
     output_formats: Optional[List[str]] = None
     parameters: Optional[Dict[str, str]] = None
     tags: Optional[Tags] = None

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -1,12 +1,10 @@
 import os
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, root_validator
 
 Tags = List[str]
-ParameterValues = Union[int, str, float, bool]
-EnvironmentParameterValues = Union[int, str, float, bool]
 
 EMAIL_RE = ""
 SCHEDULE_RE = ""
@@ -76,11 +74,11 @@ class CreateJob(BaseModel):
     input_uri: str
     input_filename: str = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, Any]]
     output_formats: Optional[List[str]] = None
     idempotency_token: Optional[str] = None
     job_definition_id: Optional[str] = None
-    parameters: Optional[Dict[str, ParameterValues]] = None
+    parameters: Optional[Dict[str, str]] = None
     tags: Optional[Tags] = None
     name: Optional[str] = None
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
@@ -126,11 +124,11 @@ class JobFile(BaseModel):
 class DescribeJob(BaseModel):
     input_filename: str = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, Any]]
     output_formats: Optional[List[str]] = None
     idempotency_token: Optional[str] = None
     job_definition_id: Optional[str] = None
-    parameters: Optional[Dict[str, ParameterValues]] = None
+    parameters: Optional[Dict[str, str]] = None
     tags: Optional[Tags] = None
     name: Optional[str] = None
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
@@ -200,9 +198,9 @@ class CreateJobDefinition(BaseModel):
     input_uri: str
     input_filename: str = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, Any]]
     output_formats: Optional[List[str]] = None
-    parameters: Optional[Dict[str, ParameterValues]] = None
+    parameters: Optional[Dict[str, str]] = None
     tags: Optional[Tags] = None
     name: Optional[str] = None
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
@@ -221,9 +219,9 @@ class CreateJobDefinition(BaseModel):
 class DescribeJobDefinition(BaseModel):
     input_filename: str = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, Any]]
     output_formats: Optional[List[str]] = None
-    parameters: Optional[Dict[str, ParameterValues]] = None
+    parameters: Optional[Dict[str, str]] = None
     tags: Optional[Tags] = None
     name: Optional[str] = None
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
@@ -241,9 +239,9 @@ class DescribeJobDefinition(BaseModel):
 
 class UpdateJobDefinition(BaseModel):
     runtime_environment_name: Optional[str]
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, Any]]
     output_formats: Optional[List[str]] = None
-    parameters: Optional[Dict[str, ParameterValues]] = None
+    parameters: Optional[Dict[str, str]] = None
     tags: Optional[Tags] = None
     name: Optional[str] = None
     url: Optional[str] = None
@@ -270,7 +268,7 @@ class ListJobDefinitionsResponse(BaseModel):
 
 
 class CreateJobFromDefinition(BaseModel):
-    parameters: Optional[Dict[str, ParameterValues]] = None
+    parameters: Optional[Dict[str, str]] = None
 
 
 class JobFeature(str, Enum):

--- a/jupyter_scheduler/parameterize.py
+++ b/jupyter_scheduler/parameterize.py
@@ -2,18 +2,14 @@ from typing import Dict
 
 from nbformat import NotebookNode, v4
 
-from jupyter_scheduler.models import ParameterValues
 from jupyter_scheduler.utils import find_cell_index_with_tag
 
 
-def add_parameters(nb: NotebookNode, parameters: Dict[str, ParameterValues]) -> NotebookNode:
+def add_parameters(nb: NotebookNode, parameters: Dict[str, str]) -> NotebookNode:
     content = []
 
     for key, value in parameters.items():
-        if type(value) == str:
-            content.append(f"{key} = '{value}'")
-        else:
-            content.append(f"{key} = {value}")
+        content.append(f"{key} = {value}")
 
     new_cell = v4.new_code_cell(source="\n".join(content))
     new_cell.metadata["tags"] = ["injected-parameters"]

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -331,10 +331,8 @@ export namespace SchedulerService {
 }
 
 export namespace Scheduler {
-  export type RuntimeEnvironmentParameters = {
-    [key: string]: number | string | boolean;
-  };
-  export type Parameters = { [key: string]: number | string | boolean };
+  export type RuntimeEnvironmentParameters = Record<string, any>;
+  export type Parameters = Record<string, string>;
 
   export interface ICreateJobDefinition {
     input_uri: string;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -331,7 +331,7 @@ export namespace SchedulerService {
 }
 
 export namespace Scheduler {
-  export type RuntimeEnvironmentParameters = Record<string, any>;
+  export type RuntimeEnvironmentParameters = Record<string, number | string | boolean>;
   export type Parameters = Record<string, string>;
 
   export interface ICreateJobDefinition {


### PR DESCRIPTION
Allows for any expressions valid to the notebook kernel to be used as job parameters.

Now requires strings to be explicitly wrapped in single or double quotes.


https://user-images.githubusercontent.com/44106031/199300969-f427ca9f-43ad-43c8-bb2d-1f0c78d1cb1e.mov



Closes #229.