### PR TITLE
Ignore check-wheel-contents W002 duplciate files error during release process as it is done in main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/jupyter-server/jupyter-scheduler"
 
+[tool.check-wheel-contents]
+ignore = ["W002"]
+
 [tool.hatch.build]
 artifacts = ["jupyter_scheduler/labextension"]
 


### PR DESCRIPTION
Ignore check-wheel-contents W002 duplciate files error during release process as it is done in main to remove release step error.

Details of the error: https://github.com/jupyter-server/jupyter-scheduler/actions/runs/7936673633
