### PR TITLE
Added telemetry support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ dmypy.json
 # job outputs in local development env
 dev/jobs
 
+# Notebook files created in dev folder
+dev/*.ipynb
+
 # jupyter releaser local checkout
 .jupyter_releaser_checkout
 

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -27,13 +27,15 @@ export function CreateScheduleOptions(
 
   const labelId = `${props.id}-label`;
 
-  const telemetryHandler = useContext(TelemetryContext)
+  const telemetryHandler = useContext(TelemetryContext);
 
   const handleScheduleOptionsChange = (
     event: ChangeEvent<HTMLInputElement>,
     value: string
   ) => {
-    telemetryHandler(`create-job.job-type.${value === 'Job' ? 'run-now' : 'run-on-schedule'}`);
+    telemetryHandler(
+      `create-job.job-type.${value === 'Job' ? 'run-now' : 'run-on-schedule'}`
+    );
     const name = event.target.name;
     props.handleModelChange({ ...props.model, [name]: value });
   };
@@ -49,12 +51,12 @@ export function CreateScheduleOptions(
       >
         <FormControlLabel
           value="Job"
-          control={<Radio/>}
+          control={<Radio />}
           label={trans.__('Run now')}
         />
         <FormControlLabel
           value="JobDefinition"
-          control={<Radio/>}
+          control={<Radio />}
           label={trans.__('Run on a schedule')}
         />
       </RadioGroup>
@@ -71,4 +73,3 @@ export function CreateScheduleOptions(
     </Stack>
   );
 }
-

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useContext } from 'react';
 
 import { FormControlLabel, InputLabel, Radio, RadioGroup } from '@mui/material';
 import Stack from '@mui/system/Stack';
@@ -7,6 +7,7 @@ import { useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
 import { ScheduleInputs } from './schedule-inputs';
 import { Scheduler } from '../tokens';
+import { TelemetryContext } from '../context';
 
 export type CreateScheduleOptionsProps = {
   label: string;
@@ -26,10 +27,13 @@ export function CreateScheduleOptions(
 
   const labelId = `${props.id}-label`;
 
+  const telemetryHandler = useContext(TelemetryContext)
+
   const handleScheduleOptionsChange = (
     event: ChangeEvent<HTMLInputElement>,
     value: string
   ) => {
+    telemetryHandler(`create-job.job-type.${value === 'Job' ? 'run-now' : 'run-on-schedule'}`);
     const name = event.target.name;
     props.handleModelChange({ ...props.model, [name]: value });
   };
@@ -45,12 +49,12 @@ export function CreateScheduleOptions(
       >
         <FormControlLabel
           value="Job"
-          control={<Radio />}
+          control={<Radio/>}
           label={trans.__('Run now')}
         />
         <FormControlLabel
           value="JobDefinition"
-          control={<Radio />}
+          control={<Radio/>}
           label={trans.__('Run on a schedule')}
         />
       </RadioGroup>
@@ -67,3 +71,4 @@ export function CreateScheduleOptions(
     </Stack>
   );
 }
+

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -3,7 +3,7 @@ import React, { ChangeEvent } from 'react';
 import { FormControlLabel, InputLabel, Radio, RadioGroup } from '@mui/material';
 import Stack from '@mui/system/Stack';
 
-import { useLogger, useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
 import { ScheduleInputs } from './schedule-inputs';
 import { Scheduler } from '../tokens';
@@ -26,7 +26,7 @@ export function CreateScheduleOptions(
 
   const labelId = `${props.id}-label`;
 
-  const log = useLogger();
+  const log = useEventLogger();
 
   const handleScheduleOptionsChange = (
     event: ChangeEvent<HTMLInputElement>,

--- a/src/components/create-schedule-options.tsx
+++ b/src/components/create-schedule-options.tsx
@@ -1,13 +1,12 @@
-import React, { ChangeEvent, useContext } from 'react';
+import React, { ChangeEvent } from 'react';
 
 import { FormControlLabel, InputLabel, Radio, RadioGroup } from '@mui/material';
 import Stack from '@mui/system/Stack';
 
-import { useTranslator } from '../hooks';
+import { useLogger, useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
 import { ScheduleInputs } from './schedule-inputs';
 import { Scheduler } from '../tokens';
-import { TelemetryContext } from '../context';
 
 export type CreateScheduleOptionsProps = {
   label: string;
@@ -27,13 +26,13 @@ export function CreateScheduleOptions(
 
   const labelId = `${props.id}-label`;
 
-  const telemetryHandler = useContext(TelemetryContext);
+  const log = useLogger();
 
   const handleScheduleOptionsChange = (
     event: ChangeEvent<HTMLInputElement>,
     value: string
   ) => {
-    telemetryHandler(
+    log(
       `create-job.job-type.${value === 'Job' ? 'run-now' : 'run-on-schedule'}`
     );
     const name = event.target.name;

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -13,7 +13,7 @@ import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 
 import { Scheduler, SchedulerService } from '../handler';
-import { useTranslator } from '../hooks';
+import { useLogger, useTranslator } from '../hooks';
 import { TranslationBundle } from '@jupyterlab/translation';
 import { ConfirmDeleteButton } from './confirm-buttons';
 
@@ -94,10 +94,14 @@ export function buildJobDefinitionRow(
   ss: SchedulerService,
   handleApiError: (error: string | null) => void
 ): JSX.Element {
+  const log = useLogger();
   const cellContents: React.ReactNode[] = [
     // name
     <Link
-      onClick={() => openJobDefinitionDetail(jobDef.job_definition_id)}
+      onClick={() => {
+        log('job-definition-list.open-detail');
+        openJobDefinitionDetail(jobDef.job_definition_id);
+      }}
       title={`Open detail view for "${jobDef.name}"`}
     >
       {jobDef.name}
@@ -110,6 +114,7 @@ export function buildJobDefinitionRow(
       <PauseButton
         jobDef={jobDef}
         clickHandler={async () => {
+          log('job-definition-list.pause');
           handleApiError(null);
           ss.pauseJobDefinition(jobDef.job_definition_id)
             .then(_ => {
@@ -123,6 +128,7 @@ export function buildJobDefinitionRow(
       <ResumeButton
         jobDef={jobDef}
         clickHandler={async () => {
+          log('job-definition-list.resume');
           handleApiError(null);
           ss.resumeJobDefinition(jobDef.job_definition_id)
             .then(_ => {
@@ -136,6 +142,7 @@ export function buildJobDefinitionRow(
       <ConfirmDeleteButton
         name={jobDef.name}
         clickHandler={async () => {
+          log('job-definition-list.delete');
           handleApiError(null);
           ss.deleteJobDefinition(jobDef.job_definition_id)
             .then(_ => {

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -13,7 +13,7 @@ import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 
 import { Scheduler, SchedulerService } from '../handler';
-import { useLogger, useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 import { TranslationBundle } from '@jupyterlab/translation';
 import { ConfirmDeleteButton } from './confirm-buttons';
 
@@ -94,7 +94,7 @@ export function buildJobDefinitionRow(
   ss: SchedulerService,
   handleApiError: (error: string | null) => void
 ): JSX.Element {
-  const log = useLogger();
+  const log = useEventLogger();
   const cellContents: React.ReactNode[] = [
     // name
     <Link

--- a/src/components/job-file-link.tsx
+++ b/src/components/job-file-link.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Scheduler } from '../handler';
-import { useTranslator } from '../hooks';
+import { useLogger, useTranslator } from '../hooks';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 
@@ -11,6 +11,7 @@ export interface IJobFileLinkProps {
   jobFile: Scheduler.IJobFile;
   app: JupyterFrontEnd;
   children?: React.ReactNode;
+  parentComponentName?: string;
 }
 
 export function JobFileLink(props: IJobFileLinkProps): JSX.Element | null {
@@ -19,6 +20,8 @@ export function JobFileLink(props: IJobFileLinkProps): JSX.Element | null {
   if (!props.jobFile.file_path) {
     return null;
   }
+
+  const log = useLogger();
 
   const fileBaseName = props.jobFile.file_path.split('/').pop();
 
@@ -38,6 +41,15 @@ export function JobFileLink(props: IJobFileLinkProps): JSX.Element | null {
           | React.MouseEvent<HTMLAnchorElement, MouseEvent>
       ) => {
         e.preventDefault();
+        if (props.parentComponentName) {
+          log(
+            `${props.parentComponentName}.${
+              props.jobFile.file_format === 'input'
+                ? 'open-input-file'
+                : 'open-output-file'
+            }`
+          );
+        }
         props.app.commands.execute('docmanager:open', {
           path: props.jobFile.file_path
         });

--- a/src/components/job-file-link.tsx
+++ b/src/components/job-file-link.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Scheduler } from '../handler';
-import { useLogger, useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 
@@ -21,7 +21,7 @@ export function JobFileLink(props: IJobFileLinkProps): JSX.Element | null {
     return null;
   }
 
-  const log = useLogger();
+  const log = useEventLogger();
 
   const fileBaseName = props.jobFile.file_path.split('/').pop();
 

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -5,7 +5,7 @@ import { ConfirmDeleteButton, ConfirmButton } from './confirm-buttons';
 import { JobFileLink } from './job-file-link';
 import { CommandIDs } from '..';
 import { Scheduler } from '../handler';
-import { useLogger, useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 import { ICreateJobModel } from '../model';
 import DownloadIcon from '@mui/icons-material/Download';
 import StopIcon from '@mui/icons-material/Stop';
@@ -16,7 +16,7 @@ function StopButton(props: {
   clickHandler: () => void;
 }): JSX.Element | null {
   const trans = useTranslator('jupyterlab');
-  const log = useLogger();
+  const log = useEventLogger();
   const buttonTitle = props.job.name
     ? trans.__('Stop "%1"', props.job.name)
     : trans.__('Stop job');
@@ -84,7 +84,7 @@ type DownloadFilesButtonProps = {
 function DownloadFilesButton(props: DownloadFilesButtonProps) {
   const [downloading, setDownloading] = useState(false);
   const trans = useTranslator('jupyterlab');
-  const log = useLogger();
+  const log = useEventLogger();
 
   return (
     <IconButton
@@ -131,7 +131,7 @@ export function buildJobRow(
     jobFile => jobFile.file_format === 'input' && jobFile.file_path
   );
   const trans = useTranslator('jupyterlab');
-  const log = useLogger();
+  const log = useEventLogger();
 
   const cellContents: React.ReactNode[] = [
     <Link

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,9 @@
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import React from 'react';
 
+type ITelemetryProcessor = (eventName: string) => void
+export const TelemetryContext = React.createContext<ITelemetryProcessor>(() => {})
+
 // Context to be overridden with JupyterLab context
 const TranslatorContext = React.createContext<ITranslator>(nullTranslator);
 export default TranslatorContext;

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,12 +1,10 @@
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import React from 'react';
 
-type ITelemetryProcessor = (eventName: string) => void;
-export const TelemetryContext = React.createContext<ITelemetryProcessor>(
-  (eventName: string) => {
-    /*noop*/
-  }
-);
+export type Logger = (eventName: string) => void;
+export const LogContext = React.createContext<Logger>((eventName: string) => {
+  /*noop*/
+});
 
 // Context to be overridden with JupyterLab context
 const TranslatorContext = React.createContext<ITranslator>(nullTranslator);

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,8 +1,12 @@
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import React from 'react';
 
