### PR TITLE
refactor schedule inputs

### DIFF
--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -1,11 +1,11 @@
-import React, { ChangeEvent, useMemo } from 'react';
+import React, { ChangeEvent } from 'react';
 
 import { FormControlLabel, InputLabel, Radio, RadioGroup } from '@mui/material';
 import Stack from '@mui/system/Stack';
 
 import { useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
-import { ScheduleInputs, ScheduleValidator } from './schedule-inputs';
+import { ScheduleInputs } from './schedule-inputs';
 import { Scheduler } from '../tokens';
 
 export type CreateScheduleOptionsProps = {
@@ -22,7 +22,6 @@ export function CreateScheduleOptions(
   props: CreateScheduleOptionsProps
 ): JSX.Element | null {
   const trans = useTranslator('jupyterlab');
-  const validator = useMemo(() => new ScheduleValidator(trans), [trans]);
 
   const labelId = `${props.id}-label`;
 
@@ -31,33 +30,6 @@ export function CreateScheduleOptions(
     value: string
   ) => {
     const name = event.target.name;
-
-    // When changing from JobDefinition to Job, remove errors,
-    // so that in case there's an error with the schedule,
-    // the form can still be submitted.
-    if (value === 'Job') {
-      // Change from 'JobDefinition' and clear all job definition specific errors
-      props.handleErrorsChange({
-        ...props.errors,
-        schedule: '',
-        scheduleInterval: '',
-        timezone: '',
-        scheduleHourMinute: '',
-        scheduleMinute: '',
-        scheduleHour: '',
-        scheduleMonthDay: '',
-        scheduleWeekDay: '',
-        scheduleTime: ''
-      });
-    }
-    if (value === 'JobDefinition' && props.model.schedule) {
-      // If the schedule is not populated, don't display an error for now.
-      props.handleErrorsChange({
-        ...props.errors,
-        schedule: validator.validateSchedule(props.model.schedule)
-      });
-    }
-
     props.handleModelChange({ ...props.model, [name]: value });
   };
 

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -208,15 +208,13 @@ export function ScheduleInputs<
       return trans.__('00:00-23:59');
     }
 
-    const displayMinutes: string = minutes < 10 ? '0' + minutes : '' + minutes;
-    if (hours === 0) {
-      return trans.__('%1:%2 AM', hours, displayMinutes);
-    } else if (hours === 12) {
-      return trans.__('%1:%2 PM', hours, displayMinutes);
-    } else if (hours > 12) {
-      return trans.__('%1:%2 PM', hours - 12, displayMinutes);
+    const displayHours = hours % 12 === 0 ? '12' : hours % 12;
+    const displayMinutes = minutes < 10 ? '0' + minutes : minutes;
+
+    if (hours < 12) {
+      return trans.__('%1:%2 AM', displayHours, displayMinutes);
     } else {
-      return trans.__('%1:%2 AM', hours, displayMinutes);
+      return trans.__('%1:%2 PM', displayHours, displayMinutes);
     }
   }, [trans, props.model.scheduleClock]);
 

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -93,7 +93,7 @@ export function ScheduleInputs<
   );
 
   // validates all schedule fields
