### PR TITLE
Emit telemetry events on success and failure of the Create Job, Create Job Definition, Create Job from Job Definition hooks

### DIFF
--- a/src/components/advanced-table/advanced-table.tsx
+++ b/src/components/advanced-table/advanced-table.tsx
@@ -13,6 +13,7 @@ import { Scheduler } from '../../handler';
 import { AdvancedTableHeader } from './advanced-table-header';
 import { useTranslator } from '../../hooks';
 import { Alert } from '@mui/material';
+import { getErrorMessage } from '../../util/errors';
 
 const PAGE_SIZE = 25;
 
@@ -102,8 +103,9 @@ export function AdvancedTable<
         setNextToken(payload?.next_token);
         setTotalCount(payload?.total_count);
       })
-      .catch((e: Error) => {
-        setDisplayError(e.message);
+      .catch((e: unknown) => {
+        const message = getErrorMessage(e);
+        setDisplayError(message);
       });
   };
 
@@ -152,8 +154,9 @@ export function AdvancedTable<
         setPage(newPage);
         setMaxPage(newPage);
       })
-      .catch((e: Error) => {
-        setDisplayError(e.message);
+      .catch((e: unknown) => {
+        const message = getErrorMessage(e);
+        setDisplayError(message);
       });
   };
 

--- a/src/components/job-definition-row.tsx
+++ b/src/components/job-definition-row.tsx
@@ -16,6 +16,7 @@ import { Scheduler, SchedulerService } from '../handler';
 import { useEventLogger, useTranslator } from '../hooks';
 import { TranslationBundle } from '@jupyterlab/translation';
 import { ConfirmDeleteButton } from './confirm-buttons';
+import { getErrorMessage } from '../util/errors';
 
 function CreatedAt(props: {
   job: Scheduler.IDescribeJobDefinition;
@@ -120,8 +121,9 @@ export function buildJobDefinitionRow(
             .then(_ => {
               forceReload();
             })
-            .catch((error: Error) => {
-              handleApiError(error.message);
+            .catch((e: unknown) => {
+              const message = getErrorMessage(e);
+              handleApiError(message);
             });
         }}
       />
@@ -134,8 +136,9 @@ export function buildJobDefinitionRow(
             .then(_ => {
               forceReload();
             })
-            .catch((error: Error) => {
-              handleApiError(error.message);
+            .catch((e: unknown) => {
+              const message = getErrorMessage(e);
+              handleApiError(message);
             });
         }}
       />
@@ -148,8 +151,9 @@ export function buildJobDefinitionRow(
             .then(_ => {
               deleteRow(jobDef.job_definition_id);
             })
-            .catch((error: Error) => {
-              handleApiError(error.message);
+            .catch((e: unknown) => {
+              const message = getErrorMessage(e);
+              handleApiError(message);
             });
         }}
       />

--- a/src/components/job-row.tsx
+++ b/src/components/job-row.tsx
@@ -10,6 +10,7 @@ import { ICreateJobModel } from '../model';
 import DownloadIcon from '@mui/icons-material/Download';
 import StopIcon from '@mui/icons-material/Stop';
 import { IconButton, Stack, Link, TableCell, TableRow } from '@mui/material';
+import { getErrorMessage } from '../util/errors';
 
 function StopButton(props: {
   job: Scheduler.IDescribeJob;
@@ -106,8 +107,9 @@ function DownloadFilesButton(props: DownloadFilesButtonProps) {
               props.reload();
             })
           )
-          .catch((e: Error) => {
-            props.setDisplayError(e.message);
+          .catch((e: unknown) => {
+            const message = getErrorMessage(e);
+            props.setDisplayError(message);
           });
       }}
     >
@@ -178,7 +180,10 @@ export function buildJobRow(
               id: job.job_id
             })
             .then(_ => deleteRow(job.job_id))
-            .catch((e: Error) => setDisplayError(e.message));
+            .catch((e: unknown) => {
+              const message = getErrorMessage(e);
+              setDisplayError(message);
+            });
         }}
       />
       <StopButton
@@ -189,7 +194,10 @@ export function buildJobRow(
             .execute(CommandIDs.stopJob, {
               id: job.job_id
             })
-            .catch((e: Error) => setDisplayError(e.message));
+            .catch((e: unknown) => {
+              const message = getErrorMessage(e);
+              setDisplayError(message);
+            });
         }}
       />
     </Stack>

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,10 +1,12 @@
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import React from 'react';
 
-export type Logger = (eventName: string) => void;
-export const LogContext = React.createContext<Logger>((eventName: string) => {
-  /*noop*/
-});
+export type Logger = (eventName: string, error?: Error) => void;
+export const LogContext = React.createContext<Logger>(
+  (eventName: string, error?: Error) => {
+    /*noop*/
+  }
+);
 
 // Context to be overridden with JupyterLab context
 const TranslatorContext = React.createContext<ITranslator>(nullTranslator);

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,7 +3,7 @@ import React from 'react';
 
 export type Logger = (eventName: string, error?: Error) => void;
 export const LogContext = React.createContext<Logger>(
-  (eventName: string, error?: Error) => {
+  (eventName: string, eventDetail?: string) => {
     /*noop*/
   }
 );

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,7 @@
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import React from 'react';
 
-export type Logger = (eventName: string, error?: Error) => void;
+export type Logger = (eventName: string, eventDetail?: string) => void;
 export const LogContext = React.createContext<Logger>(
   (eventName: string, eventDetail?: string) => {
     /*noop*/

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,7 @@ export const NotebookJobsPanelId = 'notebook-jobs-panel';
 export { Scheduler } from './tokens';
 
 type EventLog = {
-  body: { name: string; detail?: string } };
+  body: { name: string; detail?: string };
   timestamp: Date;
 };
 
@@ -183,7 +183,7 @@ async function activatePlugin(
   let mainAreaWidget: MainAreaWidget<NotebookJobsPanel> | undefined;
   let jobsPanel: NotebookJobsPanel | undefined;
 
-  const eventLogger: Scheduler.EventLogger = (eventName, e?: Error) => {
+  const eventLogger: Scheduler.EventLogger = (eventName, eventDetail) => {
     if (!eventName) {
       return;
     }
@@ -194,11 +194,8 @@ async function activatePlugin(
       timestamp: new Date()
     };
 
-    if (e) {
-      eventLog.body.error = { message: e.message };
-      if (e instanceof ServerConnection.ResponseError) {
-        eventLog.body.error.httpStatusCode = e.response.status;
-      }
+    if (eventDetail) {
+      eventLog.body.detail = eventDetail;
     }
 
     telemetryHandler(eventLog).then();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,7 @@ export const NotebookJobsPanelId = 'notebook-jobs-panel';
 export { Scheduler } from './tokens';
 
 type EventLog = {
-  body: { name: string; error?: { message?: string; httpStatusCode?: number } };
+  body: { name: string; detail?: string } };
   timestamp: Date;
 };
 

--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -139,6 +139,7 @@ export function CreateJobFromDefinition(
         createJobFromDefinitionModel
       )
       .then(response => {
+        log('create-job-from-definition.create-job.success');
         // Switch to the list view with "Job List" active
         props.showListView(
           JobsView.ListJobs,
@@ -147,6 +148,7 @@ export function CreateJobFromDefinition(
         );
       })
       .catch((error: Error) => {
+        log('create-job-from-definition.create-job.failure');
         props.handleModelChange({
           ...props.model,
           createError: error.message,
@@ -240,7 +242,7 @@ export function CreateJobFromDefinition(
                 <Button
                   variant="contained"
                   onClick={(e: React.MouseEvent) => {
-                    log('create-job-from-definition.create');
+                    log('create-job-from-definition.create-job');
                     submitCreateJobRequest(e);
                     return false;
                   }}

--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -148,7 +148,7 @@ export function CreateJobFromDefinition(
         );
       })
       .catch((error: Error) => {
-        log('create-job-from-definition.create-job.failure', error);
+        log('create-job-from-definition.create-job.failure', error.message);
         props.handleModelChange({
           ...props.model,
           createError: error.message,

--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -148,7 +148,7 @@ export function CreateJobFromDefinition(
         );
       })
       .catch((error: Error) => {
-        log('create-job-from-definition.create-job.failure');
+        log('create-job-from-definition.create-job.failure', error);
         props.handleModelChange({
           ...props.model,
           createError: error.message,

--- a/src/mainviews/create-job-from-definition.tsx
+++ b/src/mainviews/create-job-from-definition.tsx
@@ -13,6 +13,7 @@ import { Alert, Button, CircularProgress } from '@mui/material';
 import { Box, Stack } from '@mui/system';
 
 import { LabeledValue } from '../components/labeled-value';
+import { getErrorMessage } from '../util/errors';
 
 export interface ICreateJobFromDefinitionProps {
   model: ICreateJobModel;
@@ -147,11 +148,12 @@ export function CreateJobFromDefinition(
           props.model.jobName
         );
       })
-      .catch((error: Error) => {
-        log('create-job-from-definition.create-job.failure', error.message);
+      .catch((e: unknown) => {
+        const detail = getErrorMessage(e);
+        log('create-job-from-definition.create-job.failure', detail);
         props.handleModelChange({
           ...props.model,
-          createError: error.message,
+          createError: detail,
           createInProgress: false
         });
       });

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -340,7 +340,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         props.showListView(JobsView.ListJobs, response.job_id, jobOptions.name);
       })
       .catch((error: Error) => {
-        log('create-job.create-job.failure', error);
+        log('create-job.create-job.failure', error.message);
         props.handleModelChange({
           ...props.model,
           createError: error.message,
@@ -393,7 +393,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         );
       })
       .catch((error: Error) => {
-        log('create-job.create-job-definition.failure', error);
+        log('create-job.create-job-definition.failure', error.message);
         props.handleModelChange({
           ...props.model,
           createError: error.message,

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -340,7 +340,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         props.showListView(JobsView.ListJobs, response.job_id, jobOptions.name);
       })
       .catch((error: Error) => {
-        log('create-job.create-job.failure');
+        log('create-job.create-job.failure', error);
         props.handleModelChange({
           ...props.model,
           createError: error.message,
@@ -393,7 +393,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         );
       })
       .catch((error: Error) => {
-        log('create-job.create-job-definition.failure');
+        log('create-job.create-job-definition.failure', error);
         props.handleModelChange({
           ...props.model,
           createError: error.message,

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -41,6 +41,7 @@ import {
 } from '@mui/material';
 
 import { Box, Stack } from '@mui/system';
+import { getErrorMessage } from '../util/errors';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -339,11 +340,12 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         // Switch to the list view with "Job List" active
         props.showListView(JobsView.ListJobs, response.job_id, jobOptions.name);
       })
-      .catch((error: Error) => {
-        log('create-job.create-job.failure', error.message);
+      .catch((e: unknown) => {
+        const detail = getErrorMessage(e);
+        log('create-job.create-job.failure', detail);
         props.handleModelChange({
           ...props.model,
-          createError: error.message,
+          createError: detail,
           createInProgress: false
         });
       });
@@ -392,11 +394,12 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
           jobDefinitionOptions.name
         );
       })
-      .catch((error: Error) => {
-        log('create-job.create-job-definition.failure', error.message);
+      .catch((e: unknown) => {
+        const detail = getErrorMessage(e);
+        log('create-job.create-job-definition.failure', detail);
         props.handleModelChange({
           ...props.model,
-          createError: error.message,
+          createError: detail,
           createInProgress: false
         });
       });

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -599,7 +599,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                       props.model.createType === 'Job'
                         ? 'create-job'
                         : 'create-job-definition';
-                    log(`create-job.${eventType}.create`);
+                    log(`create-job.${eventType}`);
                     submitForm(e);
                     return false;
                   }}

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -335,10 +335,12 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     api
       .createJob(jobOptions)
       .then(response => {
+        log('create-job.create-job.success');
         // Switch to the list view with "Job List" active
         props.showListView(JobsView.ListJobs, response.job_id, jobOptions.name);
       })
       .catch((error: Error) => {
+        log('create-job.create-job.failure');
         props.handleModelChange({
           ...props.model,
           createError: error.message,
@@ -382,6 +384,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
     api
       .createJobDefinition(jobDefinitionOptions)
       .then(response => {
+        log('create-job.create-job-definition.success');
         // Switch to the list view with "Job Definition List" active
         props.showListView(
           JobsView.ListJobDefinitions,
@@ -390,6 +393,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
         );
       })
       .catch((error: Error) => {
+        log('create-job.create-job-definition.failure');
         props.handleModelChange({
           ...props.model,
           createError: error.message,
@@ -591,7 +595,11 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
                 <Button
                   variant="contained"
                   onClick={(e: React.MouseEvent) => {
-                    log('create-job.create');
+                    const eventType =
+                      props.model.createType === 'Job'
+                        ? 'create-job'
+                        : 'create-job-definition';
+                    log(`create-job.${eventType}.create`);
                     submitForm(e);
                     return false;
                   }}

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -31,6 +31,7 @@ import {
 import { Scheduler as SchedulerTokens } from '../../tokens';
 
 import { timestampLocalize } from './job-detail';
+import { getErrorMessage } from '../../util/errors';
 
 export interface IJobDefinitionProps {
   app: JupyterFrontEnd;
@@ -79,21 +80,30 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
   const handleDeleteJobDefinition = async () => {
     ss.deleteJobDefinition(model.definitionId ?? '')
       .then(_ => props.setJobsView(JobsView.ListJobDefinitions))
-      .catch((e: Error) => setDisplayError(e.message));
+      .catch((e: unknown) => {
+        const message = getErrorMessage(e);
+        setDisplayError(message);
+      });
   };
 
   const pauseJobDefinition = async () => {
     setDisplayError(null);
     ss.pauseJobDefinition(model.definitionId)
       .then(_ => props.refresh())
-      .catch((e: Error) => setDisplayError(e.message));
+      .catch((e: unknown) => {
+        const message = getErrorMessage(e);
+        setDisplayError(message);
+      });
   };
 
   const resumeJobDefinition = async () => {
     setDisplayError(null);
     ss.resumeJobDefinition(model.definitionId)
       .then(_ => props.refresh())
-      .catch((e: Error) => setDisplayError(e.message));
+      .catch((e: unknown) => {
+        const message = getErrorMessage(e);
+        setDisplayError(message);
+      });
   };
 
   const runJobDefinition = () => {

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -38,6 +38,7 @@ import {
   ILabeledValueProps,
   LabeledValue
 } from '../../components/labeled-value';
+import { getErrorMessage } from '../../util/errors';
 
 export interface IJobDetailProps {
   app: JupyterFrontEnd;
@@ -103,7 +104,10 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
     setDisplayError(null);
     ss.deleteJob(props.model?.jobId ?? '')
       .then(_ => props.setJobsView(JobsView.ListJobs))
-      .catch((e: Error) => setDisplayError(e.message));
+      .catch((e: unknown) => {
+        const message = getErrorMessage(e);
+        setDisplayError(message);
+      });
   };
 
   const handleStopJob = async () => {
@@ -114,7 +118,10 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
         id: props.model?.jobId
       })
       .then(_ => props.handleModelChange())
-      .catch((e: Error) => setDisplayError(e.message));
+      .catch((e: unknown) => {
+        const message = getErrorMessage(e);
+        setDisplayError(message);
+      });
   };
 
   const downloadFiles = async () => {
@@ -130,8 +137,9 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
           props.handleModelChange().then(_ => setDownloading(false))
         );
       })
-      .catch((e: Error) => {
-        setDisplayError(e.message);
+      .catch((e: unknown) => {
+        const message = getErrorMessage(e);
+        setDisplayError(message);
         setDownloading(false);
       });
   };

--- a/src/mainviews/edit-job-definition.tsx
+++ b/src/mainviews/edit-job-definition.tsx
@@ -21,6 +21,7 @@ import { Scheduler } from '../tokens';
 import { InputFileSnapshot } from '../components/input-file-snapshot';
 import { LabeledValue } from '../components/labeled-value';
 import { timestampLocalize } from './detail-view/job-detail';
+import { getErrorMessage } from '../util/errors';
 
 export type EditJobDefinitionProps = {
   model: IUpdateJobDefinitionModel;
@@ -77,9 +78,10 @@ function EditJobDefinitionBody(props: EditJobDefinitionProps): JSX.Element {
       .then(() => {
         props.showJobDefinitionDetail(props.model.definitionId);
       })
-      .catch((e: Error) => {
+      .catch((e: unknown) => {
         setSaving(false);
-        setDisplayError(e.message);
+        const message = getErrorMessage(e);
+        setDisplayError(message);
       });
   };
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -60,5 +60,5 @@ export namespace Scheduler {
     '@jupyterlab/scheduler:ITelemetryHandler'
   );
 
-  export type EventLogger = (eventName: string) => void;
+  export type EventLogger = (eventName: string, eventDetail?: string) => void;
 }

--- a/src/util/errors.tsx
+++ b/src/util/errors.tsx
@@ -26,3 +26,7 @@ export const SERVER_EXTENSION_404_JSX = (
     </p>
   </div>
 );
+
+export function getErrorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : 'Unknown error occured';
+}

--- a/src/util/errors.tsx
+++ b/src/util/errors.tsx
@@ -28,5 +28,7 @@ export const SERVER_EXTENSION_404_JSX = (
 );
 
 export function getErrorMessage(e: unknown): string {
-  return e instanceof Error ? e.message : 'Unknown error occured';
+  return e instanceof Error
+    ? e.message
+    : 'An error occurred. Please try again.';
 }


### PR DESCRIPTION
Emit telemetry events on success and failure of the Create Job, Create Job Definition, Create Job from Job Definition hooks. 
* Log object's `body.name` string is now following a new convention: `org.jupyter.jupyter-scheduler.SOURCE.EVENT[.STATUS]` (vs old convention `org.jupyter.jupyter-scheduler.SOURCE.EVENT`) where `STATUS` is either `"success"` or `"failure"`
* `CreateJob` now emits `"create-job"` or `"create-job-definition"` for `EVENT` instead of just `"create"` depending on if job or job definition is being created
* Log object's `body` now has optional `detail` parameter storing error message (or other string with event detail)
```ts
type EventLog = {
  body: { name: string; detail?: string };
  timestamp: Date;
};
```
* Improve error catching logic by catching errors as `unknown` type and using type guarding instead of assuming all errors caught would be of `Error` type (ts runtime error type) which is not guaranteed.
* Fix #471 

Emitted objects examples:
<img width="480" alt="Screenshot 2024-01-18 at 2 52 01 PM" src="https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/e8b40131-e16a-4afa-8a5d-309adcbb7740">

<img width="481" alt="Screenshot 2024-01-18 at 2 50 31 PM" src="https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/823ff018-7dc8-4a94-ba07-f4990b043ba3">



