### PR TITLE
fix(event-note-icon): add viewBox attr to svg so it resizes

### DIFF
--- a/style/icons/event-note.svg
+++ b/style/icons/event-note.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="48" width="48">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" height="48" width="48">
   <path fill="#0097A7" d="M14 27v-3h20v3Zm0 9v-3h13.95v3Zm-5 8q-1.2 0-2.1-.9Q6 42.2 6 41V10q0-1.2.9-2.1Q7.8 7 9 7h3.25V4h3.25v3h17V4h3.25v3H39q1.2 0 2.1.9.9.9.9 2.1v31q0 1.2-.9 2.1-.9.9-2.1.9Zm0-3h30V19.5H9V41Z"/>
 </svg>


### PR DESCRIPTION
Bringing this fix as Sagemaker Studio couldn't resize the icon associated to "scheduling:show-notebook-jobs" command, added to the new Studio launcher with a smaller size than before

See this codepen for more infos https://codepen.io/tefa-dev/pen/gOjLZQZ, the icon doesn't resize without `viewBox`