### PR TITLE
Pydantic v1 and v2 compatibility, add `pydantic_v1` module

### DIFF
--- a/jupyter_scheduler/handlers.py
+++ b/jupyter_scheduler/handlers.py
@@ -1,7 +1,6 @@
 import json
 import re
 
-from jupyter_scheduler.pydantic_v1 import ValidationError
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.extension.handler import ExtensionHandlerMixin
 from jupyter_server.utils import ensure_async
@@ -28,6 +27,7 @@ from jupyter_scheduler.models import (
     UpdateJob,
     UpdateJobDefinition,
 )
+from jupyter_scheduler.pydantic_v1 import ValidationError
 
 
 class JobHandlersMixin:

--- a/jupyter_scheduler/handlers.py
+++ b/jupyter_scheduler/handlers.py
@@ -1,10 +1,10 @@
 import json
 import re
 
+from jupyter_scheduler.pydantic_v1 import ValidationError
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.extension.handler import ExtensionHandlerMixin
 from jupyter_server.utils import ensure_async
-from pydantic import ValidationError
 from tornado.web import HTTPError, authenticated
 
 from jupyter_scheduler.environments import EnvironmentRetrievalError

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -2,7 +2,7 @@ import os
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, root_validator
+from jupyter_scheduler.pydantic_v1 import BaseModel, root_validator
 
 Tags = List[str]
 EnvironmentParameterValues = Union[int, float, bool, str]

--- a/jupyter_scheduler/pydantic_v1/__init__.py
+++ b/jupyter_scheduler/pydantic_v1/__init__.py
@@ -1,0 +1,25 @@
+from importlib import metadata
+
+## Create namespaces for pydantic v1 and v2.
+# Adapted from LangChain's langchain.pydantic_v1 module.
+#
+# This code must stay at the top of the file before other modules may
+# attempt to import pydantic since it adds pydantic_v1 and pydantic_v2 to sys.modules.
+#
+# This hack is done for the following reasons:
+# * Code will attempt to remain compatible with both pydantic v1 and v2 since
+#   both dependencies and dependents may be stuck on either version of v1 or v2.
+# * Creating namespaces for pydantic v1 and v2 should allow us to write code that
+#   unambiguously uses either v1 or v2 API.
+# * This change is easier to roll out and roll back.
+
+try:
+    from pydantic.v1 import *
+except ImportError:
+    from pydantic import *
+
+
+try:
+    _PYDANTIC_MAJOR_VERSION: int = int(metadata.version("pydantic").split(".")[0])
+except metadata.PackageNotFoundError:
+    _PYDANTIC_MAJOR_VERSION = 0

--- a/jupyter_scheduler/pydantic_v1/__init__.py
+++ b/jupyter_scheduler/pydantic_v1/__init__.py
@@ -6,9 +6,3 @@ try:
     from pydantic.v1 import *
 except ImportError:
     from pydantic import *
-
-
-try:
-    _PYDANTIC_MAJOR_VERSION: int = int(metadata.version("pydantic").split(".")[0])
-except metadata.PackageNotFoundError:
-    _PYDANTIC_MAJOR_VERSION = 0

--- a/jupyter_scheduler/pydantic_v1/__init__.py
+++ b/jupyter_scheduler/pydantic_v1/__init__.py
@@ -1,17 +1,6 @@
 from importlib import metadata
 
-## Create namespaces for pydantic v1 and v2.
-# Adapted from LangChain's langchain.pydantic_v1 module.
-#
-# This code must stay at the top of the file before other modules may
-# attempt to import pydantic since it adds pydantic_v1 and pydantic_v2 to sys.modules.
-#
-# This hack is done for the following reasons:
-# * Code will attempt to remain compatible with both pydantic v1 and v2 since
-#   both dependencies and dependents may be stuck on either version of v1 or v2.
-# * Creating namespaces for pydantic v1 and v2 should allow us to write code that
-#   unambiguously uses either v1 or v2 API.
-# * This change is easier to roll out and roll back.
+# expose Pydantic v1 API, regardless of Pydantic version in current env
 
 try:
     from pydantic.v1 import *

