### PR TITLE
Adds success message on "run job from definition"

### DIFF
--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -18,7 +18,9 @@ export interface ICreateJobFromDefinitionProps {
   model: ICreateJobModel;
   handleModelChange: (model: ICreateJobModel) => void;
   showListView: (
-    list: JobsView.ListJobs | JobsView.ListJobDefinitions
+    list: JobsView.ListJobs | JobsView.ListJobDefinitions,
+    newlyCreatedId?: string,
+    newlyCreatedName?: string
   ) => unknown;
   // Extension point: optional additional component
   advancedOptions: React.FunctionComponent<SchedulerTokens.IAdvancedOptionsProps>;
@@ -138,7 +140,11 @@ export function CreateJobFromDefinition(
       )
       .then(response => {
         // Switch to the list view with "Job List" active
-        props.showListView(JobsView.ListJobs);
+        props.showListView(
+          JobsView.ListJobs,
+          response.job_id,
+          props.model.jobName
+        );
       })
       .catch((error: Error) => {
         props.handleModelChange({

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -67,6 +67,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const runJobDefinition = () => {
     const initialState: ICreateJobModel = {
       ...emptyCreateJobModel(),
+      jobName: props.model.name,
       inputFile: props.model.inputFile,
       outputPath: props.model.outputPrefix ?? '',
       environment: props.model.environment,


### PR DESCRIPTION
Fixes #300 opened by @edwardps. Adds the job definition as the new job name to the "create job from job definition" model, displays a success message after a successful create.

https://user-images.githubusercontent.com/93281816/201399757-93da7362-f712-4735-a10c-e57bd4933940.mov

