### PR TITLE
Uses same schema for create job/JD error

### DIFF
--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -383,10 +383,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         // Switch to the list view with "Job Definition List" active
         props.showListView(JobsView.ListJobDefinitions);
       })
-      .catch((error: string) => {
+      .catch((error: Error) => {
         props.handleModelChange({
           ...props.model,
-          createError: error,
+          createError: error.message,
           createInProgress: false
         });
       });


### PR DESCRIPTION
Fixes #281 by correcting an error in the "create job definition" error handler. It now uses the same schema as the "create job" error handler.

In the following animation, the "create job definition" handler is overridden to always fail.

![create-job-defn](https://user-images.githubusercontent.com/93281816/200435374-31acb680-b693-414e-8776-76c6a43f93b9.gif)
