### PR TITLE
Adds error reporting

### DIFF
--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,66 @@
+import { Alert, AlertTitle, Stack, Typography } from '@mui/material';
+
+import React from 'react';
+
+interface IErrorBoundaryProps {}
+
+interface IErrorBoundaryState {
+  hasError: boolean;
+  error?: unknown;
+}
+
+export class ErrorBoundary extends React.Component<
+  React.PropsWithChildren<IErrorBoundaryProps>,
+  IErrorBoundaryState
+> {
+  constructor(props: IErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: unknown): IErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true, error: error };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
+    // You can also log the error to an error reporting service
+    console.log('Caught error in ErrorBoundary', error, errorInfo);
+  }
+
+  render(): React.ReactNode {
+    const errorMessage =
+      'We encountered an internal error. Please try your command again.';
+
+    let errorDetail;
+    if (typeof this.state.error === 'string') {
+      errorDetail = this.state.error;
+    } else if (this.state.error instanceof Error) {
+      errorDetail = this.state.error.message;
+    }
+
+    let infoSection;
+    if (errorDetail !== undefined) {
+      infoSection = (
+        <>
+          <Typography variant="h1">Error details</Typography>
+          <pre>{errorDetail}</pre>
+        </>
+      );
+    }
+    if (this.state.hasError) {
+      return (
+        <div className="jp-error-boundary">
+          <Stack spacing={4}>
+            <Alert severity="error">
+              <AlertTitle>Internal error</AlertTitle>
+              {errorMessage}
+            </Alert>
+            {infoSection}
+          </Stack>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -22,13 +22,7 @@ export class ErrorBoundary extends React.Component<
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error: unknown): IErrorBoundaryState {
-    // Update state so the next render will show the fallback UI.
-    return { hasError: true, error: error };
-  }
-
   componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
-    // You can also log the error to an error reporting service
     // errorInfo has full stack trace, which we are not using
     this.setState({ hasError: true, error });
   }
@@ -41,15 +35,6 @@ export class ErrorBoundary extends React.Component<
       errorDetail = this.state.error.message;
     }
 
