### PR TITLE
move input job file link

### DIFF
--- a/src/components/job-file-link.tsx
+++ b/src/components/job-file-link.tsx
@@ -10,16 +10,28 @@ import { Link } from '@mui/material';
 export interface IJobFileLinkProps {
   jobFile: Scheduler.IJobFile;
   app: JupyterFrontEnd;
+  children?: React.ReactNode;
 }
 
 export function JobFileLink(props: IJobFileLinkProps): JSX.Element | null {
   const trans = useTranslator('jupyterlab');
 
+  if (!props.jobFile.file_path) {
+    return null;
+  }
+
+  const fileBaseName = props.jobFile.file_path.split('/').pop();
+
+  const title =
+    props.jobFile.file_format === 'input'
+      ? trans.__('Open input file "%1"', fileBaseName)
+      : trans.__('Open output file "%1"', fileBaseName);
+
   return (
     <Link
       key={props.jobFile.file_format}
       href={`/lab/tree/${props.jobFile.file_path}`}
-      title={trans.__('Open "%1"', props.jobFile.file_path)}
+      title={title}
       onClick={(
         e:
           | React.MouseEvent<HTMLSpanElement, MouseEvent>
@@ -32,7 +44,7 @@ export function JobFileLink(props: IJobFileLinkProps): JSX.Element | null {
       }}
       style={{ paddingRight: '1em' }}
     >
-      {props.jobFile.display_name}
+      {props.children || props.jobFile.display_name}
     </Link>
   );
 }

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -113,15 +113,9 @@ export function buildJobRow(
   const cellContents: React.ReactNode[] = [
     <Link onClick={() => showDetailView(job.job_id)}>{job.name}</Link>,
     inputFile ? (
-      <Link
-        onClick={() => {
-          app.commands.execute('docmanager:open', {
-            path: inputFile.file_path
-          });
-        }}
-      >
+      <JobFileLink app={app} jobFile={inputFile}>
         {job.input_filename}
-      </Link>
+      </JobFileLink>
     ) : (
       job.input_filename
     ),

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -9,6 +9,7 @@ import { useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
 import DownloadIcon from '@mui/icons-material/Download';
 import StopIcon from '@mui/icons-material/Stop';
+import { Link } from '@mui/material';
 import { IconButton, Stack, TableCell, TableRow } from '@mui/material';
 
 function StopButton(props: {
@@ -57,11 +58,11 @@ function JobFiles(props: {
 
   return (
     <>
-      {props.job.job_files.map(jobFile => {
-        return (
-          jobFile.file_path && <JobFileLink jobFile={jobFile} app={props.app} />
-        );
-      })}
+      {props.job.job_files
+        .filter(jobFile => jobFile.file_format !== 'input' && jobFile.file_path)
+        .map(jobFile => (
+          <JobFileLink jobFile={jobFile} app={props.app} />
+        ))}
     </>
   );
 }
@@ -106,9 +107,25 @@ export function buildJobRow(
   showDetailView: (jobId: string) => void,
   reload: () => void
 ): JSX.Element {
+  const inputFile = job.job_files.find(
+    jobFile => jobFile.file_format === 'input' && jobFile.file_path
+  );
+
   const cellContents: React.ReactNode[] = [
-    <a onClick={() => showDetailView(job.job_id)}>{job.name}</a>,
-    job.input_filename,
+    <Link onClick={() => showDetailView(job.job_id)}>{job.name}</Link>,
+    inputFile ? (
+      <Link
+        onClick={() => {
+          app.commands.execute('docmanager:open', {
+            path: inputFile.file_path
+          });
+        }}
+      >
+        {job.input_filename}
+      </Link>
+    ) : (
+      job.input_filename
+    ),
     <>
       {!job.downloaded && job.status === 'COMPLETED' && (
         <DownloadFilesButton app={app} job={job} reload={reload} />

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -9,8 +9,7 @@ import { useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
 import DownloadIcon from '@mui/icons-material/Download';
 import StopIcon from '@mui/icons-material/Stop';
-import { Link } from '@mui/material';
-import { IconButton, Stack, TableCell, TableRow } from '@mui/material';
+import { IconButton, Stack, Link, TableCell, TableRow } from '@mui/material';
 
 function StopButton(props: {
   job: Scheduler.IDescribeJob;

--- a/src/components/labeled-value.tsx
+++ b/src/components/labeled-value.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export interface ILabeledValueProps {
   label: string;
   id?: string;
-  value?: string | number | boolean;
+  value?: React.ReactNode;
   style?: React.CSSProperties;
   InputProps?: {
     startAdornment: JSX.Element;

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -18,7 +18,6 @@ import {
   Card,
   CardContent,
   FormLabel,
-  Link,
   Stack,
   TextField,
   TextFieldProps
@@ -128,15 +127,9 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       {
         label: trans.__('Input file'),
         value: inputJobFile ? (
-          <Link
-            onClick={() => {
-              props.app.commands.execute('docmanager:open', {
-                path: inputJobFile.file_path
-              });
-            }}
-          >
+          <JobFileLink app={props.app} jobFile={inputJobFile}>
             {props.model.inputFile}
-          </Link>
+          </JobFileLink>
         ) : (
           props.model.inputFile
         )

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -110,11 +110,11 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
     },
     {
       sortField: 'input_filename',
-      name: trans.__('Input filename')
+      name: trans.__('Input file')
     },
     {
       sortField: null,
-      name: trans.__('Job files')
+      name: trans.__('Output files')
     },
     {
       sortField: 'create_time',

--- a/src/model.ts
+++ b/src/model.ts
@@ -274,7 +274,7 @@ export interface IJobDetailModel {
   startTime?: number;
   endTime?: number;
   outputPrefix?: string;
-  job_files: { [key: string]: string }[];
+  job_files: Scheduler.IJobFile[];
   downloaded: boolean;
 }
 


### PR DESCRIPTION
## Description

- Replaces input filename with link to input file upon download
- Renames "Input filename" label to "Input file"
- Renames "Job files" label to "Output files" (since their corresponding elements no longer include the input file)
- Only renders "Output files" section in Job Detail when there are output files

## Demo

https://user-images.githubusercontent.com/44106031/199618050-ee351671-01eb-4d3f-9bb9-5757d03b2af9.mov

## Related issues

Closes #242.