--- a/jupyter_scheduler/pydantic_v1/dataclasses.py
+++ b/jupyter_scheduler/pydantic_v1/dataclasses.py
@@ -1,0 +1,4 @@
+try:
+    from pydantic.v1.dataclasses import *
+except ImportError:
+    from pydantic.dataclasses import *

--- a/jupyter_scheduler/pydantic_v1/main.py
+++ b/jupyter_scheduler/pydantic_v1/main.py
@@ -1,0 +1,4 @@
+try:
+    from pydantic.v1.main import *
+except ImportError:
+    from pydantic.main import *

--- a/jupyter_scheduler/task_runner.py
+++ b/jupyter_scheduler/task_runner.py
@@ -5,8 +5,8 @@ from heapq import heappop, heappush
 from typing import List, Optional
 
 import traitlets
+from jupyter_scheduler.pydantic_v1 import BaseModel
 from jupyter_server.transutils import _i18n
-from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, Integer, String, create_engine
 from sqlalchemy.orm import sessionmaker
 from traitlets.config import LoggingConfigurable

--- a/jupyter_scheduler/task_runner.py
+++ b/jupyter_scheduler/task_runner.py
@@ -5,7 +5,6 @@ from heapq import heappop, heappush
 from typing import List, Optional
 
 import traitlets
-from jupyter_scheduler.pydantic_v1 import BaseModel
 from jupyter_server.transutils import _i18n
 from sqlalchemy import Boolean, Column, Integer, String, create_engine
 from sqlalchemy.orm import sessionmaker
@@ -13,6 +12,7 @@ from traitlets.config import LoggingConfigurable
 
 from jupyter_scheduler.models import CreateJob, UpdateJobDefinition
 from jupyter_scheduler.orm import JobDefinition, declarative_base
+from jupyter_scheduler.pydantic_v1 import BaseModel
 from jupyter_scheduler.utils import (
     compute_next_run_time,
     get_localized_timestamp,

--- a/jupyter_scheduler/tests/test_handlers.py
+++ b/jupyter_scheduler/tests/test_handlers.py
@@ -2,7 +2,6 @@ import json
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
 from tornado.httpclient import HTTPClientError
 
 from jupyter_scheduler.exceptions import (
@@ -11,6 +10,7 @@ from jupyter_scheduler.exceptions import (
     SchedulerError,
 )
 from jupyter_scheduler.handlers import compute_sort_model
+from jupyter_scheduler.pydantic_v1 import ValidationError
 from jupyter_scheduler.models import (
     CountJobsQuery,
     DescribeJob,

--- a/jupyter_scheduler/tests/test_handlers.py
+++ b/jupyter_scheduler/tests/test_handlers.py
@@ -10,7 +10,6 @@ from jupyter_scheduler.exceptions import (
     SchedulerError,
 )
 from jupyter_scheduler.handlers import compute_sort_model
-from jupyter_scheduler.pydantic_v1 import ValidationError
 from jupyter_scheduler.models import (
     CountJobsQuery,
     DescribeJob,
@@ -21,6 +20,7 @@ from jupyter_scheduler.models import (
     Status,
     UpdateJob,
 )
+from jupyter_scheduler.pydantic_v1 import ValidationError
 from jupyter_scheduler.tests.utils import expected_http_error
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jupyter_server>=1.6,<3",
     "traitlets~=5.0",
     "nbconvert~=7.0",
-    "pydantic~=1.10",
+    "pydantic>=1.10,<3",
     "sqlalchemy~=1.0",
     "croniter~=1.4",
     "pytz==2023.3",


### PR DESCRIPTION
Fixes #390. Inspired by LangChain, adds a module `jupyter_scheduler.pydantic_v1` to expose the Pydantic v1 API to classes whether v1 or v2 is installed.

Updates dependencies to allow v1 and v2 to be used. Updates classes to use the new dependency.

Tested locally with both Pydantic v1 and v2; working in both cases.