-type ITelemetryProcessor = (eventName: string) => void
-export const TelemetryContext = React.createContext<ITelemetryProcessor>(() => {})
+type ITelemetryProcessor = (eventName: string) => void;
+export const TelemetryContext = React.createContext<ITelemetryProcessor>(
+  (eventName: string) => {
+    /*noop*/
+  }
+);
 
 // Context to be overridden with JupyterLab context
 const TranslatorContext = React.createContext<ITranslator>(nullTranslator);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -9,7 +9,7 @@ export function useTranslator(bundleId: string): TranslationBundle {
   return translator.load(bundleId);
 }
 
-export function useLogger(): Logger {
+export function useEventLogger(): Logger {
   const logger: Logger = useContext(LogContext);
   return logger;
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,9 +2,14 @@ import { useContext } from 'react';
 
 import { TranslationBundle } from '@jupyterlab/translation';
 
-import TranslatorContext from './context';
+import TranslatorContext, { Logger, LogContext } from './context';
 
 export function useTranslator(bundleId: string): TranslationBundle {
   const translator = useContext(TranslatorContext);
   return translator.load(bundleId);
+}
+
+export function useLogger(): Logger {
+  const logger: Logger = useContext(LogContext);
+  return logger;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -76,7 +76,7 @@ const telemetryHandler = async (
 };
 
 const telemetry: JupyterFrontEndPlugin<Scheduler.TelemetryHandler> = {
-  id: '@jupyterlab/scheduler:ITelemetryHandler',
+  id: '@jupyterlab/scheduler:TelemetryHandler',
   autoStart: true,
   provides: Scheduler.TelemetryHandler,
   activate: (app: JupyterFrontEnd) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,7 +51,7 @@ const schedulerPlugin: JupyterFrontEndPlugin<void> = {
     ITranslator,
     ILayoutRestorer,
     Scheduler.IAdvancedOptions,
-    Scheduler.ITelemetryHandler
+    Scheduler.TelemetryHandler
   ],
   optional: [ILauncher],
   autoStart: true,
@@ -75,10 +75,10 @@ const telemetryHandler = async (
   console.log(JSON.stringify(eventLog, undefined, 4));
 };
 
-const telemetry: JupyterFrontEndPlugin<Scheduler.ITelemetryHandler> = {
+const telemetry: JupyterFrontEndPlugin<Scheduler.TelemetryHandler> = {
   id: '@jupyterlab/scheduler:ITelemetryHandler',
   autoStart: true,
-  provides: Scheduler.ITelemetryHandler,
+  provides: Scheduler.TelemetryHandler,
   activate: (app: JupyterFrontEnd) => {
     return telemetryHandler;
   }
@@ -144,7 +144,7 @@ async function activatePlugin(
   translator: ITranslator,
   restorer: ILayoutRestorer,
   advancedOptions: Scheduler.IAdvancedOptions,
-  telemetryHandler: Scheduler.ITelemetryHandler,
+  telemetryHandler: Scheduler.TelemetryHandler,
   launcher: ILauncher | null
 ): Promise<void> {
   const trans = translator.load('jupyterlab');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,9 +69,11 @@ const advancedOptions: JupyterFrontEndPlugin<Scheduler.IAdvancedOptions> = {
 };
 
 // Default Telemetry Handler
-const telemetryHandler = async (eventLog: Scheduler.EventLog): Promise<void> => {
-  console.log(eventLog)
-}
+const telemetryHandler = async (
+  eventLog: Scheduler.IEventLog
+): Promise<void> => {
+  console.log(JSON.stringify(eventLog, undefined, 4));
+};
 
 const telemetry: JupyterFrontEndPlugin<Scheduler.ITelemetryHandler> = {
   id: '@jupyterlab/scheduler:ITelemetryHandler',
@@ -81,7 +83,6 @@ const telemetry: JupyterFrontEndPlugin<Scheduler.ITelemetryHandler> = {
     return telemetryHandler;
   }
 };
-
 
 function getSelectedItem(widget: FileBrowser | null): Contents.IModel | null {
   if (widget === null) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,8 @@ const schedulerPlugin: JupyterFrontEndPlugin<void> = {
     INotebookTracker,
     ITranslator,
     ILayoutRestorer,
-    Scheduler.IAdvancedOptions
+    Scheduler.IAdvancedOptions,
+    Scheduler.ITelemetryHandler
   ],
   optional: [ILauncher],
   autoStart: true,
@@ -66,6 +67,21 @@ const advancedOptions: JupyterFrontEndPlugin<Scheduler.IAdvancedOptions> = {
     return AdvancedOptions;
   }
 };
+
+// Default Telemetry Handler
+const telemetryHandler = async (eventLog: Scheduler.EventLog): Promise<void> => {
+  console.log(eventLog)
+}
+
+const telemetry: JupyterFrontEndPlugin<Scheduler.ITelemetryHandler> = {
+  id: '@jupyterlab/scheduler:ITelemetryHandler',
+  autoStart: true,
+  provides: Scheduler.ITelemetryHandler,
+  activate: (app: JupyterFrontEnd) => {
+    return telemetryHandler;
+  }
+};
+
 
 function getSelectedItem(widget: FileBrowser | null): Contents.IModel | null {
   if (widget === null) {
@@ -127,6 +143,7 @@ async function activatePlugin(
   translator: ITranslator,
   restorer: ILayoutRestorer,
   advancedOptions: Scheduler.IAdvancedOptions,
+  telemetryHandler: Scheduler.ITelemetryHandler,
   launcher: ILauncher | null
 ): Promise<void> {
   const trans = translator.load('jupyterlab');
@@ -170,6 +187,7 @@ async function activatePlugin(
       jobsPanel = new NotebookJobsPanel({
         app,
         translator,
+        telemetryHandler,
         advancedOptions: advancedOptions
       });
       // Create new main area widget
@@ -290,7 +308,8 @@ async function activatePlugin(
 
 const plugins: JupyterFrontEndPlugin<any>[] = [
   schedulerPlugin,
-  advancedOptions
+  advancedOptions,
+  telemetry
 ];
 
 export { JobsView };

--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -4,7 +4,7 @@ import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
-import { useTranslator } from '../hooks';
+import { useLogger, useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 
@@ -198,6 +198,8 @@ export function CreateJobFromDefinition(
   const cantSubmit = trans.__('One or more of the fields has an error.');
   const createError: string | undefined = props.model.createError;
 
+  const log = useLogger();
+
   return (
     <Box sx={{ p: 4 }}>
       <form className={`${formPrefix}form`} onSubmit={e => e.preventDefault()}>
@@ -227,7 +229,10 @@ export function CreateJobFromDefinition(
               <>
                 <Button
                   variant="outlined"
-                  onClick={e => props.showListView(JobsView.ListJobs)}
+                  onClick={e => {
+                    log('create-job-from-definition.cancel');
+                    props.showListView(JobsView.ListJobs);
+                  }}
                 >
                   {trans.__('Cancel')}
                 </Button>
@@ -235,6 +240,7 @@ export function CreateJobFromDefinition(
                 <Button
                   variant="contained"
                   onClick={(e: React.MouseEvent) => {
+                    log('create-job-from-definition.create');
                     submitCreateJobRequest(e);
                     return false;
                   }}

--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -4,7 +4,7 @@ import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
-import { useLogger, useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 
@@ -198,7 +198,7 @@ export function CreateJobFromDefinition(
   const cantSubmit = trans.__('One or more of the fields has an error.');
   const createError: string | undefined = props.model.createError;
 
-  const log = useLogger();
+  const log = useEventLogger();
 
   return (
     <Box sx={{ p: 4 }}>

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -530,12 +530,18 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             handleErrorsChange={setErrors}
           />
           <Accordion
-            telemetry-event-name={`create-job.advanced-options.${advancedOptionsExpanded ? 'expanded': 'collapsed'}`}
+            telemetry-event-name={`create-job.advanced-options.${
+              advancedOptionsExpanded ? 'expanded' : 'collapsed'
+            }`}
             defaultExpanded={false}
             expanded={advancedOptionsExpanded}
             onChange={(e: React.SyntheticEvent, expanded: boolean) => {
-              telemetryHandler(`create-job.advanced-options.${expanded ? 'expand': 'collapse'}`);
-              setAdvancedOptionsExpanded(expanded)
+              telemetryHandler(
+                `create-job.advanced-options.${
+                  expanded ? 'expand' : 'collapse'
+                }`
+              );
+              setAdvancedOptionsExpanded(expanded);
             }}
           >
             <AccordionSummary
@@ -580,8 +586,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                 <Button
                   variant="outlined"
                   onClick={e => {
-                    telemetryHandler("create-job.cancel")
-                    props.showListView(JobsView.ListJobs)
+                    telemetryHandler('create-job.cancel');
+                    props.showListView(JobsView.ListJobs);
                   }}
                 >
                   {trans.__('Cancel')}
@@ -590,7 +596,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                 <Button
                   variant="contained"
                   onClick={(e: React.MouseEvent) => {
-                    telemetryHandler("create-job.create")
+                    telemetryHandler('create-job.create');
                     submitForm(e);
                     return false;
                   }}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -3,8 +3,7 @@ import React, {
   useEffect,
   useMemo,
   useState,
-  useRef,
-  useContext
+  useRef
 } from 'react';
 
 import { Heading } from '../components/heading';
@@ -18,7 +17,7 @@ import {
 } from '../components/output-format-picker';
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
-import { useTranslator } from '../hooks';
+import { useLogger, useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 import { NameError } from '../util/job-name-validation';
@@ -42,7 +41,6 @@ import {
 } from '@mui/material';
 
 import { Box, Stack } from '@mui/system';
-import { TelemetryContext } from '../context';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -453,7 +451,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   // Does the currently-selected environment accept times in UTC only?
   const utcOnly = envsByName[props.model.environment]?.utc_only;
 
-  const telemetryHandler = useContext(TelemetryContext);
+  const log = useLogger();
 
   return (
     <Box sx={{ p: 4 }}>
@@ -530,13 +528,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             handleErrorsChange={setErrors}
           />
           <Accordion
-            telemetry-event-name={`create-job.advanced-options.${
-              advancedOptionsExpanded ? 'expanded' : 'collapsed'
-            }`}
             defaultExpanded={false}
             expanded={advancedOptionsExpanded}
             onChange={(e: React.SyntheticEvent, expanded: boolean) => {
-              telemetryHandler(
+              log(
                 `create-job.advanced-options.${
                   expanded ? 'expand' : 'collapse'
                 }`
@@ -586,7 +581,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                 <Button
                   variant="outlined"
                   onClick={e => {
-                    telemetryHandler('create-job.cancel');
+                    log('create-job.cancel');
                     props.showListView(JobsView.ListJobs);
                   }}
                 >
@@ -596,7 +591,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                 <Button
                   variant="contained"
                   onClick={(e: React.MouseEvent) => {
-                    telemetryHandler('create-job.create');
+                    log('create-job.create');
                     submitForm(e);
                     return false;
                   }}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -17,7 +17,7 @@ import {
 } from '../components/output-format-picker';
 import { ParametersPicker } from '../components/parameters-picker';
 import { Scheduler, SchedulerService } from '../handler';
-import { useLogger, useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 import { ICreateJobModel, IJobParameter, JobsView } from '../model';
 import { Scheduler as SchedulerTokens } from '../tokens';
 import { NameError } from '../util/job-name-validation';
@@ -451,7 +451,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   // Does the currently-selected environment accept times in UTC only?
   const utcOnly = envsByName[props.model.environment]?.utc_only;
 
-  const log = useLogger();
+  const log = useEventLogger();
 
   return (
     <Box sx={{ p: 4 }}>

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -3,7 +3,8 @@ import React, {
   useEffect,
   useMemo,
   useState,
-  useRef
+  useRef,
+  useContext
 } from 'react';
 
 import { Heading } from '../components/heading';
@@ -41,6 +42,7 @@ import {
 } from '@mui/material';
 
 import { Box, Stack } from '@mui/system';
+import { TelemetryContext } from '../context';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -451,6 +453,8 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
   // Does the currently-selected environment accept times in UTC only?
   const utcOnly = envsByName[props.model.environment]?.utc_only;
 
+  const telemetryHandler = useContext(TelemetryContext);
+
   return (
     <Box sx={{ p: 4 }}>
       <form className={`${formPrefix}form`} onSubmit={e => e.preventDefault()}>
@@ -526,11 +530,13 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             handleErrorsChange={setErrors}
           />
           <Accordion
+            telemetry-event-name={`create-job.advanced-options.${advancedOptionsExpanded ? 'expanded': 'collapsed'}`}
             defaultExpanded={false}
             expanded={advancedOptionsExpanded}
-            onChange={(_: React.SyntheticEvent, expanded: boolean) =>
+            onChange={(e: React.SyntheticEvent, expanded: boolean) => {
+              telemetryHandler(`create-job.advanced-options.${expanded ? 'expand': 'collapse'}`);
               setAdvancedOptionsExpanded(expanded)
-            }
+            }}
           >
             <AccordionSummary
               expandIcon={<caretDownIcon.react />}
@@ -573,7 +579,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
               <>
                 <Button
                   variant="outlined"
-                  onClick={e => props.showListView(JobsView.ListJobs)}
+                  onClick={e => {
+                    telemetryHandler("create-job.cancel")
+                    props.showListView(JobsView.ListJobs)
+                  }}
                 >
                   {trans.__('Cancel')}
                 </Button>
@@ -581,6 +590,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                 <Button
                   variant="contained"
                   onClick={(e: React.MouseEvent) => {
+                    telemetryHandler("create-job.create")
                     submitForm(e);
                     return false;
                   }}

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -20,7 +20,7 @@ import {
   LabeledValue
 } from '../../components/labeled-value';
 import { SchedulerService } from '../../handler';
-import { useLogger, useTranslator } from '../../hooks';
+import { useEventLogger, useTranslator } from '../../hooks';
 import { ListJobsTable } from '../list-jobs';
 import {
   IJobDefinitionModel,
@@ -48,7 +48,7 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
   const [displayError, setDisplayError] = useState<string | null>(null);
   const ss = useMemo(() => new SchedulerService({}), []);
-  const log = useLogger();
+  const log = useEventLogger();
 
   const ReloadButton = (
     <Button

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -20,7 +20,7 @@ import {
   LabeledValue
 } from '../../components/labeled-value';
 import { SchedulerService } from '../../handler';
-import { useTranslator } from '../../hooks';
+import { useLogger, useTranslator } from '../../hooks';
 import { ListJobsTable } from '../list-jobs';
 import {
   IJobDefinitionModel,
@@ -48,9 +48,16 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
   const [displayError, setDisplayError] = useState<string | null>(null);
   const ss = useMemo(() => new SchedulerService({}), []);
+  const log = useLogger();
 
   const ReloadButton = (
-    <Button variant="contained" onClick={props.reload}>
+    <Button
+      variant="contained"
+      onClick={e => {
+        log('job-definition-detail.reload');
+        props.reload();
+      }}
+    >
       {trans.__('Reload Job Definition')}
     </Button>
   );
@@ -119,23 +126,50 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const DefinitionButtonBar = (
     <ButtonBar>
       {ReloadButton}
-      <Button variant="outlined" onClick={runJobDefinition}>
+      <Button
+        variant="outlined"
+        onClick={e => {
+          log('job-definition-detail.run');
+          runJobDefinition();
+        }}
+      >
         {trans.__('Run Job')}
       </Button>
       {model.active ? (
-        <Button variant="outlined" onClick={pauseJobDefinition}>
+        <Button
+          variant="outlined"
+          onClick={e => {
+            log('job-definition-detail.pause');
+            pauseJobDefinition();
+          }}
+        >
           {trans.__('Pause')}
         </Button>
       ) : (
-        <Button variant="outlined" onClick={resumeJobDefinition}>
+        <Button
+          variant="outlined"
+          onClick={e => {
+            log('job-definition-detail.resume');
+            resumeJobDefinition();
+          }}
+        >
           {trans.__('Resume')}
         </Button>
       )}
-      <Button variant="outlined" onClick={() => props.editJobDefinition(model)}>
+      <Button
+        variant="outlined"
+        onClick={() => {
+          log('job-definition-detail.edit');
+          props.editJobDefinition(model);
+        }}
+      >
         {trans.__('Edit Job Definition')}
       </Button>
       <ConfirmDialogDeleteButton
-        handleDelete={handleDeleteJobDefinition}
+        handleDelete={async () => {
+          log('job-definition-detail.delete');
+          handleDeleteJobDefinition();
+        }}
         title={trans.__('Delete Job Definition')}
         dialogText={trans.__(
           'Are you sure that you want to delete this job definition?'

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../components/confirm-dialog-buttons';
 import { JobFileLink } from '../../components/job-file-link';
 import { Scheduler, SchedulerService } from '../../handler';
-import { useTranslator } from '../../hooks';
+import { useLogger, useTranslator } from '../../hooks';
 import { ICreateJobModel, IJobDetailModel, JobsView } from '../../model';
 import { Scheduler as SchedulerTokens } from '../../tokens';
 
@@ -38,6 +38,7 @@ import {
   ILabeledValueProps,
   LabeledValue
 } from '../../components/labeled-value';
+
 export interface IJobDetailProps {
   app: JupyterFrontEnd;
   model: IJobDetailModel | null;
@@ -95,7 +96,10 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     [trans]
   );
 
+  const log = useLogger();
+
   const handleDeleteJob = async () => {
+    log('job-detail.delete');
     setDisplayError(null);
     ss.deleteJob(props.model?.jobId ?? '')
       .then(_ => props.setJobsView(JobsView.ListJobs))
@@ -103,6 +107,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   };
 
   const handleStopJob = async () => {
+    log('job-detail.stop');
     setDisplayError(null);
     props.app.commands
       .execute('scheduling:stop-job', {
@@ -113,6 +118,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
   };
 
   const downloadFiles = async () => {
+    log('job-detail.download');
     setDownloading(true);
     props.app.commands
       .execute(CommandIDs.downloadFiles, {
@@ -132,7 +138,13 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
 
   const JobButtonBar = (
     <ButtonBar>
-      <Button variant="contained" onClick={props.reload}>
+      <Button
+        variant="contained"
+        onClick={e => {
+          log('job-detail.reload');
+          props.reload();
+        }}
+      >
         {trans.__('Reload Job')}
       </Button>
       {props.model !== null &&
@@ -189,7 +201,11 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
       {
         label: trans.__('Input file'),
         value: inputJobFile ? (
-          <JobFileLink app={props.app} jobFile={inputJobFile}>
+          <JobFileLink
+            app={props.app}
+            jobFile={inputJobFile}
+            parentComponentName="job-detail"
+          >
             {props.model.inputFile}
           </JobFileLink>
         ) : (
@@ -262,7 +278,11 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
                     jobFile.file_format !== 'input' && jobFile.file_path
                 )
                 .map(jobFile => (
-                  <JobFileLink jobFile={jobFile} app={props.app} />
+                  <JobFileLink
+                    jobFile={jobFile}
+                    app={props.app}
+                    parentComponentName="job-detail"
+                  />
                 ))}
             </>
           )}

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../components/confirm-dialog-buttons';
 import { JobFileLink } from '../../components/job-file-link';
 import { Scheduler, SchedulerService } from '../../handler';
-import { useLogger, useTranslator } from '../../hooks';
+import { useEventLogger, useTranslator } from '../../hooks';
 import { ICreateJobModel, IJobDetailModel, JobsView } from '../../model';
 import { Scheduler as SchedulerTokens } from '../../tokens';
 
@@ -96,7 +96,7 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     [trans]
   );
 
-  const log = useLogger();
+  const log = useEventLogger();
 
   const handleDeleteJob = async () => {
     log('job-detail.delete');

--- a/src/mainviews/edit-job-definition.tsx
+++ b/src/mainviews/edit-job-definition.tsx
@@ -15,7 +15,7 @@ import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
 import { ScheduleInputs } from '../components/schedule-inputs';
 import { IUpdateJobDefinitionModel, JobsView } from '../model';
-import { useLogger, useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 import { SchedulerService } from '../handler';
 import { Scheduler } from '../tokens';
 import { InputFileSnapshot } from '../components/input-file-snapshot';
@@ -31,7 +31,7 @@ export type EditJobDefinitionProps = {
 
 function EditJobDefinitionBody(props: EditJobDefinitionProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
-  const log = useLogger();
+  const log = useEventLogger();
   const ss = useMemo(() => new SchedulerService({}), []);
   const [loading, setLoading] = useState(false);
   const [utcOnly, setUtcOnly] = useState(false);

--- a/src/mainviews/edit-job-definition.tsx
+++ b/src/mainviews/edit-job-definition.tsx
@@ -15,7 +15,7 @@ import { Heading } from '../components/heading';
 import { Cluster } from '../components/cluster';
 import { ScheduleInputs } from '../components/schedule-inputs';
 import { IUpdateJobDefinitionModel, JobsView } from '../model';
-import { useTranslator } from '../hooks';
+import { useLogger, useTranslator } from '../hooks';
 import { SchedulerService } from '../handler';
 import { Scheduler } from '../tokens';
 import { InputFileSnapshot } from '../components/input-file-snapshot';
@@ -31,6 +31,7 @@ export type EditJobDefinitionProps = {
 
 function EditJobDefinitionBody(props: EditJobDefinitionProps): JSX.Element {
   const trans = useTranslator('jupyterlab');
+  const log = useLogger();
   const ss = useMemo(() => new SchedulerService({}), []);
   const [loading, setLoading] = useState(false);
   const [utcOnly, setUtcOnly] = useState(false);
@@ -113,16 +114,20 @@ function EditJobDefinitionBody(props: EditJobDefinitionProps): JSX.Element {
           <>
             <Button
               variant="outlined"
-              onClick={() =>
-                props.showJobDefinitionDetail(props.model.definitionId)
-              }
+              onClick={() => {
+                log('job-definition-edit.cancel');
+                props.showJobDefinitionDetail(props.model.definitionId);
+              }}
             >
               {trans.__('Cancel')}
             </Button>
             <Button
               color="primary"
               variant="contained"
-              onClick={handleSubmit}
+              onClick={e => {
+                log('job-definition-edit.save');
+                handleSubmit();
+              }}
               disabled={hasErrors}
             >
               {trans.__('Save Changes')}

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -4,7 +4,7 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { Alert, Button, Box, Stack, Tab, Tabs } from '@mui/material';
 
 import { Heading } from '../components/heading';
-import { useLogger, useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 import { buildJobRow } from '../components/job-row';
 import { buildJobDefinitionRow } from '../components/job-definition-row';
 import { ICreateJobModel, JobsView } from '../model';
@@ -45,7 +45,7 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
 
   const trans = useTranslator('jupyterlab');
 
-  const log = useLogger();
+  const log = useEventLogger();
 
   // Cache environment list — we need this for the output formats.
   const [environmentList, setEnvironmentList] = useState<
@@ -199,7 +199,7 @@ type ListJobDefinitionsTableProps = {
 
 function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
   const trans = useTranslator('jupyterlab');
-  const log = useLogger();
+  const log = useEventLogger();
   const [jobDefsQuery, setJobDefsQuery] =
     useState<Scheduler.IListJobDefinitionsQuery>({});
   const [deletedRows, setDeletedRows] = useState<

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -4,7 +4,7 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { Alert, Button, Box, Stack, Tab, Tabs } from '@mui/material';
 
 import { Heading } from '../components/heading';
-import { useTranslator } from '../hooks';
+import { useLogger, useTranslator } from '../hooks';
 import { buildJobRow } from '../components/job-row';
 import { buildJobDefinitionRow } from '../components/job-definition-row';
 import { ICreateJobModel, JobsView } from '../model';
@@ -45,6 +45,8 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
 
   const trans = useTranslator('jupyterlab');
 
+  const log = useLogger();
+
   // Cache environment list — we need this for the output formats.
   const [environmentList, setEnvironmentList] = useState<
     Scheduler.IRuntimeEnvironment[]
@@ -71,7 +73,14 @@ export function ListJobsTable(props: IListJobsTableProps): JSX.Element {
 
   const reloadButton = (
     <Cluster justifyContent="flex-end">
-      <Button variant="contained" size="small" onClick={reload}>
+      <Button
+        variant="contained"
+        size="small"
+        onClick={e => {
+          log('jobs-list.reload');
+          reload();
+        }}
+      >
         {trans.__('Reload')}
       </Button>
     </Cluster>
@@ -190,6 +199,7 @@ type ListJobDefinitionsTableProps = {
 
 function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
   const trans = useTranslator('jupyterlab');
+  const log = useLogger();
   const [jobDefsQuery, setJobDefsQuery] =
     useState<Scheduler.IListJobDefinitionsQuery>({});
   const [deletedRows, setDeletedRows] = useState<
@@ -242,6 +252,7 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
         variant="contained"
         size="small"
         onClick={() => {
+          log('jobs-definition-list.reload');
           setDisplayError(null);
           setJobDefsQuery(query => ({ ...query }));
         }}

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -41,7 +41,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   readonly _translator: ITranslator;
   readonly _trans: TranslationBundle;
   readonly _advancedOptions: React.FunctionComponent<Scheduler.IAdvancedOptionsProps>;
-  readonly _telemetryHandler: Scheduler.ITelemetryHandler;
+  readonly _telemetryHandler: Scheduler.TelemetryHandler;
   private _newlyCreatedId: string | undefined;
   private _newlyCreatedName: string | undefined;
   private _last_input_drop_target: Element | null;
@@ -325,7 +325,7 @@ namespace NotebookJobsPanel {
     app: JupyterFrontEnd;
     translator: ITranslator;
     advancedOptions: Scheduler.IAdvancedOptions;
-    telemetryHandler: Scheduler.ITelemetryHandler;
+    telemetryHandler: Scheduler.TelemetryHandler;
     model?: JobsModel;
   }
 }

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -125,13 +125,13 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
   };
 
   handleTelemetry(eventName: string): void {
-    if(eventName){
+    if (eventName) {
       const eventLog = {
         body: {
           name: `org.jupyter.jupyter-scheduler.${eventName}`
         },
-        timestamp: new Date()      
-      }
+        timestamp: new Date()
+      };
       this._telemetryHandler(eventLog).then();
     }
   }

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -27,7 +27,7 @@ import {
 } from './model';
 import { getJupyterLabTheme } from './theme-provider';
 import { Scheduler } from './tokens';
-import { TelemetryContext } from './context';
+import TranslatorContext, { LogContext } from './context';
 
 /**
  * The mime type for a rich contents drag object.
@@ -124,16 +124,17 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     }
   };
 
-  handleTelemetry(eventName: string): void {
-    if (eventName) {
-      const eventLog = {
-        body: {
-          name: `org.jupyter.jupyter-scheduler.${eventName}`
-        },
-        timestamp: new Date()
-      };
-      this._telemetryHandler(eventLog).then();
+  log(eventName: string): void {
+    if (!eventName) {
+      return;
     }
+    const eventLog = {
+      body: {
+        name: `org.jupyter.jupyter-scheduler.${eventName}`
+      },
+      timestamp: new Date()
+    };
+    this._telemetryHandler(eventLog).then();
   }
 
   /**
@@ -233,81 +234,84 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
 
     return (
       <ThemeProvider theme={getJupyterLabTheme()}>
-        <TelemetryContext.Provider value={this.handleTelemetry.bind(this)}>
-          <ErrorBoundary
-            alertTitle={this._trans.__('Internal error')}
-            alertMessage={this._trans.__(
-              'We encountered an internal error. Please try your command again.'
-            )}
-            detailTitle={this._trans.__('Error details')}
-          >
-            {this.model.jobsView === JobsView.CreateForm && (
-              <CreateJob
-                key={this.model.createJobModel.key}
-                model={this.model.createJobModel}
-                handleModelChange={newModel =>
-                  (this.model.createJobModel = newModel)
-                }
-                showListView={this.showListView.bind(this)}
-                advancedOptions={this._advancedOptions}
-              />
-            )}
-            {this.model.jobsView === JobsView.CreateFromJobDescriptionForm && (
-              <CreateJobFromDefinition
-                key={this.model.createJobModel.key}
-                model={this.model.createJobModel}
-                handleModelChange={newModel =>
-                  (this.model.createJobModel = newModel)
-                }
-                showListView={this.showListView.bind(this)}
-                advancedOptions={this._advancedOptions}
-              />
-            )}
-            {(this.model.jobsView === JobsView.ListJobs ||
-              this.model.jobsView === JobsView.ListJobDefinitions) && (
-              <NotebookJobsList
-                app={this._app}
-                listView={this.model.jobsView}
-                showListView={this.showListView.bind(this)}
-                showCreateJob={showCreateJob}
-                showJobDetail={this.showDetailView.bind(this)}
-                showJobDefinitionDetail={this.showJobDefinitionDetail.bind(
-                  this
-                )}
-                newlyCreatedId={this._newlyCreatedId}
-                newlyCreatedName={this._newlyCreatedName}
-              />
-            )}
-            {(this.model.jobsView === JobsView.JobDetail ||
-              this.model.jobsView === JobsView.JobDefinitionDetail) && (
-              <DetailView
-                app={this._app}
-                model={this.model.jobDetailModel}
-                setCreateJobModel={newModel =>
-                  (this.model.createJobModel = newModel)
-                }
-                jobsView={this.model.jobsView}
-                setJobsView={view => (this.model.jobsView = view)}
-                showCreateJob={showCreateJob}
-                showJobDetail={this.showDetailView.bind(this)}
-                editJobDefinition={this.editJobDefinition.bind(this)}
-                advancedOptions={this._advancedOptions}
-              />
-            )}
-            {this.model.jobsView === JobsView.EditJobDefinition && (
-              <EditJobDefinition
-                model={this.model.updateJobDefinitionModel}
-                handleModelChange={newModel =>
-                  (this.model.updateJobDefinitionModel = newModel)
-                }
-                showListView={this.showListView.bind(this)}
-                showJobDefinitionDetail={this.showJobDefinitionDetail.bind(
-                  this
-                )}
-              />
-            )}
-          </ErrorBoundary>
-        </TelemetryContext.Provider>
+        <TranslatorContext.Provider value={this._translator}>
+          <LogContext.Provider value={this.log.bind(this)}>
+            <ErrorBoundary
+              alertTitle={this._trans.__('Internal error')}
+              alertMessage={this._trans.__(
+                'We encountered an internal error. Please try your command again.'
+              )}
+              detailTitle={this._trans.__('Error details')}
+            >
+              {this.model.jobsView === JobsView.CreateForm && (
+                <CreateJob
+                  key={this.model.createJobModel.key}
+                  model={this.model.createJobModel}
+                  handleModelChange={newModel =>
+                    (this.model.createJobModel = newModel)
+                  }
+                  showListView={this.showListView.bind(this)}
+                  advancedOptions={this._advancedOptions}
+                />
+              )}
+              {this.model.jobsView ===
+                JobsView.CreateFromJobDescriptionForm && (
+                <CreateJobFromDefinition
+                  key={this.model.createJobModel.key}
+                  model={this.model.createJobModel}
+                  handleModelChange={newModel =>
+                    (this.model.createJobModel = newModel)
+                  }
+                  showListView={this.showListView.bind(this)}
+                  advancedOptions={this._advancedOptions}
+                />
+              )}
+              {(this.model.jobsView === JobsView.ListJobs ||
+                this.model.jobsView === JobsView.ListJobDefinitions) && (
+                <NotebookJobsList
+                  app={this._app}
+                  listView={this.model.jobsView}
+                  showListView={this.showListView.bind(this)}
+                  showCreateJob={showCreateJob}
+                  showJobDetail={this.showDetailView.bind(this)}
+                  showJobDefinitionDetail={this.showJobDefinitionDetail.bind(
+                    this
+                  )}
+                  newlyCreatedId={this._newlyCreatedId}
+                  newlyCreatedName={this._newlyCreatedName}
+                />
+              )}
+              {(this.model.jobsView === JobsView.JobDetail ||
+                this.model.jobsView === JobsView.JobDefinitionDetail) && (
+                <DetailView
+                  app={this._app}
+                  model={this.model.jobDetailModel}
+                  setCreateJobModel={newModel =>
+                    (this.model.createJobModel = newModel)
+                  }
+                  jobsView={this.model.jobsView}
+                  setJobsView={view => (this.model.jobsView = view)}
+                  showCreateJob={showCreateJob}
+                  showJobDetail={this.showDetailView.bind(this)}
+                  editJobDefinition={this.editJobDefinition.bind(this)}
+                  advancedOptions={this._advancedOptions}
+                />
+              )}
+              {this.model.jobsView === JobsView.EditJobDefinition && (
+                <EditJobDefinition
+                  model={this.model.updateJobDefinitionModel}
+                  handleModelChange={newModel =>
+                    (this.model.updateJobDefinitionModel = newModel)
+                  }
+                  showListView={this.showListView.bind(this)}
+                  showJobDefinitionDetail={this.showJobDefinitionDetail.bind(
+                    this
+                  )}
+                />
+              )}
+            </ErrorBoundary>
+          </LogContext.Provider>
+        </TranslatorContext.Provider>
       </ThemeProvider>
     );
   }

--- a/src/notebook-jobs-panel.tsx
+++ b/src/notebook-jobs-panel.tsx
@@ -124,7 +124,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     }
   };
 
-  log(eventName: string): void {
+  logEvent(eventName: string): void {
     if (!eventName) {
       return;
     }
@@ -235,7 +235,7 @@ export class NotebookJobsPanel extends VDomRenderer<JobsModel> {
     return (
       <ThemeProvider theme={getJupyterLabTheme()}>
         <TranslatorContext.Provider value={this._translator}>
-          <LogContext.Provider value={this.log.bind(this)}>
+          <LogContext.Provider value={this.logEvent.bind(this)}>
             <ErrorBoundary
               alertTitle={this._trans.__('Internal error')}
               alertMessage={this._trans.__(

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -54,9 +54,9 @@ export namespace Scheduler {
     timestamp: Date;
   }
 
-  export type ITelemetryHandler = (eventLog: IEventLog) => Promise<void>;
+  export type TelemetryHandler = (eventLog: IEventLog) => Promise<void>;
 
-  export const ITelemetryHandler = new Token<ITelemetryHandler>(
+  export const TelemetryHandler = new Token<TelemetryHandler>(
     '@jupyterlab/scheduler:ITelemetryHandler'
   );
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -46,16 +46,16 @@ export namespace Scheduler {
     '@jupyterlab/scheduler:IAdvancedOptions'
   );
 
-  export interface Event {
-    name: string 
+  export interface IEvent {
+    name: string;
   }
-  export interface EventLog {
-    body: Event 
-    timestamp: Date
+  export interface IEventLog {
+    body: IEvent;
+    timestamp: Date;
   }
 
-  export type ITelemetryHandler = (eventLog: EventLog) => Promise<void>;
-  
+  export type ITelemetryHandler = (eventLog: IEventLog) => Promise<void>;
+
   export const ITelemetryHandler = new Token<ITelemetryHandler>(
     '@jupyterlab/scheduler:ITelemetryHandler'
   );

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -45,4 +45,18 @@ export namespace Scheduler {
   export const IAdvancedOptions = new Token<IAdvancedOptions>(
     '@jupyterlab/scheduler:IAdvancedOptions'
   );
+
+  export interface Event {
+    name: string 
+  }
+  export interface EventLog {
+    body: Event 
+    timestamp: Date
+  }
+
+  export type ITelemetryHandler = (eventLog: EventLog) => Promise<void>;
+  
+  export const ITelemetryHandler = new Token<ITelemetryHandler>(
+    '@jupyterlab/scheduler:ITelemetryHandler'
+  );
 }


### PR DESCRIPTION
## Description
This PR adds support for telemetry and emits data for different events in the Scheduler components. A new plugin is provided that receives the event data. Implementors can disable the default plugin and provide their own implementation that will pass the telemetry data to their handler.

### Event log examples

#### Advanced options expanded
```json
{
    "body": {
        "name": "org.jupyter.jupyter-scheduler.create-job.advanced-options.expand"
    },
    "timestamp": "2023-10-26T17:17:44.350Z"
}
```

#### Create job cancel button clicked
```json
{
    "body": {
        "name": "org.jupyter.jupyter-scheduler.create-job.cancel"
    },
    "timestamp": "2023-10-26T17:18:53.323Z"
}
```

#### Create job run on schedule option selected
```json
{
    "body": {
        "name": "org.jupyter.jupyter-scheduler.create-job.job-type.run-on-schedule"
    },
    "timestamp": "2023-10-26T17:19:28.917Z"
}
```





### Providing your implementation to process telemetry events
 Create a new handler and a plugin that provides the handler.
```python

const myTelemetryHandler: async (eventLog: Scheduler.IEventLog): Promise<void> => {
    // process the eventLog 
}

const myTelemetryPlugin: JupyterFrontEndPlugin<Scheduler.TelemetryHandler> = {
  id: '@jupyterlab/scheduler:MyTelemetryHandler',
  autoStart: true,
  provides: Scheduler.TelemetryHandler,
  activate: (app: JupyterFrontEnd) => {
    return myTelemetryHandler;
  }
};
```

Disable the default plugin in the `package.json` file of your extension package.

```json
"jupyterlab": {
    "extension": true,
    "disabledExtensions": [
      "@jupyterlab/scheduler:TelemetryHandler"
    ]
  }
```

### Attaching new events to telemetry handler
A new hook `useLogger` is available that could be accessed in any component.

```ts
const log = useLogger();
```

Any event handler can then call the `log` to pass in the event name.

```ts
log("job-detail.<my-event>")
```
