### PR TITLE
Adds tooltips to job definition links from list view

### DIFF
--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -7,7 +7,7 @@ import { PathExt } from '@jupyterlab/coreutils';
 
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import { IconButton } from '@mui/material';
+import { IconButton, Link } from '@mui/material';
 import Stack from '@mui/material/Stack';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
@@ -96,9 +96,12 @@ export function buildJobDefinitionRow(
 ): JSX.Element {
   const cellContents: React.ReactNode[] = [
     // name
-    <a onClick={() => openJobDefinitionDetail(jobDef.job_definition_id)}>
+    <Link
+      onClick={() => openJobDefinitionDetail(jobDef.job_definition_id)}
+      title={`Open detail view for "${jobDef.name}"`}
+    >
       {jobDef.name}
-    </a>,
+    </Link>,
     PathExt.basename(jobDef.input_filename),
     <CreatedAt job={jobDef} />,
     <ScheduleSummary schedule={jobDef.schedule} />,


### PR DESCRIPTION
Fixes #269. In the jobs list, job names already had tooltips on hover. Adds the same functionality, with the same styling, to the job definitions list.

![image](https://user-images.githubusercontent.com/93281816/200679451-c405ca80-f954-4483-b64e-59acc1a108a8.png)
