### PR TITLE
Error alerts in list job definitions view

### DIFF
--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -91,7 +91,8 @@ export function buildJobDefinitionRow(
   ) => void,
   forceReload: () => void,
   trans: TranslationBundle,
-  ss: SchedulerService
+  ss: SchedulerService,
+  handleApiError: (error: string) => void
 ): JSX.Element {
   const cellContents: React.ReactNode[] = [
     // name
@@ -106,23 +107,37 @@ export function buildJobDefinitionRow(
       <PauseButton
         jobDef={jobDef}
         clickHandler={async () => {
-          await ss.pauseJobDefinition(jobDef.job_definition_id);
-          forceReload();
+          ss.pauseJobDefinition(jobDef.job_definition_id)
+            .then(response => {
+              forceReload();
+            })
+            .catch((error: Error) => {
+              handleApiError(error.message);
+            });
         }}
       />
       <ResumeButton
         jobDef={jobDef}
         clickHandler={async () => {
-          await ss.resumeJobDefinition(jobDef.job_definition_id);
-          forceReload();
+          ss.resumeJobDefinition(jobDef.job_definition_id)
+            .then(response => {
+              forceReload();
+            })
+            .catch((error: Error) => {
+              handleApiError(error.message);
+            });
         }}
       />
       <ConfirmDeleteButton
         name={jobDef.name}
         clickHandler={async () => {
-          await ss.deleteJobDefinition(jobDef.job_definition_id);
-
-          deleteRow(jobDef.job_definition_id);
+          ss.deleteJobDefinition(jobDef.job_definition_id)
+            .then(response => {
+              deleteRow(jobDef.job_definition_id);
+            })
+            .catch((error: Error) => {
+              handleApiError(error.message);
+            });
         }}
       />
     </Stack>

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -108,7 +108,7 @@ export function buildJobDefinitionRow(
         jobDef={jobDef}
         clickHandler={async () => {
           ss.pauseJobDefinition(jobDef.job_definition_id)
-            .then(response => {
+            .then(_ => {
               forceReload();
             })
             .catch((error: Error) => {
@@ -120,7 +120,7 @@ export function buildJobDefinitionRow(
         jobDef={jobDef}
         clickHandler={async () => {
           ss.resumeJobDefinition(jobDef.job_definition_id)
-            .then(response => {
+            .then(_ => {
               forceReload();
             })
             .catch((error: Error) => {
@@ -132,7 +132,7 @@ export function buildJobDefinitionRow(
         name={jobDef.name}
         clickHandler={async () => {
           ss.deleteJobDefinition(jobDef.job_definition_id)
-            .then(response => {
+            .then(_ => {
               deleteRow(jobDef.job_definition_id);
             })
             .catch((error: Error) => {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -60,7 +60,7 @@ export class SchedulerService {
           method: 'GET'
         }
       );
-    } catch (e: any) {
+    } catch (e) {
       console.error(e);
     }
     return data as Scheduler.IDescribeJobDefinition;
@@ -78,7 +78,7 @@ export class SchedulerService {
       data = await requestAPI(this.serverSettings, `job_definitions${query}`, {
         method: 'GET'
       });
-    } catch (e: any) {
+    } catch (e) {
       console.error(e);
     }
     return data as Scheduler.IListJobDefinitionsResponse;
@@ -93,7 +93,7 @@ export class SchedulerService {
         method: 'POST',
         body: JSON.stringify(definition)
       });
-    } catch (e: any) {
+    } catch (e) {
       return Promise.reject(e);
     }
     return data as Scheduler.IDescribeJobDefinition;
@@ -112,7 +112,7 @@ export class SchedulerService {
           method: 'DELETE'
         }
       );
-    } catch (e: any) {
+    } catch (e) {
       Promise.reject(e);
     }
     return data as Scheduler.IDescribeJobDefinition;
@@ -128,7 +128,7 @@ export class SchedulerService {
       data = await requestAPI(this.serverSettings, `jobs${query}`, {
         method: 'GET'
       });
-    } catch (e: any) {
+    } catch (e) {
       console.error(e);
     }
     return data as Scheduler.IDescribeJob;
@@ -145,7 +145,7 @@ export class SchedulerService {
       data = await requestAPI(this.serverSettings, `jobs${query}`, {
         method: 'GET'
       });
-    } catch (e: any) {
+    } catch (e) {
       console.error(e);
     }
     return data as Scheduler.IListJobsResponse;
@@ -198,7 +198,7 @@ export class SchedulerService {
           body: JSON.stringify(model)
         }
       );
-    } catch (e: any) {
+    } catch (e) {
       return Promise.reject(e);
     }
     return data as Scheduler.ICreateJobResponse;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -113,7 +113,7 @@ export class SchedulerService {
         }
       );
     } catch (e: any) {
-      console.error(e);
+      Promise.reject(e);
     }
     return data as Scheduler.IDescribeJobDefinition;
   }
@@ -244,8 +244,8 @@ export class SchedulerService {
         method: 'PATCH',
         body: JSON.stringify({ active: false })
       });
-    } catch (e) {
-      console.error(e);
+    } catch (e: unknown) {
+      Promise.reject(e);
     }
   }
 
@@ -255,8 +255,8 @@ export class SchedulerService {
         method: 'PATCH',
         body: JSON.stringify({ active: true })
       });
-    } catch (e) {
-      console.error(e);
+    } catch (e: unknown) {
+      Promise.reject(e);
     }
   }
 

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -228,7 +228,10 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
       <Button
         variant="contained"
         size="small"
-        onClick={() => setJobDefsQuery(query => ({ ...query }))}
+        onClick={() => {
+          setDisplayError(undefined);
+          setJobDefsQuery(query => ({ ...query }));
+        }}
       >
         {trans.__('Reload')}
       </Button>

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
-import Button from '@mui/material/Button';
-import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import { Alert, Button, Box, Stack, Tab, Tabs } from '@mui/material';
 
 import { Heading } from '../components/heading';
 import { useTranslator } from '../hooks';
@@ -189,6 +185,8 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
   const [deletedRows, setDeletedRows] = useState<
     Set<Scheduler.IDescribeJobDefinition['job_definition_id']>
   >(new Set());
+  const [displayError, setDisplayError] = useState<string | undefined>();
+
   const api = useMemo(() => new SchedulerService({}), []);
 
   const deleteRow = useCallback(
@@ -245,7 +243,8 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
       deleteRow,
       () => setJobDefsQuery({}),
       trans,
-      new SchedulerService({})
+      new SchedulerService({}),
+      setDisplayError
     );
 
   const rowFilter = (jobDef: Scheduler.IDescribeJobDefinition) =>
@@ -262,6 +261,7 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
 
   return (
     <>
+      {displayError && <Alert severity="error">{displayError}</Alert>}
       {reloadButton}
       <AdvancedTable
         query={jobDefsQuery}


### PR DESCRIPTION
Fixes #276 by capturing failures of pause, reject, and delete job definition actions and displaying them as alerts.

This only affects the job definitions list. The jobs list's "delete" action is asynchronous; there are no other immediate actions.

![reject-pause](https://user-images.githubusercontent.com/93281816/200448506-9af2b968-4c7f-4b2b-9e15-65ac32776357.gif)
