### PR TITLE
correctly handle last page even when latest next_token is truthy

### DIFF
--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -155,8 +155,6 @@ export function AdvancedTable<
       .catch((e: Error) => {
         setDisplayError(e.message);
       });
-
-    return true;
   };
 
   const renderedRows: JSX.Element[] = useMemo(

--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -193,19 +193,8 @@ export function AdvancedTable<
           // for some reason `to` is set incorrectly on the last page in
           // server-side pagination, so we need to build the string differently
           // in this case.
-
-          // In a case where "from" is larger than the row count, display no message.
-          // This happens when the last page incorrectly has a nextToken.
-          if (from > loadedRows) {
-            return '';
-          }
-
           return trans.__('%1–%2 of %3', from, loadedRows, loadedRows);
         } else {
-          if (from > to) {
-            return '';
-          }
-
           return trans.__(
             '%1–%2 of %3',
             from,
@@ -214,10 +203,6 @@ export function AdvancedTable<
           );
         }
       } else {
-        if (from > to) {
-          return '';
-        }
-
         return trans.__('%1–%2 of %3', from, to, count);
       }
     },


### PR DESCRIPTION
Renders error banner in `AdvancedTable` when attempting to navigate to a next page with no rows. We determine that the user is already on the last page and disable the next page button as well.

## Demos

https://user-images.githubusercontent.com/44106031/200930566-b732e602-a9d8-47ee-9d8e-97590e6c9c13.mov

https://user-images.githubusercontent.com/44106031/200930588-b40c7fee-0804-4535-a8fa-9bfed606efe2.mov


## Related issues / PRs

- Closes #289
- Reverts #290
- Closes #291
