### PR TITLE
Errors for pause, resume, delete in detail page and list view

### DIFF
--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -92,7 +92,7 @@ export function buildJobDefinitionRow(
   forceReload: () => void,
   trans: TranslationBundle,
   ss: SchedulerService,
-  handleApiError: (error: string | undefined) => void
+  handleApiError: (error: string | null) => void
 ): JSX.Element {
   const cellContents: React.ReactNode[] = [
     // name
@@ -110,7 +110,7 @@ export function buildJobDefinitionRow(
       <PauseButton
         jobDef={jobDef}
         clickHandler={async () => {
-          handleApiError(undefined);
+          handleApiError(null);
           ss.pauseJobDefinition(jobDef.job_definition_id)
             .then(_ => {
               forceReload();
@@ -123,7 +123,7 @@ export function buildJobDefinitionRow(
       <ResumeButton
         jobDef={jobDef}
         clickHandler={async () => {
-          handleApiError(undefined);
+          handleApiError(null);
           ss.resumeJobDefinition(jobDef.job_definition_id)
             .then(_ => {
               forceReload();
@@ -136,7 +136,7 @@ export function buildJobDefinitionRow(
       <ConfirmDeleteButton
         name={jobDef.name}
         clickHandler={async () => {
-          handleApiError(undefined);
+          handleApiError(null);
           ss.deleteJobDefinition(jobDef.job_definition_id)
             .then(_ => {
               deleteRow(jobDef.job_definition_id);

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -92,7 +92,7 @@ export function buildJobDefinitionRow(
   forceReload: () => void,
   trans: TranslationBundle,
   ss: SchedulerService,
-  handleApiError: (error: string) => void
+  handleApiError: (error: string | undefined) => void
 ): JSX.Element {
   const cellContents: React.ReactNode[] = [
     // name
@@ -110,6 +110,7 @@ export function buildJobDefinitionRow(
       <PauseButton
         jobDef={jobDef}
         clickHandler={async () => {
+          handleApiError(undefined);
           ss.pauseJobDefinition(jobDef.job_definition_id)
             .then(_ => {
               forceReload();
@@ -122,6 +123,7 @@ export function buildJobDefinitionRow(
       <ResumeButton
         jobDef={jobDef}
         clickHandler={async () => {
+          handleApiError(undefined);
           ss.resumeJobDefinition(jobDef.job_definition_id)
             .then(_ => {
               forceReload();
@@ -134,6 +136,7 @@ export function buildJobDefinitionRow(
       <ConfirmDeleteButton
         name={jobDef.name}
         clickHandler={async () => {
+          handleApiError(undefined);
           ss.deleteJobDefinition(jobDef.job_definition_id)
             .then(_ => {
               deleteRow(jobDef.job_definition_id);

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -47,21 +47,21 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const handleDeleteJobDefinition = async () => {
     ss.deleteJobDefinition(props.model.definitionId ?? '')
       .then(_ => props.setJobsView(JobsView.ListJobDefinitions))
-      .catch(e => setDisplayError(e));
+      .catch((e: Error) => setDisplayError(e.message));
   };
 
   const pauseJobDefinition = async () => {
     setDisplayError(undefined);
     ss.pauseJobDefinition(props.model.definitionId)
       .then(_ => props.refresh())
-      .catch(e => setDisplayError(e));
+      .catch((e: Error) => setDisplayError(e.message));
   };
 
   const resumeJobDefinition = async () => {
     setDisplayError(undefined);
     ss.resumeJobDefinition(props.model.definitionId)
       .then(_ => props.refresh())
-      .catch(e => setDisplayError(e));
+      .catch((e: Error) => setDisplayError(e.message));
   };
 
   const runJobDefinition = () => {

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -51,12 +51,14 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   };
 
   const pauseJobDefinition = async () => {
+    setDisplayError(undefined);
     ss.pauseJobDefinition(props.model.definitionId)
       .then(_ => props.refresh())
       .catch(e => setDisplayError(e));
   };
 
   const resumeJobDefinition = async () => {
+    setDisplayError(undefined);
     ss.resumeJobDefinition(props.model.definitionId)
       .then(_ => props.refresh())
       .catch(e => setDisplayError(e));

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -40,7 +40,7 @@ export interface IJobDefinitionProps {
 
 export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
-  const [displayError, setDisplayError] = useState<string | undefined>();
+  const [displayError, setDisplayError] = useState<string | null>(null);
 
   const ss = useMemo(() => new SchedulerService({}), []);
 
@@ -51,14 +51,14 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   };
 
   const pauseJobDefinition = async () => {
-    setDisplayError(undefined);
+    setDisplayError(null);
     ss.pauseJobDefinition(props.model.definitionId)
       .then(_ => props.refresh())
       .catch((e: Error) => setDisplayError(e.message));
   };
 
   const resumeJobDefinition = async () => {
-    setDisplayError(undefined);
+    setDisplayError(null);
     ss.resumeJobDefinition(props.model.definitionId)
       .then(_ => props.refresh())
       .catch((e: Error) => setDisplayError(e.message));

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   IJobDefinitionModel,
   JobsView,
@@ -12,7 +12,14 @@ import cronstrue from 'cronstrue';
 import { ListJobsTable } from '../list-jobs';
 import { Scheduler as SchedulerTokens } from '../../tokens';
 
-import { Button, Card, CardContent, FormLabel, Stack } from '@mui/material';
+import {
+  Alert,
+  Button,
+  Card,
+  CardContent,
+  FormLabel,
+  Stack
+} from '@mui/material';
 import { ConfirmDialogDeleteButton } from '../../components/confirm-dialog-buttons';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import {
@@ -33,22 +40,26 @@ export interface IJobDefinitionProps {
 
 export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
+  const [displayError, setDisplayError] = useState<string | undefined>();
 
   const ss = useMemo(() => new SchedulerService({}), []);
 
   const handleDeleteJobDefinition = async () => {
-    await ss.deleteJobDefinition(props.model.definitionId ?? '');
-    props.setJobsView(JobsView.ListJobDefinitions);
+    ss.deleteJobDefinition(props.model.definitionId ?? '')
+      .then(_ => props.setJobsView(JobsView.ListJobDefinitions))
+      .catch(e => setDisplayError(e));
   };
 
   const pauseJobDefinition = async () => {
-    await ss.pauseJobDefinition(props.model.definitionId);
-    props.refresh();
+    ss.pauseJobDefinition(props.model.definitionId)
+      .then(_ => props.refresh())
+      .catch(e => setDisplayError(e));
   };
 
   const resumeJobDefinition = async () => {
-    await ss.resumeJobDefinition(props.model.definitionId);
-    props.refresh();
+    ss.resumeJobDefinition(props.model.definitionId)
+      .then(_ => props.refresh())
+      .catch(e => setDisplayError(e));
   };
 
   const runJobDefinition = () => {
@@ -217,6 +228,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
 
   return (
     <>
+      {displayError && <Alert severity="error">{displayError}</Alert>}
       {DefinitionButtonBar}
       {JobDefinition}
       {JobsList}

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -97,7 +97,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     setDisplayError(undefined);
     ss.deleteJob(props.model.jobId ?? '')
       .then(_ => props.setJobsView(JobsView.ListJobs))
-      .catch(e => setDisplayError(e));
+      .catch((e: Error) => setDisplayError(e.message));
   };
 
   const handleStopJob = async () => {
@@ -107,7 +107,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
         id: props.model.jobId
       })
       .then(_ => props.handleModelChange())
-      .catch(e => setDisplayError(e));
+      .catch((e: Error) => setDisplayError(e.message));
   };
 
   const downloadFiles = async () => {

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -94,14 +94,14 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   );
 
   const handleDeleteJob = async () => {
-    setDisplayError(undefined);
+    setDisplayError(null);
     ss.deleteJob(props.model.jobId ?? '')
       .then(_ => props.setJobsView(JobsView.ListJobs))
       .catch((e: Error) => setDisplayError(e.message));
   };
 
   const handleStopJob = async () => {
-    setDisplayError(undefined);
+    setDisplayError(null);
     props.app.commands
       .execute('scheduling:stop-job', {
         id: props.model.jobId

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -62,11 +62,12 @@ export const timestampLocalize = (time: number | ''): string => {
 export function JobDetail(props: IJobDetailProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
   const [downloading, setDownloading] = useState(false);
+  const [displayError, setDisplayError] = useState<string | undefined>();
 
   const ss = new SchedulerService({});
 
   const translateStatus = useCallback(
-    (status: Scheduler.Status) => {
+    (status: Scheduler.Status | undefined) => {
       // This may look inefficient, but it's intended to call the `trans` function
       // with distinct, static values, so that code analyzers can pick up all the
       // needed source strings.
@@ -85,21 +86,26 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
           return trans.__('Stopped');
         case 'STOPPING':
           return trans.__('Stopping');
+        default:
+          return '';
       }
     },
     [trans]
   );
 
   const handleDeleteJob = async () => {
-    await ss.deleteJob(props.model.jobId ?? '');
-    props.setJobsView(JobsView.ListJobs);
+    ss.deleteJob(props.model.jobId ?? '')
+      .then(_ => props.setJobsView(JobsView.ListJobs))
+      .catch(e => setDisplayError(e));
   };
 
   const handleStopJob = async () => {
-    await props.app.commands.execute('scheduling:stop-job', {
-      id: props.model.jobId
-    });
-    props.handleModelChange();
+    props.app.commands
+      .execute('scheduling:stop-job', {
+        id: props.model.jobId
+      })
+      .then(_ => props.handleModelChange())
+      .catch(e => setDisplayError(e));
   };
 
   const downloadFiles = async () => {
@@ -168,7 +174,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     ],
     [
       {
-        value: translateStatus(props.model.status!),
+        value: translateStatus(props.model.status),
         label: trans.__('Status')
       },
       {
@@ -292,10 +298,11 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   return (
     <>
-      {ButtonBar}
+      {displayError && <Alert severity="error">{displayError}</Alert>}
       {props.model.statusMessage && (
         <Alert severity="error">{props.model.statusMessage}</Alert>
       )}
+      {ButtonBar}
       {CoreOptions}
       {Parameters}
       {AdvancedOptions}

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -62,7 +62,7 @@ export const timestampLocalize = (time: number | ''): string => {
 export function JobDetail(props: IJobDetailProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
   const [downloading, setDownloading] = useState(false);
-  const [displayError, setDisplayError] = useState<string | undefined>();
+  const [displayError, setDisplayError] = useState<string | null>(null);
 
   const ss = new SchedulerService({});
 

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -94,12 +94,14 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   );
 
   const handleDeleteJob = async () => {
+    setDisplayError(undefined);
     ss.deleteJob(props.model.jobId ?? '')
       .then(_ => props.setJobsView(JobsView.ListJobs))
       .catch(e => setDisplayError(e));
   };
 
   const handleStopJob = async () => {
+    setDisplayError(undefined);
     props.app.commands
       .execute('scheduling:stop-job', {
         id: props.model.jobId

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -185,7 +185,7 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
   const [deletedRows, setDeletedRows] = useState<
     Set<Scheduler.IDescribeJobDefinition['job_definition_id']>
   >(new Set());
-  const [displayError, setDisplayError] = useState<string | undefined>();
+  const [displayError, setDisplayError] = useState<string | null>();
 
   const api = useMemo(() => new SchedulerService({}), []);
 

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -185,7 +185,7 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
   const [deletedRows, setDeletedRows] = useState<
     Set<Scheduler.IDescribeJobDefinition['job_definition_id']>
   >(new Set());
-  const [displayError, setDisplayError] = useState<string | null>();
+  const [displayError, setDisplayError] = useState<string | null>(null);
 
   const api = useMemo(() => new SchedulerService({}), []);
 
@@ -229,7 +229,7 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
         variant="contained"
         size="small"
         onClick={() => {
-          setDisplayError(undefined);
+          setDisplayError(null);
           setJobDefsQuery(query => ({ ...query }));
         }}
       >


### PR DESCRIPTION
Fixes #276. Adds error handlers for the detail page and list view for pause, resume, and delete for jobs and job definitions (except for "delete job" in the list view, which does not make a command call). Displays an alert if an error gets caught. Suppresses the alert on a reload or a new command.

In the video below, the handler is customized to throw errors on all pause and delete job definition requests.

https://user-images.githubusercontent.com/93281816/200671964-4eda0ba6-80f8-4cba-9c76-8001dd066d8b.mov

