### PR TITLE
Updates "Download job files" tooltip in list jobs view

### DIFF
--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -79,7 +79,7 @@ function DownloadFilesButton(props: DownloadFilesButtonProps) {
   return (
     <IconButton
       aria-label="download"
-      title={trans.__('Download Job Files')}
+      title={trans.__('Download job files for "%1"', props.job.name)}
       disabled={downloading}
       onClick={async () => {
         setDownloading(true);


### PR DESCRIPTION
Fixes #295. Updates tooltip for consistency with rest of job row: uses sentence case and adds the job name.

![Screen Shot 2022-11-14 at 4 24 42 PM](https://user-images.githubusercontent.com/93281816/201796337-6c14a29d-5ad0-4491-a13d-8a72e971073b.png)