-  const validateScheduleFields = () => {
+  const validateScheduleFields = (model: ModelWithScheduleFields) => {
     const newErrors = { ...props.errors };
     for (const fieldKey of fieldKeys) {
       const validator = validatorsByFieldKey[fieldKey];
@@ -102,14 +102,14 @@ export function ScheduleInputs<
       // interval doesn't render this field, then clear validation errors.
       if (
         !validator ||
-        !intervalsByFieldKey[fieldKey].includes(props.model.scheduleInterval)
+        !intervalsByFieldKey[fieldKey].includes(model.scheduleInterval)
       ) {
         newErrors[fieldKey] = '';
         continue;
       }
 
       // otherwise validate the current field.
-      newErrors[fieldKey] = validator(props.model[fieldKey]);
+      newErrors[fieldKey] = validator(model[fieldKey]);
     }
 
     props.handleErrorsChange(newErrors);
@@ -121,7 +121,7 @@ export function ScheduleInputs<
    * - whenever component is unmounted, remove all schedule fields from errors object
    */
   useEffect(() => {
-    validateScheduleFields();
+    validateScheduleFields(props.model);
 
     return () => {
       props.handleErrorsChange({
@@ -169,10 +169,12 @@ export function ScheduleInputs<
       | SelectChangeEvent
       | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
-    props.handleModelChange({
+    const newModel = {
       ...props.model,
       [e.target.name]: e.target.value
-    });
+    };
+    props.handleModelChange(newModel);
+    validateScheduleFields(newModel);
   };
 
   const handleTimezoneChange = (e: unknown, value: string | null) => {
@@ -249,7 +251,6 @@ export function ScheduleInputs<
       name="scheduleClock"
       value={props.model.scheduleClock}
       onChange={handleChange}
-      onBlur={validateScheduleFields}
       error={!!props.errors.scheduleClock}
       helperText={props.errors.scheduleClock || clockHelperText}
     />
@@ -278,7 +279,6 @@ export function ScheduleInputs<
           name="scheduleInterval"
           value={props.model.scheduleInterval}
           onChange={handleChange}
-          onBlur={validateScheduleFields}
         >
           <MenuItem value={'minute'}>{trans.__('Minute')}</MenuItem>
           <MenuItem value={'hour'}>{trans.__('Hour')}</MenuItem>
@@ -298,7 +298,6 @@ export function ScheduleInputs<
             onChange={handleChange}
             error={!!props.errors.scheduleMinute}
             helperText={props.errors.scheduleMinute || trans.__('0–59')}
-            onBlur={validateScheduleFields}
           />
         </>
       )}
@@ -347,7 +346,6 @@ export function ScheduleInputs<
             onChange={handleChange}
             error={!!props.errors.scheduleMonthDay}
             helperText={props.errors.scheduleMonthDay || monthDayHelperText}
-            onBlur={validateScheduleFields}
           />
           {clockInput}
           {timezonePicker}
@@ -364,7 +362,6 @@ export function ScheduleInputs<
             name="schedule"
             error={!!props.errors.schedule}
             helperText={props.errors.schedule || scheduleHelperText}
-            onBlur={validateScheduleFields}
           />
           {cronTips}
           {timezonePicker}

--- a/src/model.ts
+++ b/src/model.ts
@@ -30,28 +30,48 @@ export interface IOutputFormat {
   readonly label: string;
 }
 
+export type ScheduleInterval =
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'weekday'
+  | 'month'
+  | 'custom';
+
 /**
  * Extended by models which back UIs using the <ScheduleInputs /> component.
  */
 export type ModelWithScheduleFields = {
-  // Intervals: 'minute' | 'hour' | 'day' | 'week' | 'weekday' | 'month' | 'custom'
-  scheduleInterval: string;
-  // String for schedule in cron format
-  schedule?: string;
-  // String for timezone in tz database format
-  timezone?: string;
-  // "Easy scheduling" inputs
-  // Minute for an input that only accepts minutes (of the hour)
-  scheduleMinuteInput?: string;
-  scheduleHourMinute?: number;
-  // Hour and minute for time inputs
-  scheduleTimeInput?: string;
-  scheduleMinute?: number;
-  scheduleHour?: number;
-  scheduleMonthDayInput?: string;
-  scheduleMonthDay?: number;
-  scheduleWeekDay?: string;
-  scheduleTime?: number;
+  /**
+   * User's scheduling input encoded as a cron expression.
+   */
+  schedule: string;
+  /**
+   * Timezone specified in tz database format.
+   */
+  timezone: string;
+  /**
+   * Easy scheduling interval. 'custom' allows users to manually input a cron
+   * expression.
+   */
+  scheduleInterval: ScheduleInterval;
+  /**
+   * Value of input field for 24-hour time (hh:mm).
+   */
+  scheduleClock: string;
+  /**
+   * Value of input field for day of the week (SUN-SAT).
+   */
+  scheduleWeekDay: string;
+  /**
+   * Value of input field for day of the month (0-31).
+   */
+  scheduleMonthDay: string;
+  /**
+   * Value of input field for past the hour.
+   */
+  scheduleMinute: string;
 };
 
 export interface ICreateJobModel
@@ -81,6 +101,16 @@ export interface ICreateJobModel
   createInProgress?: boolean;
 }
 
+export const defaultScheduleFields: ModelWithScheduleFields = {
+  schedule: '0 0 * * MON-FRI',
+  scheduleInterval: 'weekday',
+  scheduleClock: '00:00',
+  scheduleMinute: '0',
+  scheduleMonthDay: '1',
+  scheduleWeekDay: '1',
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+};
+
 export function emptyCreateJobModel(): ICreateJobModel {
   return {
     key: Math.random(),
@@ -89,9 +119,7 @@ export function emptyCreateJobModel(): ICreateJobModel {
     outputPath: '',
     environment: '',
     createType: 'Job',
-    scheduleInterval: 'weekday',
-    schedule: '0 0 * * MON-FRI',
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+    ...defaultScheduleFields
   };
 }
 
@@ -105,8 +133,7 @@ export interface IUpdateJobDefinitionModel
 export function emptyUpdateJobDefinitionModel(): IUpdateJobDefinitionModel {
   return {
     definitionId: '',
-    schedule: '',
-    scheduleInterval: 'custom'
+    ...defaultScheduleFields
   };
 }
 

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -12,6 +12,7 @@ import TranslatorContext from './context';
 import { CreateJob } from './mainviews/create-job';
 import { NotebookJobsList } from './mainviews/list-jobs';
 import {
+  defaultScheduleFields,
   ICreateJobModel,
   IJobDefinitionModel,
   JobsModel,
@@ -75,8 +76,10 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     this.model.updateJobDefinitionModel = {
       definitionId: jobDef.definitionId,
       name: jobDef.name,
-      schedule: jobDef.schedule,
-      timezone: jobDef.timezone,
+      ...defaultScheduleFields,
+      // TODO: should these properties really be optional?
+      schedule: jobDef.schedule || '* * * * *',
+      timezone: jobDef.timezone || 'UTC',
       scheduleInterval: 'custom'
     };
   }


### PR DESCRIPTION
## Description

- Refactors `ScheduleInputs` component and the corresponding UI model to remove duplicate state
- Removes duplicate logic in handling state changes
- Implements more robust **coercion logic**, i.e. populating inputs when switching to/from easy scheduling
- Automatically validates on mount and removes validation errors on unmount
- triggers validation on change

## Demo (outdated)

https://user-images.githubusercontent.com/44106031/199591081-e480e1f0-bc61-411d-9b61-6025d9976f01.mov

## Limitations

- Coercion logic has been kept as simple as possible to avoid maintainability issues. It parses each of the CRON terms via `parseInt()`, and uses a default only if the value cannot be parsed.
  - This means that inputting an invalid CRON expression like `99 99 * * MON-FRI`, then switching to "weekday" results in the time being set to `99:99`.
  - In other words, coercion generates an invalid output for invalid inputs.
  - I personally don't see this as a common edge case worth handling, as it requires the user to immediately input an invalid value and then switch intervals.
  - Furthermore, validation errors will prevent submission of an invalid coerced value

## Related issues

- Closes #251
- Closes #262