### PR TITLE
Adds UTC-only option to environment model

### DIFF
--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -25,6 +25,7 @@ class RuntimeEnvironment(BaseModel):
     metadata: Optional[Dict[str, str]]  # Optional metadata
     compute_types: Optional[List[str]]
     default_compute_type: Optional[str]  # Should be a member of the compute_types list
+    utc_only: Optional[bool]
 
     def __str__(self):
         return self.json()

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -16,6 +16,7 @@ export type CreateScheduleOptionsProps = {
   handleModelChange: (model: ICreateJobModel) => void;
   errors: Scheduler.ErrorsType;
   handleErrorsChange: (errors: Scheduler.ErrorsType) => void;
+  utcOnly?: boolean;
 };
 
 export function CreateScheduleOptions(
@@ -60,6 +61,7 @@ export function CreateScheduleOptions(
           handleModelChange={props.handleModelChange}
           errors={props.errors}
           handleErrorsChange={props.handleErrorsChange}
+          utcOnly={props.utcOnly}
         />
       )}
     </Stack>

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -248,7 +248,13 @@ export function ScheduleInputs<
   }
 
   const timezonePicker = props.utcOnly ? (
-    <p>{tzMessage}</p>
+    <p>
+      {tzMessage}
+      <br />
+      {trans.__(
+        'Schedules in UTC are affected by daylight saving time or summer time changes'
+      )}
+    </p>
   ) : (
     <Autocomplete
       id={`${props.idPrefix}timezone`}

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -39,6 +39,7 @@ export type ScheduleInputsProps<
   handleModelChange: (model: M) => void;
   errors: E;
   handleErrorsChange: (errors: E) => void;
+  utcOnly?: boolean;
 };
 
 const emptyScheduleErrors: Record<keyof ErrorsWithScheduleFields, ''> = {
@@ -226,7 +227,29 @@ export function ScheduleInputs<
     }
   }, [props.model.schedule]);
 
-  const timezonePicker = (
+  const tzOffsetHours = new Date().getTimezoneOffset() / 60;
+  let tzMessage;
+  if (tzOffsetHours === 0) {
+    tzMessage = trans.__('Specify time in UTC (local time)');
+  } else if (tzOffsetHours === -1) {
+    tzMessage = trans.__('Specify time in UTC (1 hour behind local time)');
+  } else if (tzOffsetHours < 0) {
+    tzMessage = trans.__(
+      'Specify time in UTC (%1 hours behind local time)',
+      -tzOffsetHours
+    );
+  } else if (tzOffsetHours === 1) {
+    tzMessage = trans.__('Specify time in UTC (1 hour ahead of local time)');
+  } else if (tzOffsetHours > 0) {
+    tzMessage = trans.__(
+      'Specify time in UTC (%1 hours ahead of local time)',
+      tzOffsetHours
+    );
+  }
+
+  const timezonePicker = props.utcOnly ? (
+    <p>{tzMessage}</p>
+  ) : (
     <Autocomplete
       id={`${props.idPrefix}timezone`}
       options={timezones}

--- a/src/components/schedule-inputs.tsx
+++ b/src/components/schedule-inputs.tsx
@@ -232,17 +232,19 @@ export function ScheduleInputs<
   if (tzOffsetHours === 0) {
     tzMessage = trans.__('Specify time in UTC (local time)');
   } else if (tzOffsetHours === -1) {
-    tzMessage = trans.__('Specify time in UTC (1 hour behind local time)');
+    tzMessage = trans.__(
+      'Specify time in UTC (subtract 1 hour from local time)'
+    );
   } else if (tzOffsetHours < 0) {
     tzMessage = trans.__(
-      'Specify time in UTC (%1 hours behind local time)',
+      'Specify time in UTC (subtract %1 hours from local time)',
       -tzOffsetHours
     );
   } else if (tzOffsetHours === 1) {
-    tzMessage = trans.__('Specify time in UTC (1 hour ahead of local time)');
+    tzMessage = trans.__('Specify time in UTC (add 1 hour to local time)');
   } else if (tzOffsetHours > 0) {
     tzMessage = trans.__(
-      'Specify time in UTC (%1 hours ahead of local time)',
+      'Specify time in UTC (add %1 hours to local time)',
       tzOffsetHours
     );
   }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -519,7 +519,7 @@ export namespace Scheduler {
     metadata: { [key: string]: string };
     compute_types: string[] | null;
     default_compute_type: string | null;
-    utc_only: boolean | null;
+    utc_only?: boolean;
   }
 
   export interface IOutputFormat {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -519,6 +519,7 @@ export namespace Scheduler {
     metadata: { [key: string]: string };
     compute_types: string[] | null;
     default_compute_type: string | null;
+    utc_only: boolean | null;
   }
 
   export interface IOutputFormat {

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -113,11 +113,18 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
           envList[0].name
         )?.map(format => format.name);
 
+        // Does the default environment support time zones?
+        let newTimeZone = 'UTC';
+        if (!envList[0].utc_only) {
+          newTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        }
+
         props.handleModelChange({
           ...props.model,
           environment: envList[0].name,
           computeType: newComputeType,
-          outputFormats: outputFormats
+          outputFormats: outputFormats,
+          timezone: newTimeZone
         });
       }
     };
@@ -160,6 +167,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       const envObj = environmentList.find(env => env.name === target.value);
       // Validate that the default compute type is in fact in the list
       let newComputeType = envObj?.compute_types?.[0];
+
       if (
         envObj?.default_compute_type &&
         envObj?.compute_types &&
@@ -167,15 +175,24 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       ) {
         newComputeType = envObj.default_compute_type;
       }
+
       const newEnvOutputFormats = outputFormatsForEnvironment(
         environmentList,
         target.value
       )?.map(format => format.name);
+
+      // Does the new environment support time zones?
+      let newTimeZone = 'UTC';
+      if (!envObj?.utc_only) {
+        newTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      }
+
       props.handleModelChange({
         ...props.model,
         environment: target.value,
         computeType: newComputeType,
-        outputFormats: newEnvOutputFormats
+        outputFormats: newEnvOutputFormats,
+        timezone: newTimeZone
       });
     } else {
       // otherwise, just set the model
@@ -402,6 +419,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     </InputAdornment>
   );
 
+  // Does the currently-selected environment accept times in UTC only?
+  const utcOnly =
+    environmentList.find(e => e.name === props.model.environment)?.utc_only ??
+    undefined;
+
   return (
     <Box sx={{ p: 4 }}>
       <form className={`${formPrefix}form`} onSubmit={e => e.preventDefault()}>
@@ -517,6 +539,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             handleModelChange={props.handleModelChange}
             errors={errors}
             handleErrorsChange={setErrors}
+            utcOnly={utcOnly}
           />
           <Cluster gap={3} justifyContent="flex-end">
             {props.model.createInProgress || (


### PR DESCRIPTION
Fixes #255. Allows an environment to specify that it is UTC-only. A UTC-only environment will not have a time zone selector in the schedule section when creating job descriptions. In addition, when the user submits a job for such an environment, the `timezone` argument will not be sent in the request payload.

In the screen shot below, a custom handler has overridden an environment to be UTC-only.

![Screen shot of create-job form showing UTC-only messaging](https://user-images.githubusercontent.com/93281816/199609263-348624bd-d295-432b-89c0-fac991a392bd.png)