-    let infoSection;
-    if (errorDetail !== undefined) {
-      infoSection = (
-        <>
-          <Typography variant="h1">{this.props.detailTitle}</Typography>
-          <pre>{errorDetail}</pre>
-        </>
-      );
-    }
     if (this.state.hasError) {
       return (
         <div className="jp-error-boundary">
@@ -58,7 +43,12 @@ export class ErrorBoundary extends React.Component<
               <AlertTitle>{this.props.alertTitle}</AlertTitle>
               {this.props.alertMessage}
             </Alert>
-            {infoSection}
+            {errorDetail && (
+              <>
+                <Typography variant="h1">{this.props.detailTitle}</Typography>
+                <pre>{errorDetail}</pre>
+              </>
+            )}
           </Stack>
         </div>
       );

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -2,7 +2,11 @@ import { Alert, AlertTitle, Stack, Typography } from '@mui/material';
 
 import React from 'react';
 
-interface IErrorBoundaryProps {}
+interface IErrorBoundaryProps {
+  alertTitle: string;
+  alertMessage: string;
+  detailTitle: string;
+}
 
 interface IErrorBoundaryState {
   hasError: boolean;
@@ -29,9 +33,6 @@ export class ErrorBoundary extends React.Component<
   }
 
   render(): React.ReactNode {
-    const errorMessage =
-      'We encountered an internal error. Please try your command again.';
-
     let errorDetail;
     if (typeof this.state.error === 'string') {
       errorDetail = this.state.error;
@@ -43,7 +44,7 @@ export class ErrorBoundary extends React.Component<
     if (errorDetail !== undefined) {
       infoSection = (
         <>
-          <Typography variant="h1">Error details</Typography>
+          <Typography variant="h1">{this.props.detailTitle}</Typography>
           <pre>{errorDetail}</pre>
         </>
       );
@@ -53,8 +54,8 @@ export class ErrorBoundary extends React.Component<
         <div className="jp-error-boundary">
           <Stack spacing={4}>
             <Alert severity="error">
-              <AlertTitle>Internal error</AlertTitle>
-              {errorMessage}
+              <AlertTitle>{this.props.alertTitle}</AlertTitle>
+              {this.props.alertMessage}
             </Alert>
             {infoSection}
           </Stack>

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -29,7 +29,8 @@ export class ErrorBoundary extends React.Component<
 
   componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
     // You can also log the error to an error reporting service
-    console.log('Caught error in ErrorBoundary', error, errorInfo);
+    // errorInfo has full stack trace, which we are not using
+    this.setState({ hasError: true, error });
   }
 
   render(): React.ReactNode {

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from '@mui/material/styles';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { VDomRenderer } from '@jupyterlab/apputils';
-import { ITranslator } from '@jupyterlab/translation';
+import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import { LabIcon } from '@jupyterlab/ui-components';
 
 import { ErrorBoundary } from './components/error-boundary';
@@ -32,6 +32,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   readonly _description?: string;
   readonly _app: JupyterFrontEnd;
   readonly _translator: ITranslator;
+  readonly _trans: TranslationBundle;
   readonly _advancedOptions: React.FunctionComponent<Scheduler.IAdvancedOptionsProps>;
 
   constructor(options: NotebookJobsPanel.IOptions) {
@@ -54,6 +55,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     this._description = options.description ?? trans.__('Job Runs');
     this._app = options.app;
     this._translator = options.translator;
+    this._trans = this._translator.load('jupyterlab');
     this._advancedOptions = options.advancedOptions;
 
     this.node.setAttribute('role', 'region');
@@ -93,17 +95,15 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
       this.model.jobsView = JobsView.CreateForm;
     };
 
-    const trans = this._translator.load('jupyterlab');
-
     return (
       <ThemeProvider theme={getJupyterLabTheme()}>
         <TranslatorContext.Provider value={this._translator}>
           <ErrorBoundary
-            alertTitle={trans.__('Internal error')}
-            alertMessage={trans.__(
+            alertTitle={this._trans.__('Internal error')}
+            alertMessage={this._trans.__(
               'We encountered an internal error. Please try your command again.'
             )}
-            detailTitle={trans.__('Error details')}
+            detailTitle={this._trans.__('Error details')}
           >
             {this.model.jobsView === JobsView.CreateForm && (
               <CreateJob

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -93,10 +93,18 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
       this.model.jobsView = JobsView.CreateForm;
     };
 
+    const trans = this._translator.load('jupyterlab');
+
     return (
       <ThemeProvider theme={getJupyterLabTheme()}>
         <TranslatorContext.Provider value={this._translator}>
-          <ErrorBoundary>
+          <ErrorBoundary
+            alertTitle={trans.__('Internal error')}
+            alertMessage={trans.__(
+              'We encountered an internal error. Please try your command again.'
+            )}
+            detailTitle={trans.__('Error details')}
+          >
             {this.model.jobsView === JobsView.CreateForm && (
               <CreateJob
                 key={this.model.createJobModel.key}

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -7,10 +7,16 @@ import { VDomRenderer } from '@jupyterlab/apputils';
 import { ITranslator } from '@jupyterlab/translation';
 import { LabIcon } from '@jupyterlab/ui-components';
 
+import { ErrorBoundary } from './components/error-boundary';
 import { calendarMonthIcon } from './components/icons';
-import TranslatorContext from './context';
+
 import { CreateJob } from './mainviews/create-job';
+import { DetailView } from './mainviews/detail-view';
+import { CreateJobFromDefinition } from './mainviews/create-job-from-definition';
+import { EditJobDefinition } from './mainviews/edit-job-definition';
 import { NotebookJobsList } from './mainviews/list-jobs';
+
+import TranslatorContext from './context';
 import {
   defaultScheduleFields,
   ICreateJobModel,
@@ -20,9 +26,6 @@ import {
 } from './model';
 import { getJupyterLabTheme } from './theme-provider';
 import { Scheduler } from './tokens';
-import { DetailView } from './mainviews/detail-view';
-import { CreateJobFromDefinition } from './mainviews/create-job-from-definition';
-import { EditJobDefinition } from './mainviews/edit-job-definition';
 
 export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   readonly _title?: string;
@@ -93,65 +96,71 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     return (
       <ThemeProvider theme={getJupyterLabTheme()}>
         <TranslatorContext.Provider value={this._translator}>
-          {this.model.jobsView === JobsView.CreateForm && (
-            <CreateJob
-              key={this.model.createJobModel.key}
-              model={this.model.createJobModel}
-              handleModelChange={newModel =>
-                (this.model.createJobModel = newModel)
-              }
-              showListView={this.showListView.bind(this)}
-              advancedOptions={this._advancedOptions}
-            />
-          )}
-          {this.model.jobsView === JobsView.CreateFromJobDescriptionForm && (
-            <CreateJobFromDefinition
-              key={this.model.createJobModel.key}
-              model={this.model.createJobModel}
-              handleModelChange={newModel =>
-                (this.model.createJobModel = newModel)
-              }
-              showListView={this.showListView.bind(this)}
-              advancedOptions={this._advancedOptions}
-            />
-          )}
-          {(this.model.jobsView === JobsView.ListJobs ||
-            this.model.jobsView === JobsView.ListJobDefinitions) && (
-            <NotebookJobsList
-              app={this._app}
-              listView={this.model.jobsView}
-              showListView={this.showListView.bind(this)}
-              showCreateJob={showCreateJob}
-              showJobDetail={this.showDetailView.bind(this)}
-              showJobDefinitionDetail={this.showJobDefinitionDetail.bind(this)}
-            />
-          )}
-          {(this.model.jobsView === JobsView.JobDetail ||
-            this.model.jobsView === JobsView.JobDefinitionDetail) && (
-            <DetailView
-              app={this._app}
-              model={this.model.jobDetailModel}
-              setCreateJobModel={newModel =>
-                (this.model.createJobModel = newModel)
-              }
-              jobsView={this.model.jobsView}
-              setJobsView={view => (this.model.jobsView = view)}
-              showCreateJob={showCreateJob}
-              showJobDetail={this.showDetailView.bind(this)}
-              editJobDefinition={this.editJobDefinition.bind(this)}
-              advancedOptions={this._advancedOptions}
-            />
-          )}
-          {this.model.jobsView === JobsView.EditJobDefinition && (
-            <EditJobDefinition
-              model={this.model.updateJobDefinitionModel}
-              handleModelChange={newModel =>
-                (this.model.updateJobDefinitionModel = newModel)
-              }
-              showListView={this.showListView.bind(this)}
-              showJobDefinitionDetail={this.showJobDefinitionDetail.bind(this)}
-            />
-          )}
+          <ErrorBoundary>
+            {this.model.jobsView === JobsView.CreateForm && (
+              <CreateJob
+                key={this.model.createJobModel.key}
+                model={this.model.createJobModel}
+                handleModelChange={newModel =>
+                  (this.model.createJobModel = newModel)
+                }
+                showListView={this.showListView.bind(this)}
+                advancedOptions={this._advancedOptions}
+              />
+            )}
+            {this.model.jobsView === JobsView.CreateFromJobDescriptionForm && (
+              <CreateJobFromDefinition
+                key={this.model.createJobModel.key}
+                model={this.model.createJobModel}
+                handleModelChange={newModel =>
+                  (this.model.createJobModel = newModel)
+                }
+                showListView={this.showListView.bind(this)}
+                advancedOptions={this._advancedOptions}
+              />
+            )}
+            {(this.model.jobsView === JobsView.ListJobs ||
+              this.model.jobsView === JobsView.ListJobDefinitions) && (
+              <NotebookJobsList
+                app={this._app}
+                listView={this.model.jobsView}
+                showListView={this.showListView.bind(this)}
+                showCreateJob={showCreateJob}
+                showJobDetail={this.showDetailView.bind(this)}
+                showJobDefinitionDetail={this.showJobDefinitionDetail.bind(
+                  this
+                )}
+              />
+            )}
+            {(this.model.jobsView === JobsView.JobDetail ||
+              this.model.jobsView === JobsView.JobDefinitionDetail) && (
+              <DetailView
+                app={this._app}
+                model={this.model.jobDetailModel}
+                setCreateJobModel={newModel =>
+                  (this.model.createJobModel = newModel)
+                }
+                jobsView={this.model.jobsView}
+                setJobsView={view => (this.model.jobsView = view)}
+                showCreateJob={showCreateJob}
+                showJobDetail={this.showDetailView.bind(this)}
+                editJobDefinition={this.editJobDefinition.bind(this)}
+                advancedOptions={this._advancedOptions}
+              />
+            )}
+            {this.model.jobsView === JobsView.EditJobDefinition && (
+              <EditJobDefinition
+                model={this.model.updateJobDefinitionModel}
+                handleModelChange={newModel =>
+                  (this.model.updateJobDefinitionModel = newModel)
+                }
+                showListView={this.showListView.bind(this)}
+                showJobDefinitionDetail={this.showJobDefinitionDetail.bind(
+                  this
+                )}
+              />
+            )}
+          </ErrorBoundary>
         </TranslatorContext.Provider>
       </ThemeProvider>
     );

--- a/style/base.css
+++ b/style/base.css
@@ -28,6 +28,17 @@
   margin-top: 12px;
 }
 
+/* Error reporting */
+.jp-error-boundary {
+  max-width: 500px;
+  margin: 12px;
+}
+
+.jp-error-boundary h1 {
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+
 /* Create job form */
 
 .jp-create-job-form {


### PR DESCRIPTION
Fixes #236. Adds an error handler that intercepts errors and displays a message.

In the example below, the create form has been overridden to throw an exception.

![open-create-error](https://user-images.githubusercontent.com/93281816/200076363-d0d11c45-38af-4d8b-92b8-62c2edd0a2aa.gif)
