### PR TITLE
Fix two-phase delete buttons with Safari

### DIFF
--- a/src/components/confirm-buttons.tsx
+++ b/src/components/confirm-buttons.tsx
@@ -35,7 +35,6 @@ export function ConfirmButton(props: {
                 setConfirmed(true);
               }
             }}
-            onBlur={_ => setClicked(false)}
             style={{ visibility: clicked ? 'visible' : 'hidden' }}
             autoFocus
           >


### PR DESCRIPTION
Fixes #364 for Safari (desktop macOS) compatibility by removing the `onBlur` event on the `ConfirmButton` component. We had presumed that, after clicking the initial X icon, the focus would move to the `Button` component that did the actual delete, but in Safari, this is not the case.

As a noticeable UI change, this means that it's possible to have more than one red "Delete" button visible at a time. It is also no longer possible to cancel a two-phase Delete without reloading the view or the page, but I expect that this is a rare use case.

![delete-buttons](https://github.com/jupyter-server/jupyter-scheduler/assets/93281816/c97e2c6b-c482-4294-8c1b-098233eb29d8)
