### PR TITLE
Increase download delay from 500 ms to 5 s

### DIFF
--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -85,7 +85,7 @@ function DownloadFilesButton(props: DownloadFilesButtonProps) {
           id: props.job.job_id,
           redownload: false
         });
-        await new Promise(res => setTimeout(res, 500));
+        await new Promise(res => setTimeout(res, 5000));
         setDownloading(false);
         props.reload();
       }}

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -80,7 +80,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       id: props.model.jobId,
       redownload: false
     });
-    await new Promise(res => setTimeout(res, 500));
+    await new Promise(res => setTimeout(res, 5000));
     await props.handleModelChange();
     setDownloading(false);
   };


### PR DESCRIPTION
Fixes #232 (stopgap) by increasing the wait time after clicking "Download" from 500 ms (0.5 s) to 5 seconds. Tested on my desktop.