### PR TITLE
Pins Pydantic to version 1, adds Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,13 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "jupyter_server>=1.6,<3",
     "traitlets",
     "nbconvert",
-    "pydantic",
+    "pydantic>=1,<2",
     "sqlalchemy<2",
     "croniter",
     "pytz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jupyter_server>=1.6,<3",
     "traitlets",
     "nbconvert",
-    "pydantic>=1,<2",
+    "pydantic~=1.10",
     "sqlalchemy<2",
     "croniter",
     "pytz",


### PR DESCRIPTION
Mitigation for #390 (not compatible with Pydantic 2) and partial fix for #380 (JupyterLab 4 compatibility). Updates dependencies to ensure that only Pydantic v1 is used, for now. Adds Python 3.11 compatibility (tested and working).