### PR TITLE
Avoids "filter" option in tarfile

### DIFF
--- a/jupyter_scheduler/job_files_manager.py
+++ b/jupyter_scheduler/job_files_manager.py
@@ -71,7 +71,7 @@ class Downloader:
 
         with fsspec.open(archive_filepath) as f:
             with tarfile.open(fileobj=f, mode=read_mode) as tar:
-                tar.extractall(self.output_dir, filter="data")
+                tar.extractall(self.output_dir)
 
     def download(self):
         if not self.staging_paths:


### PR DESCRIPTION
Removes the `filter` option used in `tarfile.extractall()`, which is only compatible with Python 3.11.4 and newer.

Follow-up to #388, included in #418 (this does _not_ need backporting to 1.x)