### PR TITLE
Removes zero-height style rule, which broke table display in Safari

### DIFF
--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -216,9 +216,7 @@ export function AdvancedTable<
   }
 
   const tableDiv = (
-    <div
-      style={height === 'auto' ? { flex: 1, height: 0 } : { maxHeight: height }}
-    >
+    <div style={height === 'auto' ? { flex: 1 } : { maxHeight: height }}>
       <TableContainer
         component={Paper}
         sx={{


### PR DESCRIPTION
Fixes #449, opened by @funnypenguine. Removes a zero-height style rule on the job run list on the job definitions detail page. This style rule was introduced in #150, coauthored by @dlqqq and @andrii-i .

In Safari 17.0, I now see the job list view. See screen shot below. No regressions observed in the newest versions of Firefox ESR or Chrome.

<img width="1068" alt="image" src="https://github.com/jupyter-server/jupyter-scheduler/assets/93281816/5dfa2bd3-6c95-40f5-a618-dd0e8850964b">
