### PR TITLE
Guards against "6–5 of 5"

### DIFF
--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -170,8 +170,19 @@ export function AdvancedTable<
           // for some reason `to` is set incorrectly on the last page in
           // server-side pagination, so we need to build the string differently
           // in this case.
+
+          // In a case where "from" is larger than the row count, display no message.
+          // This happens when the last page incorrectly has a nextToken.
+          if (from > loadedRows) {
+            return '';
+          }
+
           return trans.__('%1–%2 of %3', from, loadedRows, loadedRows);
         } else {
+          if (from > to) {
+            return '';
+          }
+
           return trans.__(
             '%1–%2 of %3',
             from,
@@ -180,6 +191,10 @@ export function AdvancedTable<
           );
         }
       } else {
+        if (from > to) {
+          return '';
+        }
+
         return trans.__('%1–%2 of %3', from, to, count);
       }
     },


### PR DESCRIPTION
Fixes #289 by explicitly guarding against displaying a hint in the Advanced Table footer where the "from" number is greater than the "to" number