### PR TITLE
Fix 'icon' prop typing for ConfirmButton component

### DIFF
--- a/src/components/confirm-buttons.tsx
+++ b/src/components/confirm-buttons.tsx
@@ -2,7 +2,6 @@ import { Box, Button, Chip, IconButton, SvgIconTypeMap } from '@mui/material';
 import React, { useState } from 'react';
 import { useTranslator } from '../hooks';
 import CloseIcon from '@mui/icons-material/Close';
-import { OverridableComponent } from '@mui/material/OverridableComponent';
 
 export function ConfirmButton(props: {
   onConfirm: () => void;

--- a/src/components/confirm-buttons.tsx
+++ b/src/components/confirm-buttons.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Chip, IconButton, SvgIconTypeMap } from '@mui/material';
+import { Box, Button, Chip, IconButton } from '@mui/material';
 import React, { useState } from 'react';
 import { useTranslator } from '../hooks';
 import CloseIcon from '@mui/icons-material/Close';

--- a/src/components/confirm-buttons.tsx
+++ b/src/components/confirm-buttons.tsx
@@ -7,11 +7,7 @@ import { OverridableComponent } from '@mui/material/OverridableComponent';
 export function ConfirmButton(props: {
   onConfirm: () => void;
   confirmationText: string;
-  icon:
-    | JSX.Element
-    | (OverridableComponent<SvgIconTypeMap<unknown, 'svg'>> & {
-        muiName: string;
-      });
+  icon?: JSX.Element;
   name?: string | undefined;
   remainAfterConfirmation?: boolean;
   remainText?: string;


### PR DESCRIPTION
Fixes 'icon' prop typing for ConfirmButton component. 

As mentioned in  https://github.com/jupyter-server/jupyter-scheduler/pull/383#discussion_r1228997890, `ConfirmDialogButton` component always uses `icon` prop as an instantiated element. Passing a class instead (possibility suggested by the use of `OverridableComponent & {muiName: string;}` type) would cause an error. 

https://github.com/jupyter-server/jupyter-scheduler/blob/f58284e4b93839886220a5e9be8af61070a857e9/src/components/confirm-buttons.tsx#L52-L54

Without this PR:
![Screenshot 2023-06-15 at 6 36 50 PM](https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/341699e0-d279-4512-8fd3-78c6b3b35c57)
![image](https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/8fe22247-6267-4101-b150-c2026f34293d)

With this PR:
![Screenshot 2023-06-15 at 6 36 34 PM](https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/7b9b641d-85c8-499c-8565-7e911b342005)
