### PR TITLE
hide timezone selector when editing job definition created with utc_only environment

### DIFF
--- a/dev/seed.py
+++ b/dev/seed.py
@@ -36,7 +36,7 @@ def get_db_path():
     return os.path.join(data[0], "scheduler.sqlite")
 
 
-def create_random_job_def(index: int) -> CreateJobDefinition:
+def create_random_job_def(index: int, env: str) -> CreateJobDefinition:
     name = (
         random.choice(
             [
@@ -66,7 +66,7 @@ def create_random_job_def(index: int) -> CreateJobDefinition:
         timezone=timezone,
         schedule=schedule,
         active=active,
-        runtime_environment_name="",
+        runtime_environment_name=env,
     )
 
 
@@ -128,6 +128,9 @@ async def load_data(jobs_count: int, job_defs_count: int, db_path: str):
         environments_manager=CondaEnvironmentManager(),
         task_runner_class=None,
     )
+
+    environments = scheduler.environments_manager.list_environments()
+
     job_def_ids = []
 
     # clear existing output files
@@ -138,7 +141,8 @@ async def load_data(jobs_count: int, job_defs_count: int, db_path: str):
     os.mkdir(os.path.join(root_dir, "outputs"))
 
     for index in range(1, job_defs_count + 1):
-        job_def_id = scheduler.create_job_definition(create_random_job_def(index))
+        env = random.choice(environments).name
+        job_def_id = scheduler.create_job_definition(create_random_job_def(index, env))
         job_def_ids.append(job_def_id)
 
     for index in range(1, jobs_count + 1):

--- a/src/model.ts
+++ b/src/model.ts
@@ -127,12 +127,15 @@ export interface IUpdateJobDefinitionModel
   extends ModelWithScheduleFields,
     PartialJSONObject {
   definitionId: string;
-  name?: string;
+  name: string;
+  environment: string;
 }
 
 export function emptyUpdateJobDefinitionModel(): IUpdateJobDefinitionModel {
   return {
     definitionId: '',
+    name: '',
+    environment: '',
     ...defaultScheduleFields
   };
 }

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -81,6 +81,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     this.model.updateJobDefinitionModel = {
       definitionId: jobDef.definitionId,
       name: jobDef.name,
+      environment: jobDef.environment,
       ...defaultScheduleFields,
       // TODO: should these properties really be optional?
       schedule: jobDef.schedule || '* * * * *',


### PR DESCRIPTION
Fixes #279.

New behavior of edit job definition view:

- fetches list of environments on initial render
- sets model timezone and passes `utcOnly: true` prop to `ScheduleInputs` component accordingly

Also updates the seed script to use the conda environments in the job definitions.

https://user-images.githubusercontent.com/44106031/200087959-b0f31558-1998-46d0-9c08-dabf0a010969.mov
