### PR TITLE
allow update E2E snapshots job to be manually triggered

### DIFF
--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -1,6 +1,7 @@
 name: Update Playwright Snapshots
 
 on:
+  workflow_dispatch:
   issue_comment:
     types: [created, edited]
 


### PR DESCRIPTION
Necessary for #402, since `please update playwright snapshots` calls the workflow from `main` instead of the one from `dlqqq/jl4`. Setting `on.workflow_dispatch` allows the workflow to be run manually, which allows developers to pick which branch to source the workflow from:

<img width="330" alt="Screenshot 2023-07-21 at 4 03 29 PM" src="https://github.com/jupyter-server/jupyter-scheduler/assets/44106031/1aa66dfc-beae-4961-a649-63ccefd716cb">
