### PR TITLE
Fix for failing check-release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "test": "jest --coverage",
     "watch": "run-p watch:src watch:labextension",
     "watch:src": "tsc -w",
-    "watch:labextension": "jupyter labextension watch .",
-    "prepare": "jlpm build:prod"
+    "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
     "@emotion/react": "^11.10.4",
@@ -134,7 +133,8 @@
     "hooks": {
       "before-build-npm": [
         "python -m pip install jupyterlab~=3.1",
-        "jlpm"
+        "jlpm",
+        "jlpm build:prod"
       ],
       "before-build-python": [
         "jlpm clean:all"


### PR DESCRIPTION
`check-npm` is failing to run the `prepare` step; moving this instead to the releaser hooks fixes the error. Tested this locally in a separate environment with jupyter-releaser installed. 