### PR TITLE
Adds server extension check on startup

### DIFF
--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -69,6 +69,7 @@ $ jupyter labextension list
 ```
 
 Then, remove the symlink named `jupyter-scheduler` within that folder.
+
 ```
 # Remove the symlink
 rm /opt/anaconda3/envs/jupyter-scheduler/share/jupyter/labextensions/jupyter_scheduler
@@ -134,7 +135,7 @@ Documentation source files are written in
 expressive flavor of Markdown. These files are located under `docs/`.
 
 The generated documentation files placed under `docs/_build/html` can be
-directly opened in the browser.  We recommend bookmarking these file links
+directly opened in the browser. We recommend bookmarking these file links
 if you will be editing and reviewing documentation frequently in the browser.
 
 Sphinx by default only rebuilds files it detects were changed, though this
@@ -153,21 +154,21 @@ panel on GitHub and follow the following instructions to release a new version o
 Jupyter Scheduler.
 
 1. Select the "Step 1: Prep Release" workflow on the left-hand panel, and then
-select "Run workflow". This will open the workflow form. Replace the "Next Version
-Specifier" with the next version of Jupyter Scheduler (e.g. 1.2.3). "Branch to Target"
-should be replaced with the branch that should be released. Usually this will be `main`.
-Then select "Run workflow" button to run the workflow.
+   select "Run workflow". This will open the workflow form. Replace the "Next Version
+   Specifier" with the next version of Jupyter Scheduler (e.g. 1.2.3). "Branch to Target"
+   should be replaced with the branch that should be released. Usually this will be `main`.
+   Then select "Run workflow" button to run the workflow.
 
 2. Verify the draft release changelog in the
