### PR TITLE
Make server extension verification call during extension startup non-blocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@jupyterlab/coreutils": "^6",
     "@jupyterlab/filebrowser": "^4",
     "@jupyterlab/launcher": "^4",
-    "@jupyterlab/rendermime-interfaces": "^3.9.0",
+    "@jupyterlab/rendermime-interfaces": "^3.8.0",
     "@jupyterlab/services": "^7",
     "@jupyterlab/translation": "^4",
     "@jupyterlab/ui-components": "^4",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@jupyterlab/coreutils": "^6",
     "@jupyterlab/filebrowser": "^4",
     "@jupyterlab/launcher": "^4",
+    "@jupyterlab/rendermime-interfaces": "^3.9.0",
     "@jupyterlab/services": "^7",
     "@jupyterlab/translation": "^4",
     "@jupyterlab/ui-components": "^4",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,11 +47,6 @@ type EventLog = {
   timestamp: Date;
 };
 
-type verifyServerExtensiontProps = {
-  api: SchedulerService;
-  trans: IRenderMime.TranslationBundle;
-};
-
 /**
  * Call API to verify that the server extension is actually installed.
  */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,7 +55,10 @@ type verifyServerExtensiontProps = {
 /**
  * Call API to verify that the server extension is actually installed.
  */
-async function verifyServerExtension(props: verifyServerExtensiontProps) {
+async function verifyServerExtension(props: {
+  api: SchedulerService;
+  trans: IRenderMime.TranslationBundle;
+}) {
   try {
     await props.api.getJobs({ max_items: 0 });
   } catch (e: unknown) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -164,7 +164,7 @@ function getDirectoryFromPath(path: string | null): string | null {
   return directories.join('/') + (directories.length > 0 ? '/' : '');
 }
 
-async function activatePlugin(
+function activatePlugin(
   app: JupyterFrontEnd,
   browserFactory: IFileBrowserFactory,
   notebookTracker: INotebookTracker,
@@ -173,7 +173,7 @@ async function activatePlugin(
   advancedOptions: Scheduler.IAdvancedOptions,
   telemetryHandler: Scheduler.TelemetryHandler,
   launcher: ILauncher | null
-): Promise<void> {
+): void {
   const trans = translator.load('jupyterlab');
   const api = new SchedulerService({});
   verifyServerExtension({ api, trans });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,7 +47,7 @@ type EventLog = {
   timestamp: Date;
 };
 
-type verifyServExtProps = {
+type verifyServerExtensiontProps = {
   api: SchedulerService;
   trans: IRenderMime.TranslationBundle;
 };
@@ -55,7 +55,7 @@ type verifyServExtProps = {
 /**
  * Call API to verify that the server extension is actually installed.
  */
-async function verifyServExt(props: verifyServExtProps) {
+async function verifyServerExtension(props: verifyServerExtensiontProps) {
   try {
     await props.api.getJobs({ max_items: 0 });
   } catch (e: unknown) {
@@ -178,7 +178,7 @@ async function activatePlugin(
 ): Promise<void> {
   const trans = translator.load('jupyterlab');
   const api = new SchedulerService({});
-  verifyServExt({ api, trans });
+  verifyServerExtension({ api, trans });
 
   const { commands } = app;
   const fileBrowserTracker = browserFactory.tracker;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3785,6 +3785,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/rendermime-interfaces@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@jupyterlab/rendermime-interfaces@npm:3.9.0"
+  dependencies:
+    "@lumino/coreutils": ^1.11.0 || ^2.1.2
+    "@lumino/widgets": ^1.37.2 || ^2.3.1
+  checksum: 462f5d034cd636caf9322245a50045ddaac55e05e056e7c6579e2db55088e724c8054a51a959aa284c44b108a9e0f0053707b50d6d8a9caed5825eeaf715b245
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/rendermime@npm:^4.0.3":
   version: 4.0.3
   resolution: "@jupyterlab/rendermime@npm:4.0.3"
@@ -3819,6 +3829,7 @@ __metadata:
     "@jupyterlab/coreutils": ^6
     "@jupyterlab/filebrowser": ^4
     "@jupyterlab/launcher": ^4
+    "@jupyterlab/rendermime-interfaces": ^3.9.0
     "@jupyterlab/services": ^7
     "@jupyterlab/testutils": ^4
     "@jupyterlab/translation": ^4
@@ -4179,6 +4190,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/algorithm@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/algorithm@npm:2.0.1"
+  checksum: cbf7fcf6ee6b785ea502cdfddc53d61f9d353dcb9659343511d5cd4b4030be2ff2ca4c08daec42f84417ab0318a3d9972a17319fa5231693e109ab112dcf8000
+  languageName: node
+  linkType: hard
+
 "@lumino/application@npm:^2.1.1":
   version: 2.2.0
   resolution: "@lumino/application@npm:2.2.0"
@@ -4199,6 +4217,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/collections@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/collections@npm:2.0.1"
+  dependencies:
+    "@lumino/algorithm": ^2.0.1
+  checksum: 8a29b7973a388a33c5beda0819dcd2dc2aad51a8406dcfd4581b055a9f77a39dc5800f7a8b4ae3c0bb97ae7b56a7a869e2560ffb7a920a28e93b477ba05907d6
+  languageName: node
+  linkType: hard
+
 "@lumino/commands@npm:^2.1.1, @lumino/commands@npm:^2.1.2":
   version: 2.1.2
   resolution: "@lumino/commands@npm:2.1.2"
@@ -4214,10 +4241,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/commands@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@lumino/commands@npm:2.2.0"
+  dependencies:
+    "@lumino/algorithm": ^2.0.1
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/domutils": ^2.0.1
+    "@lumino/keyboard": ^2.0.1
+    "@lumino/signaling": ^2.1.2
+    "@lumino/virtualdom": ^2.0.1
+  checksum: 093e9715491e5cef24bc80665d64841417b400f2fa595f9b60832a3b6340c405c94a6aa276911944a2c46d79a6229f3cc087b73f50852bba25ece805abd0fae9
+  languageName: node
+  linkType: hard
+
 "@lumino/coreutils@npm:^1.11.0 || ^2.0.0, @lumino/coreutils@npm:^1.11.0 || ^2.1.1, @lumino/coreutils@npm:^2, @lumino/coreutils@npm:^2.1.1":
   version: 2.1.1
   resolution: "@lumino/coreutils@npm:2.1.1"
   checksum: dfdeb2b0282caae17b6c3edfebadf4ce7c75fc879fa60cacfef9b154412f4b35e4ffd95b1833b99d8dacb99aaaa04513570129ae2024c3f33e2677a01f0576ce
+  languageName: node
+  linkType: hard
+
+"@lumino/coreutils@npm:^1.11.0 || ^2.1.2, @lumino/coreutils@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@lumino/coreutils@npm:2.1.2"
+  checksum: 7865317ac0676b448d108eb57ab5d8b2a17c101995c0f7a7106662d9fe6c859570104525f83ee3cda12ae2e326803372206d6f4c1f415a5b59e4158a7b81066f
   languageName: node
   linkType: hard
 
@@ -4230,10 +4279,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/disposable@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@lumino/disposable@npm:2.1.2"
+  dependencies:
+    "@lumino/signaling": ^2.1.2
+  checksum: ac2fb2bf18d0b2939fda454f3db248a0ff6e8a77b401e586d1caa9293b3318f808b93a117c9c3ac27cd17aab545aea83b49108d099b9b2f5503ae2a012fbc6e2
+  languageName: node
+  linkType: hard
+
 "@lumino/domutils@npm:^2.0.0":
   version: 2.0.0
   resolution: "@lumino/domutils@npm:2.0.0"
   checksum: 4a146bfc1006d5fd00ccecc61d9803965d269c15c48c892fd87216336ce967f0db91f31203c5616c83d260224cddf25af4abb6704a6770757d19e44068f690bf
+  languageName: node
+  linkType: hard
+
+"@lumino/domutils@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/domutils@npm:2.0.1"
+  checksum: 61fa0ab226869dfbb763fc426790cf5a43b7d6f4cea1364c6dd56d61c44bff05eea188d33ff847449608ef58ed343161bee15c19b96f35410e4ee35815dc611a
   languageName: node
   linkType: hard
 
@@ -4247,10 +4312,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/dragdrop@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@lumino/dragdrop@npm:2.1.4"
+  dependencies:
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+  checksum: 43d82484b13b38b612e7dfb424a840ed6a38d0db778af10655c4ba235c67b5b12db1683929b35a36ab2845f77466066dfd1ee25c1c273e8e175677eba9dc560d
+  languageName: node
+  linkType: hard
+
 "@lumino/keyboard@npm:^2.0.0":
   version: 2.0.0
   resolution: "@lumino/keyboard@npm:2.0.0"
   checksum: 3852ba51f437b1c1d7e552a0f844592a05e04dd5012070dc6e4384c58965d1ebf536c6875c1b7bae03cde3c715ddc36cd290992fcefc1a8c39094194f4689fdd
+  languageName: node
+  linkType: hard
+
+"@lumino/keyboard@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/keyboard@npm:2.0.1"
+  checksum: cf33f13427a418efd7cc91061233321e860d5404f3d86397781028309bef86c8ad2d88276ffe335c1db0fe619bd9d1e60641c81f881696957a58703ee4652c3e
   languageName: node
   linkType: hard
 
@@ -4261,6 +4343,16 @@ __metadata:
     "@lumino/algorithm": ^2.0.0
     "@lumino/collections": ^2.0.0
   checksum: 1e82dcf9b110834d4342dc63dfeac0ee780880fb99051bd82d00a1f83afd91b276c1cea5af85a414d92c527adc365d54f20ec780123b562f89c5a2cd3e96bf81
+  languageName: node
+  linkType: hard
+
+"@lumino/messaging@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/messaging@npm:2.0.1"
+  dependencies:
+    "@lumino/algorithm": ^2.0.1
+    "@lumino/collections": ^2.0.1
+  checksum: 964c4651c374b17452b4252b7d71500b32d2ecd87c192fc5bcf5d3bd1070661d78d07edcac8eca7d1d6fd50aa25992505485e1296d6dd995691b8e349b652045
   languageName: node
   linkType: hard
 
@@ -4282,6 +4374,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/properties@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/properties@npm:2.0.1"
+  checksum: c50173a935148cc4148fdaea119df1d323ee004ae16ab666800388d27e9730345629662d85f25591683329b39f0cdae60ee8c94e8943b4d0ef7d7370a38128d6
+  languageName: node
+  linkType: hard
+
 "@lumino/signaling@npm:^1.10.0 || ^2.0.0, @lumino/signaling@npm:^2, @lumino/signaling@npm:^2.1.1":
   version: 2.1.1
   resolution: "@lumino/signaling@npm:2.1.1"
@@ -4292,12 +4391,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lumino/signaling@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@lumino/signaling@npm:2.1.2"
+  dependencies:
+    "@lumino/algorithm": ^2.0.1
+    "@lumino/coreutils": ^2.1.2
+  checksum: ad7d7153db57980da899c43e412e6130316ef30b231a70250e7af49058db16cadb018c1417a2ea8083d83c48623cfe6b705fa82bf10216b1a8949aed9f4aca4e
+  languageName: node
+  linkType: hard
+
 "@lumino/virtualdom@npm:^2.0.0":
   version: 2.0.0
   resolution: "@lumino/virtualdom@npm:2.0.0"
   dependencies:
     "@lumino/algorithm": ^2.0.0
   checksum: 6fc1d88e7d4a656be7664ccfc5745eb1d4e3d2034db0b11ad6abefcc642f22d265003eef0e1d02bca2e42b6da127123118c631369006f78e88a08885a6f36c25
+  languageName: node
+  linkType: hard
+
+"@lumino/virtualdom@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/virtualdom@npm:2.0.1"
+  dependencies:
+    "@lumino/algorithm": ^2.0.1
+  checksum: cf59b6f15b430e13e9e657b7a0619b9056cd9ea7b2a87f407391d071c501b77403c302b6a66dca510382045e75b2e3fe551630bb391f1c6b33678057d4bec164
   languageName: node
   linkType: hard
 
@@ -4317,6 +4435,25 @@ __metadata:
     "@lumino/signaling": ^2.1.1
     "@lumino/virtualdom": ^2.0.0
   checksum: 963c0e54102b786a9cbf3467041c9f6f5c275af751afc311ebeba30d56516767c463c425e321bb389eaa66726dfc4420119a9a58573dcbf3110aba9515c80606
+  languageName: node
+  linkType: hard
+
+"@lumino/widgets@npm:^1.37.2 || ^2.3.1":
+  version: 2.3.1
+  resolution: "@lumino/widgets@npm:2.3.1"
+  dependencies:
+    "@lumino/algorithm": ^2.0.1
+    "@lumino/commands": ^2.2.0
+    "@lumino/coreutils": ^2.1.2
+    "@lumino/disposable": ^2.1.2
+    "@lumino/domutils": ^2.0.1
+    "@lumino/dragdrop": ^2.1.4
+    "@lumino/keyboard": ^2.0.1
+    "@lumino/messaging": ^2.0.1
+    "@lumino/properties": ^2.0.1
+    "@lumino/signaling": ^2.1.2
+    "@lumino/virtualdom": ^2.0.1
+  checksum: ba7b8f8839c1cd2a41dbda13281094eb6981a270cccf4f25a0cf83686dcc526a2d8044a20204317630bb7dd4a04d65361408c7623a921549c781afca84b91c67
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3775,6 +3775,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/rendermime-interfaces@npm:^3.8.0":
+  version: 3.9.0
+  resolution: "@jupyterlab/rendermime-interfaces@npm:3.9.0"
+  dependencies:
+    "@lumino/coreutils": ^1.11.0 || ^2.1.2
+    "@lumino/widgets": ^1.37.2 || ^2.3.1
+  checksum: 462f5d034cd636caf9322245a50045ddaac55e05e056e7c6579e2db55088e724c8054a51a959aa284c44b108a9e0f0053707b50d6d8a9caed5825eeaf715b245
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/rendermime-interfaces@npm:^3.8.3":
   version: 3.8.3
   resolution: "@jupyterlab/rendermime-interfaces@npm:3.8.3"
@@ -3782,16 +3792,6 @@ __metadata:
     "@lumino/coreutils": ^1.11.0 || ^2.1.1
     "@lumino/widgets": ^1.37.2 || ^2.1.1
   checksum: aeb055196099e29eff78e98e904e3dac10255ac4693ed0d99022d08fe3de4dd792e66c06f6e11f110be2276e9ba36ae15b8a08e6fb1b4c25e774d5525199b5d3
-  languageName: node
-  linkType: hard
-
-"@jupyterlab/rendermime-interfaces@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@jupyterlab/rendermime-interfaces@npm:3.9.0"
-  dependencies:
-    "@lumino/coreutils": ^1.11.0 || ^2.1.2
-    "@lumino/widgets": ^1.37.2 || ^2.3.1
-  checksum: 462f5d034cd636caf9322245a50045ddaac55e05e056e7c6579e2db55088e724c8054a51a959aa284c44b108a9e0f0053707b50d6d8a9caed5825eeaf715b245
   languageName: node
   linkType: hard
 
@@ -3829,7 +3829,7 @@ __metadata:
     "@jupyterlab/coreutils": ^6
     "@jupyterlab/filebrowser": ^4
     "@jupyterlab/launcher": ^4
-    "@jupyterlab/rendermime-interfaces": ^3.9.0
+    "@jupyterlab/rendermime-interfaces": ^3.8.0
     "@jupyterlab/services": ^7
     "@jupyterlab/testutils": ^4
     "@jupyterlab/translation": ^4


### PR DESCRIPTION
* Make server extension verification call in index.ts non-blocking, refactor it into a separate function
* Fixes #479 

To test:
1. Add a sleep statement like `await asyncio.sleep(20)` (20 seconds) to [JobHandler.get ](https://github.com/jupyter-server/jupyter-scheduler/blob/1b50f81f966c9e0146f91b1606fd78519857527e/jupyter_scheduler/handlers.py#L189) as so:

```python
class JobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
    @authenticated
    async def get(self, job_id=None):
        await asyncio.sleep(20)
        ...
```
2. Launch the extension with and without this PR, note that with this PR startup is not blocked