### PR TITLE
Remove unused s3fs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "croniter~=1.4",
     "pytz==2023.3",
     "fsspec==2023.6.0",
-    "s3fs==2023.6.0",
     "psutil~=5.9"
 ]
 


### PR DESCRIPTION
Remove `s3fs` from the list of dependencies as `s3fs` is not used anywhere in the Jupyter Scheduler codebase.