-[Releases](https://github.com/jupyter-server/jupyter-scheduler/releases) page
-for Jupyter Scheduler.
+   [Releases](https://github.com/jupyter-server/jupyter-scheduler/releases) page
+   for Jupyter Scheduler.
 
 3. Return to the Actions panel and select the "Step 2: Publish Release" workflow.
-Run this workflow with the target branch set to the same branch specified in
-Step 1.
+   Run this workflow with the target branch set to the same branch specified in
+   Step 1.
 
 4. Wait for the workflow to complete, and then verify the publish on PyPi and
-NPM.
+   NPM.
 
 ### Manual release
 

--- a/docs/operators/index.md
+++ b/docs/operators/index.md
@@ -91,9 +91,9 @@ For more information on writing a custom implementation, please see the {doc}`de
 You can configure the Jupyter Scheduler UI by installing a lab extension that both:
 
 1. Exports a
-[plugin](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#plugins)
-providing the `Scheduler.IAdvancedOptions`
-[token](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#tokens).
+   [plugin](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#plugins)
+   providing the `Scheduler.IAdvancedOptions`
+   [token](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#tokens).
 
 2. Disables the `@jupyterlab/scheduler:IAdvancedOptions` plugin.
 

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -28,30 +28,30 @@ and checking that both the `jupyter_scheduler` server extension and the
 
 ## Use
 
-Jupyter Scheduler runs Jupyter notebooks in the background, either once or on a schedule. You can create *jobs* (single run of an individual notebook) and *job definitions* (scheduled recurring notebook jobs). When the scheduler runs your notebook, it makes a copy of the input file. The scheduler uses unique names for the input and output files so that rerunning the same notebook produces new files every time.
-
+Jupyter Scheduler runs Jupyter notebooks in the background, either once or on a schedule. You can create _jobs_ (single run of an individual notebook) and _job definitions_ (scheduled recurring notebook jobs). When the scheduler runs your notebook, it makes a copy of the input file. The scheduler uses unique names for the input and output files so that rerunning the same notebook produces new files every time.
 
 ### Creating a job or job definition
 
 #### Choose a notebook
-To create a *job* or *job definition* from a file browser, right-click on a notebook in the file browser and choose “Create Notebook Job” from the context menu:
+
+To create a _job_ or _job definition_ from a file browser, right-click on a notebook in the file browser and choose “Create Notebook Job” from the context menu:
 ![“Create Notebook Job” button in the file browser context menu](./images/create_job_from_filebrowser.png)
 
-To create a *job* or *job definition* from an open notebook, click on a “Create a notebook job” button in the top toolbar of the open notebook:
+To create a _job_ or _job definition_ from an open notebook, click on a “Create a notebook job” button in the top toolbar of the open notebook:
 ![“Create a notebook job” button in the top toolbar of the open Notebook](./images/create_job_from_notebook.png)
 
 #### Submit the Create Job form
 
 Give your notebook job or job definition a name, choose an environment to run it in, select its output formats, and provide parameters that are set as local variables when your notebook gets executed. This parameterized execution is similar to the one used in [Papermill](https://papermill.readthedocs.io/en/latest/).
 
-To create a *job* that runs once, select "Run now" in the "Schedule" section, and click "Create".
-   !["Create Job Form"](./images/create_job_form.png)
+To create a _job_ that runs once, select "Run now" in the "Schedule" section, and click "Create".
+!["Create Job Form"](./images/create_job_form.png)
 
-To create a *job definition* that runs repeatedly on a schedule, select "Run on a schedule" in the "Schedule" section. You can use shortcuts to, for example, run your notebook every hour or every day.
-   !["Run on schedule"](./images/run_on_schedule.png)
+To create a _job definition_ that runs repeatedly on a schedule, select "Run on a schedule" in the "Schedule" section. You can use shortcuts to, for example, run your notebook every hour or every day.
+!["Run on schedule"](./images/run_on_schedule.png)
 
 You can also specify a custom schedule in [crontab format](https://www.man7.org/linux/man-pages/man5/crontab.5.html) by selecting "Custom schedule" in the "Interval" drop-down menu.
-   !["Custom schedule option"](./images/custom_schedule.png)
+!["Custom schedule option"](./images/custom_schedule.png)
 
 ### Using list view
 

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -6,7 +6,7 @@ For configuration options, please refer to our {doc}`operator's guide </operator
 
 ## Installation
 
-Jupyter Scheduler has a client extension and a server extension. **Both are required** to
+Jupyter Scheduler has a lab (client) extension and a server extension. **Both are required** to
 be able to schedule and run notebooks. If you install Jupyter Scheduler via the JupyterLab
 extension manager, you might only install the client extension and not the server extension.
 

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -16,7 +16,7 @@ extension manager, you might only install the client extension and not the serve
 pip install jupyter_scheduler
 ```
 
-This automatically enables the client and server extensions. You can verify this by running
+This automatically enables the lab and server extensions. You can verify this by running
 
 ```
 jupyter server extension list

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -6,13 +6,17 @@ For configuration options, please refer to our {doc}`operator's guide </operator
 
 ## Installation
 
-Jupyter Scheduler can be installed from the PyPI registry via `pip`:
+Jupyter Scheduler has a client extension and a server extension. **Both are required** to
+be able to schedule and run notebooks. If you install Jupyter Scheduler via the JupyterLab
+extension manager, you might only install the client extension and not the server extension.
+
+**Recommended:** Install Jupyter Scheduler from the PyPI registry via `pip`:
 
 ```
 pip install jupyter_scheduler
 ```
 
-This automatically enables its extensions. You can verify this by running
+This automatically enables the client and server extensions. You can verify this by running
 
 ```
 jupyter server extension list
@@ -25,6 +29,7 @@ and checking that both the `jupyter_scheduler` server extension and the
 ## Use
 
 Jupyter Scheduler runs Jupyter notebooks in the background, either once or on a schedule. You can create *jobs* (single run of an individual notebook) and *job definitions* (scheduled recurring notebook jobs). When the scheduler runs your notebook, it makes a copy of the input file. The scheduler uses unique names for the input and output files so that rerunning the same notebook produces new files every time.
+
 
 ### Creating a job or job definition
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ import { SchedulerService } from './handler';
 import { IJobsModel, emptyCreateJobModel, JobsView } from './model';
 import { NotebookJobsPanel } from './notebook-jobs-panel';
 import { Scheduler } from './tokens';
-import { SERVER_EXTENSION_404 } from './util/errors';
+import { SERVER_EXTENSION_404_JSX } from './util/errors';
 import { MakeNameValid } from './util/job-name-validation';
 
 export namespace CommandIDs {
@@ -129,14 +129,13 @@ async function activatePlugin(
   advancedOptions: Scheduler.IAdvancedOptions,
   launcher: ILauncher | null
 ): Promise<void> {
-  const { commands } = app;
   const trans = translator.load('jupyterlab');
   const api = new SchedulerService({});
 
   // Try calling an API to verify that the server extension is actually installed
   let serverExtensionOk = false;
   api
-    .getJobs({ max_items: 1 })
+    .getJobs({ max_items: 0 })
     .then(response => {
       serverExtensionOk = true;
     })
@@ -147,7 +146,7 @@ async function activatePlugin(
       if (responseCode === 404) {
         showDialog({
           title: trans.__('Jupyter Scheduler server extension not found'),
-          body: SERVER_EXTENSION_404,
+          body: SERVER_EXTENSION_404_JSX,
           buttons: [Dialog.okButton()]
         }).catch(console.warn);
       } else {
@@ -161,6 +160,7 @@ async function activatePlugin(
     return; // Don't activate the rest of the plugin
   }
 
+  const { commands } = app;
   const fileBrowserTracker = browserFactory.tracker;
   const widgetTracker = new WidgetTracker<MainAreaWidget<NotebookJobsPanel>>({
     namespace: 'jupyterlab-scheduler'

--- a/src/util/errors.tsx
+++ b/src/util/errors.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export const SERVER_EXTENSION_404 = (
+  <div>
+    <p>
+      The Jupyter Scheduler extension is installed but it can't be activated. It
+      looks like the required Jupyter Server extension (
+      <code>jupyter_scheduler</code>) is not installed or not enabled in this
+      environment.
+    </p>
+    <h3>Why am I seeing this message?</h3>
+    <p>
+      If you installed the Jupyter Scheduler extension from the Extension
+      Manager in JupyterLab, you might have installed only the client extension
+      and not the server extension. You can install the server extension by
+      running <code>pip install jupyter_scheduler</code> in the same environment
+      in which you run JupyterLab.
+    </p>
+    <h3>How do I check if the extension is installed?</h3>
+    <p>
+      Please ensure that <code>jupyter server extension list</code> includes
+      jupyter_scheduler and that it is enabled. If it is enabled, please restart
+      JupyterLab. If the server extension is installed but not enabled, run{' '}
+      <code>jupyter server extension enable --user --py jupyter_scheduler</code>{' '}
+      and restart JupyterLab.
+    </p>
+  </div>
+);

--- a/src/util/errors.tsx
+++ b/src/util/errors.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const SERVER_EXTENSION_404 = (
+export const SERVER_EXTENSION_404_JSX = (
   <div>
     <p>
       The Jupyter Scheduler extension is installed but it can't be activated. It


### PR DESCRIPTION
Fixes #329, alternative to #340.

On initial JupyterLab startup, when activating the extension, the client attempts to call an API on the server. If it gets a 404 error, it displays a modal dialog and halts activation. No UI elements will appear in this case.

![image](https://user-images.githubusercontent.com/93281816/221069629-89b18669-9582-4151-8e1b-f613e4c1e57a.png)

Also updates the documentation to reflect the preferred way of installing the extension.