### PR TITLE
WIP: Adds error message on 404 response from backend

### DIFF
--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -41,6 +41,9 @@ import {
 } from '@mui/material';
 
 import { Box, Stack } from '@mui/system';
+import { ServerConnection } from '@jupyterlab/services';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { SERVER_EXTENSION_404 } from '../util/errors';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -338,6 +341,29 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         // Switch to the list view with "Job List" active
         props.showListView(JobsView.ListJobs, response.job_id, jobOptions.name);
       })
+      .catch((responseError: ServerConnection.ResponseError) => {
+        // Response error: got something other than 200 OK in response
+        const responseCode = responseError.response.status;
+        // Treat a 404 Not Found response as the backend not being present.
+        if (responseCode === 404) {
+          showDialog({
+            title: trans.__('Jupyter Scheduler server extension not found'),
+            body: SERVER_EXTENSION_404,
+            buttons: [Dialog.okButton()]
+          }).catch(console.warn);
+        }
+
+        const errorMessage =
+          responseCode === 404
+            ? trans.__('Jupyter Scheduler server extension cannot be found.')
+            : responseError.message;
+
+        props.handleModelChange({
+          ...props.model,
+          createError: errorMessage,
+          createInProgress: false
+        });
+      })
       .catch((error: Error) => {
         props.handleModelChange({
           ...props.model,
@@ -388,6 +414,29 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
           response.job_definition_id,
           jobDefinitionOptions.name
         );
+      })
+      .catch((responseError: ServerConnection.ResponseError) => {
+        // Response error: got something other than 200 OK in response
+        const responseCode = responseError.response.status;
+        // Treat a 404 Not Found response as the backend not being present.
+        if (responseCode === 404) {
+          showDialog({
+            title: trans.__('Jupyter Scheduler server extension not found'),
+            body: SERVER_EXTENSION_404,
+            buttons: [Dialog.okButton()]
+          }).catch(console.warn);
+        }
+
+        const errorMessage =
+          responseCode === 404
+            ? trans.__('Jupyter Scheduler server extension cannot be found.')
+            : responseError.message;
+
+        props.handleModelChange({
+          ...props.model,
+          createError: errorMessage,
+          createInProgress: false
+        });
       })
       .catch((error: Error) => {
         props.handleModelChange({

--- a/src/util/errors.tsx
+++ b/src/util/errors.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export const SERVER_EXTENSION_404 = (
+  <div>
+    <p>
+      It looks like the required Jupyter Server extension (
+      <code>jupyter_scheduler</code>) is not installed or not enabled in this
+      environment.
+    </p>
+    <h3>Why am I seeing this message?</h3>
+    <p>
+      If you installed the Jupyter Scheduler extension from the Extension
+      Manager in JupyterLab, you might have installed only the client extension
+      and not the server extension. You can install the server extension by
+      running <code>pip install jupyter_scheduler</code> in the same environment
+      in which you run JupyterLab.
+    </p>
+    <h3>How do I check if the extension is installed?</h3>
+    <p>
+      Please ensure that <code>jupyter server extension list</code> includes
+      jupyter_scheduler and that it is enabled. If it is enabled, please restart
+      JupyterLab. If the server extension is installed but not enabled, run{' '}
+      <code>jupyter server extension enable --user --py jupyter_scheduler</code>{' '}
+      and restart JupyterLab.
+    </p>
+  </div>
+);


### PR DESCRIPTION
Work-in-progress change for #329.

If the server extension is absent or disabled, displays a dialog box after the user attempts to create a job or job definition:

![image](https://user-images.githubusercontent.com/93281816/221057046-f2f88dd3-61ce-467d-bd8c-9a9091ffee9f.png)

… then, after the dialog box is dismissed, the user sees an informative message instead of a lot of HTML.

![image (1)](https://user-images.githubusercontent.com/93281816/221057099-5ffcf8b5-8380-4bd5-aeb9-d0dd833d9246.png)
