### PR TITLE
Validates job name

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -345,7 +345,10 @@ export namespace SchedulerService {
 }
 
 export namespace Scheduler {
-  export type RuntimeEnvironmentParameters = Record<string, number | string | boolean>;
+  export type RuntimeEnvironmentParameters = Record<
+    string,
+    number | string | boolean
+  >;
   export type Parameters = Record<string, string>;
 
   export interface ICreateJobDefinition {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,16 +10,16 @@ import { INotebookTracker } from '@jupyterlab/notebook';
 import { Contents } from '@jupyterlab/services';
 import { ITranslator } from '@jupyterlab/translation';
 
-import { SchedulerService } from './handler';
-import { IJobsModel, emptyCreateJobModel, JobsView } from './model';
-import { NotebookJobsPanel } from './notebook-jobs-panel';
+import AdvancedOptions from './advanced-options';
 import {
   calendarAddOnIcon,
   calendarMonthIcon,
   eventNoteIcon
 } from './components/icons';
+import { SchedulerService } from './handler';
+import { IJobsModel, emptyCreateJobModel, JobsView } from './model';
+import { NotebookJobsPanel } from './notebook-jobs-panel';
 import { Scheduler } from './tokens';
-import AdvancedOptions from './advanced-options';
 import { MakeNameValid } from './util/job-name-validation';
 
 export namespace CommandIDs {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ import {
 } from './components/icons';
 import { Scheduler } from './tokens';
 import AdvancedOptions from './advanced-options';
+import { MakeNameValid } from './util/job-name-validation';
 
 export namespace CommandIDs {
   export const deleteJob = 'scheduling:delete-job';
@@ -74,13 +75,21 @@ function getSelectedItem(widget: FileBrowser | null): Contents.IModel | null {
   return firstItem;
 }
 
-// Get only the file name, with no parent directories, of the currently selected file.
-function getSelectedFileName(widget: FileBrowser | null): string | null {
+// Get only the file base name, with no parent directories and no extension,
+// of the currently selected file.
+function getSelectedFileBaseName(widget: FileBrowser | null): string | null {
   const selectedItem = getSelectedItem(widget);
   if (selectedItem === null) {
     return null;
   }
-  return selectedItem.name;
+  const parts = selectedItem.name.split('.');
+  if (parts.length === 1) {
+    // no extension
+    return parts[0];
+  }
+
+  parts.splice(-1); // Remove the extension
+  return parts.join('.');
 }
 
 // Get the file name, with all parent directories, of the currently selected file.
@@ -183,7 +192,9 @@ async function activatePlugin(
       // Update the job form inside the notebook jobs widget
       const newCreateModel = emptyCreateJobModel();
       newCreateModel.inputFile = filePath;
-      newCreateModel.jobName = getSelectedFileName(widget) ?? '';
+      newCreateModel.jobName = MakeNameValid(
+        getSelectedFileBaseName(widget) ?? ''
+      );
       newCreateModel.outputPath = getDirectoryFromPath(filePath) ?? '';
 
       await showJobsPanel({
@@ -206,7 +217,7 @@ async function activatePlugin(
       // Update the job form inside the notebook jobs widget
       const newCreateModel = emptyCreateJobModel();
       newCreateModel.inputFile = filePath;
-      newCreateModel.jobName = fileName;
+      newCreateModel.jobName = MakeNameValid(fileName);
       newCreateModel.outputPath = getDirectoryFromPath(filePath) ?? '';
 
       await showJobsPanel({

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -14,6 +14,9 @@ import { Scheduler, SchedulerService } from '../handler';
 import { useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
+import { NameError } from '../util/job-name-validation';
+
+import { caretDownIcon } from '@jupyterlab/ui-components';
 
 import ErrorIcon from '@mui/icons-material/Error';
 import FolderIcon from '@mui/icons-material/Folder';
@@ -32,8 +35,6 @@ import {
 } from '@mui/material';
 
 import { Box, Stack } from '@mui/system';
-
-import { caretDownIcon } from '@jupyterlab/ui-components';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -410,7 +411,16 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
           <TextField
             label={trans.__('Job name')}
             variant="outlined"
-            onChange={handleInputChange}
+            onChange={e => {
+              // Validate name
+              setErrors({
+                ...errors,
+                jobName: NameError(e.target.value, trans)
+              });
+              handleInputChange(e as ChangeEvent<HTMLInputElement>);
+            }}
+            error={!!errors['jobName']}
+            helperText={errors['jobName'] ?? ''}
             value={props.model.jobName}
             id={`${formPrefix}jobName`}
             name="jobName"

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,7 +1,10 @@
+import { VDomModel } from '@jupyterlab/apputils';
+
 import { Signal } from '@lumino/signaling';
 import { PartialJSONObject } from '@lumino/coreutils';
+
 import { Scheduler } from './handler';
-import { VDomModel } from '@jupyterlab/apputils';
+import { MakeNameValid } from './util/job-name-validation';
 
 /**
  * Top-level models
@@ -331,7 +334,7 @@ export function convertDescribeJobtoJobDetail(
   return {
     ...emptyCreateJobModel(),
     jobId: describeJob.job_id,
-    jobName: describeJob.name ?? '',
+    jobName: MakeNameValid(describeJob.name ?? ''),
     inputFile: describeJob.input_filename,
     job_files: convertJobFilesToJson(describeJob.job_files),
     environment: describeJob.runtime_environment_name,

--- a/src/model.ts
+++ b/src/model.ts
@@ -4,7 +4,6 @@ import { Signal } from '@lumino/signaling';
 import { PartialJSONObject } from '@lumino/coreutils';
 
 import { Scheduler } from './handler';
-import { MakeNameValid } from './util/job-name-validation';
 
 /**
  * Top-level models
@@ -334,7 +333,7 @@ export function convertDescribeJobtoJobDetail(
   return {
     ...emptyCreateJobModel(),
     jobId: describeJob.job_id,
-    jobName: MakeNameValid(describeJob.name ?? ''),
+    jobName: describeJob.name ?? '',
     inputFile: describeJob.input_filename,
     job_files: convertJobFilesToJson(describeJob.job_files),
     environment: describeJob.runtime_environment_name,

--- a/src/util/job-name-validation.tsx
+++ b/src/util/job-name-validation.tsx
@@ -54,10 +54,10 @@ export function NameError(name: string, trans: TranslationBundle): string {
     );
   }
 
-    // Check for length.
-    if (name.length > maxLength) {
-      return trans.__('Name may not be longer than %1 characters', maxLength);
-    }
+  // Check for length.
+  if (name.length > maxLength) {
+    return trans.__('Name may not be longer than %1 characters', maxLength);
+  }
 
   // By process of elimination, incorrect characters must be present
   return trans.__(

--- a/src/util/job-name-validation.tsx
+++ b/src/util/job-name-validation.tsx
@@ -58,7 +58,7 @@ export function NameError(name: string, trans: TranslationBundle): string {
     if (name.length > maxLength) {
       return trans.__('Name may not be longer than %1 characters', maxLength);
     }
-    
+
   // By process of elimination, incorrect characters must be present
   return trans.__(
     'Name must contain only letters, numbers, periods, hyphens, and underscores'

--- a/src/util/job-name-validation.tsx
+++ b/src/util/job-name-validation.tsx
@@ -54,11 +54,6 @@ export function NameError(name: string, trans: TranslationBundle): string {
     );
   }
 
-  // Check for length.
-  if (name.length > maxLength) {
-    return trans.__('Name may not be longer than %1 characters', maxLength);
-  }
-
   // Check for incorrect characters
   if (invalidCharRegex.test(name)) {
     return trans.__(
@@ -66,5 +61,10 @@ export function NameError(name: string, trans: TranslationBundle): string {
     );
   }
 
-  return ''; // No other errors found
+  // Check for length.
+  if (name.length > maxLength) {
+    return trans.__('Name may not be longer than %1 characters', maxLength);
+  }
+
+  return 'Name is not valid'; // We shouldn't get here
 }

--- a/src/util/job-name-validation.tsx
+++ b/src/util/job-name-validation.tsx
@@ -54,17 +54,13 @@ export function NameError(name: string, trans: TranslationBundle): string {
     );
   }
 
-  // Check for incorrect characters
-  if (invalidCharRegex.test(name)) {
-    return trans.__(
-      'Name must contain only letters, numbers, periods, hyphens, and underscores'
-    );
-  }
-
-  // Check for length.
-  if (name.length > maxLength) {
-    return trans.__('Name may not be longer than %1 characters', maxLength);
-  }
-
-  return 'Name is not valid'; // We shouldn't get here
+    // Check for length.
+    if (name.length > maxLength) {
+      return trans.__('Name may not be longer than %1 characters', maxLength);
+    }
+    
+  // By process of elimination, incorrect characters must be present
+  return trans.__(
+    'Name must contain only letters, numbers, periods, hyphens, and underscores'
+  );
 }

--- a/src/util/job-name-validation.tsx
+++ b/src/util/job-name-validation.tsx
@@ -1,0 +1,70 @@
+// Utilities to validate and sanitize job names (make them valid)
+
+import { TranslationBundle } from '@jupyterlab/translation';
+
+const jobNameRegex = /^[a-zA-Z0-9._][a-zA-Z0-9._-]{0,62}$/;
+const invalidFirstCharRegex = /^[^a-zA-Z0-9._]/;
+const invalidCharRegex = /[^a-zA-Z0-9._-]/g;
+const maxLength = 63;
+
+export function NameIsValid(name: string): boolean {
+  return jobNameRegex.test(name);
+}
+
+// Modify an input string to be a valid name
+export function MakeNameValid(name: string): string {
+  if (jobNameRegex.test(name)) {
+    return name;
+  }
+
+  // Clean up first position
+  if (invalidFirstCharRegex.test(name)) {
+    name = name.slice(1);
+  }
+
+  // Truncate length
+  name = name.substring(0, maxLength);
+
+  // Purge invalid characters
+  name = name.replace(invalidCharRegex, '');
+
+  // If nothing's left, put something in so that validation passes
+  if (name === '') {
+    // Deliberately not translated so as not to violate character limits
+    name = 'job';
+  }
+
+  return name;
+}
+
+export function NameError(name: string, trans: TranslationBundle): string {
+  if (NameIsValid(name)) {
+    return ''; // No errors
+  }
+
+  // Check for blank
+  if (name === '') {
+    return trans.__('You must specify a name');
+  }
+
+  // Check for errors in first position
+  if (invalidFirstCharRegex.test(name)) {
+    return trans.__(
+      'Name must start with a letter, number, period, or underscore'
+    );
+  }
+
+  // Check for length.
+  if (name.length > maxLength) {
+    return trans.__('Name may not be longer than %1 characters', maxLength);
+  }
+
+  // Check for incorrect characters
+  if (invalidCharRegex.test(name)) {
+    return trans.__(
+      'Name must contain only letters, numbers, periods, hyphens, and underscores'
+    );
+  }
+
+  return ''; // No other errors found
+}


### PR DESCRIPTION
Fixes #234. Adds validation for jobName in the create form. Sanitizes the input filename by truncating its extension, removing disallowed characters, and substituting `job` (not translated) if nothing is left. Job names are now mandatory.

Screen shots: 

Happy case (valid job name)

![image](https://user-images.githubusercontent.com/93281816/199362460-b71bec68-313f-478a-ba26-2b487c141da6.png)

Empty job name

![image](https://user-images.githubusercontent.com/93281816/199362490-b63a78aa-fc58-4775-bc2e-b3a890fe1b1c.png)

Hyphen in first position

![image](https://user-images.githubusercontent.com/93281816/199362523-227bc355-fa6d-4f75-a9ee-357b00f26e78.png)

Too long

![image](https://user-images.githubusercontent.com/93281816/199363778-2aa1f1d6-ae33-4a2e-ad9c-7a190a8c5d95.png)

Invalid characters

![image](https://user-images.githubusercontent.com/93281816/199366855-74b11295-a626-4ce8-a435-7c9e908a64a9.png)
