### PR TITLE
Fix check release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 
 # job outputs in local development env
 dev/jobs
+
+# jupyter releaser local checkout
+.jupyter_releaser_checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ docs = [
 [project.urls]
 Homepage = "https://github.com/jupyter-server/jupyter-scheduler"
 
+[tool.check-wheel-contents]
+ignore = ["W002"]
+
 [tool.hatch.build]
 artifacts = ["jupyter_scheduler/labextension"]
 


### PR DESCRIPTION
Check release workflow on `main` got broken due to [an upstream change in Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser/pull/487). In short, our current build process generates duplicate files, which causes the `pipx run check-wheel-contents` command called by the `check-python` step to fail unless given explicit configuration in `pyproject.toml`.

To verify this fix:

```
pip install jupyter_releaser
jupyter releaser build-npm
jupyter releaser check-npm
jupyter releaser build-python
jupyter releaser check-python
```