### PR TITLE
Add click handler to mouseDown on confirm button for Safari compatibilty

### DIFF
--- a/src/components/confirm-buttons.tsx
+++ b/src/components/confirm-buttons.tsx
@@ -19,6 +19,16 @@ export function ConfirmButton(props: {
   const [clicked, setClicked] = useState(false);
   const [confirmed, setConfirmed] = useState(false);
 
+  // For Safari compatibility, also apply this to the "mouseDown" event, since the
+  // "click" event doesn't fire when the user clicks or taps on a button made visible
+  // in this way
+  const clickHandler = (e: any) => {
+    props.onConfirm();
+    if (props.remainAfterConfirmation) {
+      setConfirmed(true);
+    }
+  };
+
   return (
     <Box sx={{ width: '6em' }}>
       {clicked ? (
@@ -29,12 +39,8 @@ export function ConfirmButton(props: {
             variant="contained"
             color="error"
             title={props.name}
-            onClick={_ => {
-              props.onConfirm();
-              if (props.remainAfterConfirmation) {
-                setConfirmed(true);
-              }
-            }}
+            onClick={clickHandler}
+            onMouseDown={clickHandler}
             onBlur={_ => setClicked(false)}
             style={{ visibility: clicked ? 'visible' : 'hidden' }}
             autoFocus


### PR DESCRIPTION
Fixes #364; alternative to #382 and #383.

Fixes the two-phase button in Safari by attaching a handler to the `mouseDown` event. For some reason, the `click` event doesn't fire when a user clicks on a button made visible as we do, so the `blur` event fires every time, even after I make the button focused explicitly.

Also tested as working in Firefox. There is a slight change in functionality, since the second phase of the delete or stop button now starts when the user mouses down, not when they click (mouse down and mouse up).

The animation below was captured in Safari.

![two-phase-safari-working](https://github.com/jupyter-server/jupyter-scheduler/assets/93281816/be5c5db9-e3cb-41c6-ba5e-9dc9ad0d9348)

