### PR TITLE
render better empty list messages

### DIFF
--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -1,5 +1,10 @@
 import React, { useMemo } from 'react';
-import { IJobDefinitionModel, JobsView, ICreateJobModel, emptyCreateJobModel } from '../../model';
+import {
+  IJobDefinitionModel,
+  JobsView,
+  ICreateJobModel,
+  emptyCreateJobModel
+} from '../../model';
 import { useTranslator } from '../../hooks';
 import { timestampLocalize } from './job-detail';
 import { SchedulerService } from '../../handler';
@@ -194,6 +199,9 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
             showJobDetail={props.showJobDetail}
             jobDefinitionId={props.model.definitionId}
             pageSize={5}
+            emptyRowMessage={trans.__(
+              'No notebook jobs associated with this job definition.'
+            )}
           />
         </Stack>
       </CardContent>

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -254,7 +254,7 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
   const emptyRowMessage = useMemo(
     () =>
       trans.__(
-        'There are no notebook job definitions. Notebook job definitions run notebooks and other files in the background on a schedule. ' +
+        'There are no notebook job definitions. Notebook job definitions run files in the background on a schedule. ' +
           'To create a notebook job definition, right-click on a notebook in the file browser and select "Create Notebook Job".'
       ),
     [trans]

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -149,7 +149,7 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
     () =>
       props.emptyRowMessage ??
       trans.__(
-        'There are no notebook jobs. Notebook jobs run notebooks and other files in the background, either immediately or on a schedule. ' +
+        'There are no notebook jobs. Notebook jobs run files in the background, immediately or on a schedule. ' +
           'To create a notebook job, right-click on a notebook in the file browser and select "Create Notebook Job".'
       ),
     [props.emptyRowMessage, trans]

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -29,6 +29,7 @@ interface IListJobsTableProps {
   jobDefinitionId?: string;
   height?: 'auto' | string | number;
   pageSize?: number;
+  emptyRowMessage?: string;
 }
 
 export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
@@ -145,8 +146,13 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
     !deletedRows.has(job.job_id);
 
   const emptyRowMessage = useMemo(
-    () => trans.__('There are no notebook jobs.'),
-    [trans]
+    () =>
+      props.emptyRowMessage ??
+      trans.__(
+        'There are no notebook jobs. Notebook jobs run notebooks and other files in the background, either immediately or on a schedule. ' +
+          'To create a notebook job, right-click on a notebook in the file browser and select "Create Notebook Job".'
+      ),
+    [props.emptyRowMessage, trans]
   );
 
   // note that root element here must be a JSX fragment for DataGrid to be sized properly
@@ -246,7 +252,11 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
     !deletedRows.has(jobDef.job_definition_id);
 
   const emptyRowMessage = useMemo(
-    () => trans.__('There are no notebook job definitions.'),
+    () =>
+      trans.__(
+        'There are no notebook job definitions. Notebook job definitions run notebooks and other files in the background on a schedule. ' +
+          'To create a notebook job definition, right-click on a notebook in the file browser and select "Create Notebook Job".'
+      ),
     [trans]
   );
 


### PR DESCRIPTION
Closes #233.

### Job definition detail jobs list

<img width="799" alt="Screen Shot 2022-11-01 at 12 17 41 PM" src="https://user-images.githubusercontent.com/44106031/199319802-aba30362-1f55-4fbc-a2a7-1c3443059b69.png">

### Jobs list

<img width="798" alt="Screen Shot 2022-11-01 at 12 17 49 PM" src="https://user-images.githubusercontent.com/44106031/199319807-2c215e13-a50d-4aaa-870e-cf8991da33e8.png">

### Job definition list

<img width="805" alt="Screen Shot 2022-11-01 at 12 17 57 PM" src="https://user-images.githubusercontent.com/44106031/199319808-28bc6da9-290a-40d4-b0f4-47e2a67f5ea0.png">
