### PR TITLE
Adds override for job files manager, more error handlers

### DIFF
--- a/docs/operators/index.md
+++ b/docs/operators/index.md
@@ -31,7 +31,7 @@ jupyter lab --SchedulerApp.db_url=sqlite:///<database-file-path>
 
 ### scheduler_class
 
-The fully classified classname to use for the scheduler API. This class should
+The fully qualified classname to use for the scheduler API. This class should
 extend `jupyter_scheduler.scheduler.BaseScheduler` and implement all abstract
 methods. The default class is `jupyter_scheduler.scheduler.Scheduler`.
 
@@ -43,7 +43,7 @@ For more information on how to write a custom implementation, please to our {doc
 
 ### environment_manager_class
 
-The fully classified classname to use for the environment manager. This class
+The fully qualified classname to use for the environment manager. This class
 should extend `jupyter_scheduler.environments.EnvironmentManager` and implement
 all abstract methods. The default class is
 `jupyter_scheduler.environments.CondaEnvironmentManager`.
@@ -56,7 +56,7 @@ For more information on writing a custom implementation, please see the {doc}`de
 
 ### execution_manager_class
 
-The fully classified classname to use for the execution manager, the module that
+The fully qualified classname to use for the execution manager, the module that
 is responsible for reading the input file, executing and writing the output.
 This option lets you specify a custom execution engine without replacing the
 whole scheduler API. This class should extend
@@ -69,6 +69,19 @@ jupyter lab --BaseScheduler.execution_manager_class=jupyter_scheduler.executors.
 
 # Or, on the Scheduler class directly
 jupyter lab --Scheduler.execution_manager_class=jupyter_scheduler.executors.DefaultExecutionManager
+```
+
+For more information on writing a custom implementation, please see the {doc}`developer's guide </developers/index>`.
+
+### job_files_manager_class
+
+The fully qualified classname to use for the job files manager. This class
+should extend `jupyter_scheduler.job_files_manager.JobFilesManager` and implement
+all abstract methods. The default class is
+`jupyter_scheduler.job_files_manager.JobFilesManager`.
+
+```
+jupyter lab --SchedulerApp.job_files_manager_class=jupyter_scheduler.job_files_manager.JobFilesManager
 ```
 
 For more information on writing a custom implementation, please see the {doc}`developer's guide </developers/index>`.

--- a/jupyter_scheduler/extension.py
+++ b/jupyter_scheduler/extension.py
@@ -5,7 +5,6 @@ from jupyter_server.extension.application import ExtensionApp
 from jupyter_server.transutils import _i18n
 from traitlets import Bool, Type, Unicode, default
 
-from jupyter_scheduler.job_files_manager import JobFilesManager
 from jupyter_scheduler.orm import create_tables
 
 from .handlers import (
@@ -60,6 +59,13 @@ class SchedulerApp(ExtensionApp):
         help=_i18n("The scheduler class to use."),
     )
 
+    job_files_manager_class = Type(
+        default_value="jupyter_scheduler.job_files_manager.JobFilesManager",
+        klass="jupyter_scheduler.job_files_manager.JobFilesManager",
+        config=True,
+        help=_i18n("The job files manager class to use."),
+    )
+
     def initialize_settings(self):
         super().initialize_settings()
 
@@ -74,7 +80,7 @@ class SchedulerApp(ExtensionApp):
             config=self.config,
         )
 
-        job_files_manager = JobFilesManager(scheduler=scheduler)
+        job_files_manager = self.job_files_manager_class(scheduler=scheduler)
 
         self.settings.update(
             environments_manager=environments_manager,

--- a/jupyter_scheduler/job_files_manager.py
+++ b/jupyter_scheduler/job_files_manager.py
@@ -5,10 +5,10 @@ from multiprocessing import Process
 from typing import Dict, List, Optional, Type
 
 import fsspec
+from jupyter_server.utils import ensure_async
 
 from jupyter_scheduler.exceptions import SchedulerError
 from jupyter_scheduler.scheduler import BaseScheduler
-from jupyter_server.utils import ensure_async
 
 
 class JobFilesManager:
@@ -96,6 +96,7 @@ class Downloader:
                             output_file.write(input_file.read())
                 except Exception as e:
                     pass
+
 
 class JobFilesManagerWithErrors(JobFilesManager):
     """

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -270,7 +270,7 @@ export class SchedulerService {
         }
       );
     } catch (e) {
-      console.log(e);
+      return Promise.reject(e);
     }
   }
 

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -112,13 +112,20 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   const downloadFiles = async () => {
     setDownloading(true);
-    await props.app.commands.execute(CommandIDs.downloadFiles, {
-      id: props.model.jobId,
-      redownload: false
-    });
-    await new Promise(res => setTimeout(res, 5000));
-    await props.handleModelChange();
-    setDownloading(false);
+    props.app.commands
+      .execute(CommandIDs.downloadFiles, {
+        id: props.model.jobId,
+        redownload: false
+      })
+      .then(() => {
+        new Promise(res => setTimeout(res, 5000)).then(_ =>
+          props.handleModelChange().then(_ => setDownloading(false))
+        );
+      })
+      .catch((e: Error) => {
+        setDisplayError(e.message);
+        setDownloading(false);
+      });
   };
 
   const ButtonBar = (

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -39,6 +39,9 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
   const [deletedRows, setDeletedRows] = useState<
     Set<Scheduler.IDescribeJob['job_id']>
   >(new Set());
+  const [displayError, setDisplayError] = useState<React.ReactNode | null>(
+    null
+  );
 
   const trans = useTranslator('jupyterlab');
 
@@ -136,7 +139,8 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
       deleteRow,
       translateStatus,
       props.showJobDetail,
-      reload
+      reload,
+      setDisplayError
     );
 
   const rowFilter = (job: Scheduler.IDescribeJob) =>
@@ -155,6 +159,11 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
   // note that root element here must be a JSX fragment for DataGrid to be sized properly
   return (
     <>
+      {displayError && (
+        <Alert severity="error" onClose={() => setDisplayError(null)}>
+          {displayError}
+        </Alert>
+      )}
       {reloadButton}
       <AdvancedTable
         query={jobsQuery}


### PR DESCRIPTION
Fixes #296 (all remaining items) by adding error handlers for:

1. List notebook jobs: Download files
2. List notebook jobs: Delete job
3. List notebook jobs: Stop job
4. Job detail: Download files

For testing purposes, this change also lets users override the job files manager. I created a class that induces errors about half the time. You can run JupyterLab in extra-errors mode with:
```
jupyter lab \
 --SchedulerApp.job_files_manager_class=jupyter_scheduler.job_files_manager.JobFilesManagerWithErrors \
 --SchedulerApp.scheduler_class=jupyter_scheduler.scheduler.SchedulerWithErrors
```