### PR TITLE
Backport 463 to 1.x

### DIFF
--- a/jupyter_scheduler/handlers.py
+++ b/jupyter_scheduler/handlers.py
@@ -4,7 +4,6 @@ import re
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.extension.handler import ExtensionHandlerMixin
 from jupyter_server.utils import ensure_async
-from pydantic import ValidationError
 from tornado.web import HTTPError, authenticated
 
 from jupyter_scheduler.environments import EnvironmentRetrievalError
@@ -28,6 +27,7 @@ from jupyter_scheduler.models import (
     UpdateJob,
     UpdateJobDefinition,
 )
+from jupyter_scheduler.pydantic_v1 import ValidationError
 
 
 class JobHandlersMixin:

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -2,7 +2,7 @@ import os
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, root_validator
+from jupyter_scheduler.pydantic_v1 import BaseModel, root_validator
 
 Tags = List[str]
 EnvironmentParameterValues = Union[int, float, bool, str]

--- a/jupyter_scheduler/pydantic_v1/__init__.py
+++ b/jupyter_scheduler/pydantic_v1/__init__.py
@@ -1,0 +1,8 @@
+from importlib import metadata
+
+# expose Pydantic v1 API, regardless of Pydantic version in current env
+
+try:
+    from pydantic.v1 import *
+except ImportError:
+    from pydantic import *

--- a/jupyter_scheduler/pydantic_v1/dataclasses.py
+++ b/jupyter_scheduler/pydantic_v1/dataclasses.py
@@ -1,0 +1,4 @@
+try:
+    from pydantic.v1.dataclasses import *
+except ImportError:
+    from pydantic.dataclasses import *

--- a/jupyter_scheduler/pydantic_v1/main.py
+++ b/jupyter_scheduler/pydantic_v1/main.py
@@ -1,0 +1,4 @@
+try:
+    from pydantic.v1.main import *
+except ImportError:
+    from pydantic.main import *

--- a/jupyter_scheduler/task_runner.py
+++ b/jupyter_scheduler/task_runner.py
@@ -6,13 +6,13 @@ from typing import List, Optional
 
 import traitlets
 from jupyter_server.transutils import _i18n
-from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, Integer, String, create_engine
 from sqlalchemy.orm import sessionmaker
 from traitlets.config import LoggingConfigurable
 
 from jupyter_scheduler.models import CreateJob, UpdateJobDefinition
 from jupyter_scheduler.orm import JobDefinition, declarative_base
+from jupyter_scheduler.pydantic_v1 import BaseModel
 from jupyter_scheduler.utils import (
     compute_next_run_time,
     get_localized_timestamp,

--- a/jupyter_scheduler/tests/test_handlers.py
+++ b/jupyter_scheduler/tests/test_handlers.py
@@ -2,7 +2,6 @@ import json
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
 from tornado.httpclient import HTTPClientError
 
 from jupyter_scheduler.exceptions import (
@@ -21,6 +20,7 @@ from jupyter_scheduler.models import (
     Status,
     UpdateJob,
 )
+from jupyter_scheduler.pydantic_v1 import ValidationError
 from jupyter_scheduler.tests.utils import expected_http_error
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jupyter_server>=1.6,<3",
     "traitlets~=5.0",
     "nbconvert~=7.0",
-    "pydantic~=1.10",
+    "pydantic>=1.10,<3",
     "sqlalchemy~=1.0",
     "croniter~=1.4",
     "pytz==2023.3",


### PR DESCRIPTION
Backports #463, fixing #390, to 1.x.

* Custom module to allow Pydantic v1 and v2 compatibility

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Update jupyter_scheduler/pydantic_v1/__init__.py



* Removes unneeded logic

* Adds dataclasses.py

---------