### PR TITLE
[1.x] Fix RTD CI workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: ui-tests
         run: jlpm playwright install chromium
 
-      - name: Execute integration tests
+      - name: Run E2E Playwright tests
         working-directory: ui-tests
         run: jlpm test
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    nodejs: "18"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
Backport #438 to 1.x (but skip updating jupyterlab version to 4.0.6 as it is not relevant for 1.x)