### PR TITLE
Adds reload on detail page

### DIFF
--- a/src/components/button-bar.tsx
+++ b/src/components/button-bar.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Stack } from '@mui/material';
+
+export interface IButtonBarProps {
+  children?: React.ReactNode;
+}
+
+export function ButtonBar(props: IButtonBarProps): JSX.Element {
+  return (
+    <Stack direction="row" gap={2} justifyContent="flex-end" flexWrap={'wrap'}>
+      {props.children}
+    </Stack>
+  );
+}

--- a/src/mainviews/detail-view/detail-view.tsx
+++ b/src/mainviews/detail-view/detail-view.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import {
@@ -20,6 +20,7 @@ import {
   Alert,
   Box,
   Breadcrumbs,
+  Button,
   CircularProgress,
   Link,
   Stack,
@@ -86,7 +87,7 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
     }
   };
 
-  useEffect(() => {
+  const fetchModel = () => {
     switch (props.jobsView) {
       case JobsView.JobDetail:
         fetchJobDetailModel();
@@ -95,7 +96,16 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
         fetchJobDefinitionModel();
         break;
     }
+  };
+
+  useEffect(() => {
+    fetchModel();
   }, [props.jobsView, props.model, props.model.id]);
+
+  const reload = useCallback(() => {
+    setFetchError(undefined);
+    fetchModel();
+  }, []);
 
   const BreadcrumbsStyled = (
     <div role="presentation">
@@ -137,7 +147,16 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
             ? trans.__('Job Detail')
             : trans.__('Job Definition')}
         </Heading>
-        {fetchError && <Alert severity="error">{fetchError}</Alert>}
+        <Stack direction="row" gap={2} justifyContent="flex-end" flexWrap={'wrap'}>
+          <Button variant="outlined" color="primary" onClick={reload}>
+            {trans.__('Reload')}
+          </Button>
+        </Stack>
+        {fetchError && (
+          <Alert severity="error" onClose={() => setFetchError(undefined)}>
+            {fetchError}
+          </Alert>
+        )}
         {props.jobsView === JobsView.JobDetail && jobModel && (
           <JobDetail
             app={props.app}

--- a/src/mainviews/detail-view/detail-view.tsx
+++ b/src/mainviews/detail-view/detail-view.tsx
@@ -147,7 +147,12 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
             ? trans.__('Job Detail')
             : trans.__('Job Definition')}
         </Heading>
-        <Stack direction="row" gap={2} justifyContent="flex-end" flexWrap={'wrap'}>
+        <Stack
+          direction="row"
+          gap={2}
+          justifyContent="flex-end"
+          flexWrap={'wrap'}
+        >
           <Button variant="outlined" color="primary" onClick={reload}>
             {trans.__('Reload')}
           </Button>

--- a/src/mainviews/detail-view/detail-view.tsx
+++ b/src/mainviews/detail-view/detail-view.tsx
@@ -20,7 +20,6 @@ import {
   Alert,
   Box,
   Breadcrumbs,
-  Button,
   CircularProgress,
   Link,
   Stack,
@@ -147,22 +146,12 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
             ? trans.__('Job Detail')
             : trans.__('Job Definition')}
         </Heading>
-        <Stack
-          direction="row"
-          gap={2}
-          justifyContent="flex-end"
-          flexWrap={'wrap'}
-        >
-          <Button variant="outlined" color="primary" onClick={reload}>
-            {trans.__('Reload')}
-          </Button>
-        </Stack>
         {fetchError && (
           <Alert severity="error" onClose={() => setFetchError(undefined)}>
             {fetchError}
           </Alert>
         )}
-        {props.jobsView === JobsView.JobDetail && jobModel && (
+        {props.jobsView === JobsView.JobDetail && (
           <JobDetail
             app={props.app}
             model={jobModel}
@@ -171,9 +160,10 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
             setJobsView={props.setJobsView}
             // Extension point: optional additional component
             advancedOptions={props.advancedOptions}
+            reload={reload}
           />
         )}
-        {props.jobsView === JobsView.JobDefinitionDetail && jobDefinitionModel && (
+        {props.jobsView === JobsView.JobDefinitionDetail && (
           <JobDefinition
             app={props.app}
             model={jobDefinitionModel}
@@ -184,6 +174,7 @@ export function DetailView(props: IDetailViewProps): JSX.Element {
             editJobDefinition={props.editJobDefinition}
             // Extension point: optional additional component
             advancedOptions={props.advancedOptions}
+            reload={reload}
           />
         )}
         {!jobModel && !jobDefinitionModel && !fetchError && (

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -70,7 +70,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const model: IJobDefinitionModel = props.model;
 
   const handleDeleteJobDefinition = async () => {
-    ss.deleteJobDefinition(props.model?.definitionId ?? '')
+    ss.deleteJobDefinition(model.definitionId ?? '')
       .then(_ => props.setJobsView(JobsView.ListJobDefinitions))
       .catch((e: Error) => setDisplayError(e.message));
   };
@@ -109,8 +109,8 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
 
   let cronString;
   try {
-    if (props.model.schedule !== undefined) {
-      cronString = cronstrue.toString(props.model.schedule);
+    if (model.schedule !== undefined) {
+      cronString = cronstrue.toString(model.schedule);
     }
   } catch (e) {
     // Do nothing; let the errors or nothing display instead
@@ -122,7 +122,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
       <Button variant="outlined" onClick={runJobDefinition}>
         {trans.__('Run Job')}
       </Button>
-      {props.model.active ? (
+      {model.active ? (
         <Button variant="outlined" onClick={pauseJobDefinition}>
           {trans.__('Pause')}
         </Button>
@@ -145,45 +145,45 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   );
 
   const jobDefinitionFields: ILabeledValueProps[][] = [
-    [{ value: props.model.name, label: trans.__('Name') }],
+    [{ value: model.name, label: trans.__('Name') }],
     [
       {
-        value: props.model.inputFile,
+        value: model.inputFile,
         label: trans.__('Input file')
       },
       {
-        value: props.model.outputPath,
+        value: model.outputPath,
         label: trans.__('Output directory')
       }
     ],
     [
       {
-        value: props.model.environment,
+        value: model.environment,
         label: trans.__('Environment')
       },
       {
-        value: props.model.active ? trans.__('Active') : trans.__('Paused'),
+        value: model.active ? trans.__('Active') : trans.__('Paused'),
         label: trans.__('Status')
       }
     ],
     [
       {
-        value: timestampLocalize(props.model.createTime ?? ''),
+        value: timestampLocalize(model.createTime ?? ''),
         label: trans.__('Created at')
       },
       {
-        value: timestampLocalize(props.model.updateTime ?? ''),
+        value: timestampLocalize(model.updateTime ?? ''),
         label: trans.__('Updated at')
       }
     ],
     [
       {
-        value: props.model.schedule ?? '',
+        value: model.schedule ?? '',
         helperText: cronString ?? '',
         label: trans.__('Schedule')
       },
       {
-        value: props.model.timezone ?? '',
+        value: model.timezone ?? '',
         label: trans.__('Time zone')
       }
     ]
@@ -219,7 +219,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
           </FormLabel>
           <props.advancedOptions
             jobsView={JobsView.JobDefinitionDetail}
-            model={props.model}
+            model={model}
             handleModelChange={(_: any) => {
               return;
             }}
@@ -241,7 +241,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
             app={props.app}
             showCreateJob={props.showCreateJob}
             showJobDetail={props.showJobDetail}
-            jobDefinitionId={props.model.definitionId}
+            jobDefinitionId={model.definitionId}
             pageSize={5}
             emptyRowMessage={trans.__(
               'No notebook jobs associated with this job definition.'


### PR DESCRIPTION
Fixes #313. On top of the job detail and job definition detail page, adds a "Reload" button. This does not appear in the same button bar as other buttons do because those buttons only render if the job model or JD model is defined.


https://user-images.githubusercontent.com/93281816/202331296-95ebe62b-f56a-4bf9-96f3-a6f8935a8482.mov

