### PR TITLE
Log notebooks with MLFlow

### DIFF
--- a/jupyter_scheduler/executors.py
+++ b/jupyter_scheduler/executors.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import os
 import shutil
@@ -138,28 +139,15 @@ class DefaultExecutionManager(ExecutionManager):
             kernel_name=nb.metadata.kernelspec["name"], store_widget_state=True, cwd=staging_dir
         )
 
-        mlflow.set_tracking_uri(MLFLOW_SERVER_URI)
-        with mlflow.start_run(run_id=job.mlflow_run_id):
-            try:
-                ep.preprocess(nb, {"metadata": {"path": staging_dir}})
-                if job.parameters:
-                    mlflow.log_params(job.parameters)
-
-                for idx, cell in enumerate(nb.cells):
-                    if "tags" in cell.metadata and "mlflow_log" in cell.metadata["tags"]:
-                        mlflow.log_text(cell.source, f"source_cell_{idx}.txt")
-                        if cell.cell_type == "code" and cell.outputs:
-                            for output in cell.outputs:
-                                if "text/plain" in output.data:
-                                    mlflow.log_text(
-                                        output.data["text/plain"], f"output_cell_{idx}.txt"
-                                    )
-
-            except CellExecutionError as e:
-                raise e
-            finally:
-                self.add_side_effects_files(staging_dir)
-                self.create_output_files(job, nb)
+        try:
+            ep.preprocess(nb, {"metadata": {"path": staging_dir}})
+        except CellExecutionError as e:
+            raise e
+        finally:
+            self.add_side_effects_files(staging_dir)
+            self.create_output_files(job, nb)
+            if getattr(job, "mlflow_logging", False):
+                self.log_to_mlflow(job, nb)
 
     def add_side_effects_files(self, staging_dir: str):
         """Scan for side effect files potentially created after input file execution and update the job's packaged_files with these files"""
@@ -187,10 +175,105 @@ class DefaultExecutionManager(ExecutionManager):
         for output_format in job.output_formats:
             cls = nbconvert.get_exporter(output_format)
             output, _ = cls().from_notebook_node(notebook_node)
-            output_path = self.staging_paths[output_format]
-            with fsspec.open(output_path, "w", encoding="utf-8") as f:
+            with fsspec.open(self.staging_paths[output_format], "w", encoding="utf-8") as f:
                 f.write(output)
-            mlflow.log_artifact(output_path)
+
+    def log_to_mlflow(self, job, nb):
+        mlflow.set_tracking_uri(MLFLOW_SERVER_URI)
+        with mlflow.start_run(run_id=job.mlflow_run_id):
+            if job.parameters:
+                mlflow.log_params(job.parameters)
+
+            for cell_idx, cell in enumerate(nb.cells):
+                if "tags" in cell.metadata:
+                    if "mlflow_log" in cell.metadata["tags"]:
+                        self.mlflow_log(cell, cell_idx)
+                    elif "mlflow_log_input" in cell.metadata["tags"]:
+                        self.mlflow_log_input(cell, cell_idx)
+                    elif "mlflow_log_output" in cell.metadata["tags"]:
+                        self.mlflow_log_output(cell, cell_idx)
+
+            for output_format in job.output_formats:
+                output_path = self.staging_paths[output_format]
+                directory, file_name_with_extension = os.path.split(output_path)
+                file_name, file_extension = os.path.splitext(file_name_with_extension)
+                file_name_parts = file_name.split("-")
+                file_name_without_timestamp = "-".join(file_name_parts[:-7])
+                file_name_final = f"{file_name_without_timestamp}{file_extension}"
+                new_output_path = os.path.join(directory, file_name_final)
+                shutil.copy(output_path, new_output_path)
+                timestamp = "-".join(file_name_parts[-7:]).split(".")[0]
+                mlflow.log_param("job_created", timestamp)
+                mlflow.log_artifact(new_output_path, "")
+                os.remove(new_output_path)
+
+    def mlflow_log(self, cell, cell_idx):
+        self.mlflow_log_input(cell, cell_idx)
+        self.mlflow_log_output(cell, cell_idx)
+
+    def mlflow_log_input(self, cell, cell_idx):
+        mlflow.log_text(cell.source, f"cell_{cell_idx}_input.txt")
+
+    def mlflow_log_output(self, cell, cell_idx):
+        if cell.cell_type == "code" and hasattr(cell, "outputs"):
+            self._log_code_output(cell_idx, cell.outputs)
+        elif cell.cell_type == "markdown":
+            self._log_markdown_output(cell, cell_idx)
+
+    def _log_code_output(self, cell_idx, outputs):
+        for output_idx, output in enumerate(outputs):
+            if output.output_type == "stream":
+                self._log_stream_output(cell_idx, output_idx, output)
+            elif hasattr(output, "data"):
+                for output_data_idx, output_data in enumerate(output.data):
+                    if output_data == "text/plain":
+                        mlflow.log_text(
+                            output.data[output_data],
+                            f"cell_{cell_idx}_output_{output_data_idx}.txt",
+                        )
+                    elif output_data == "text/html":
+                        self._log_html_output(output, cell_idx, output_data_idx)
+                    elif output_data == "application/pdf":
+                        self._log_pdf_output(output, cell_idx, output_data_idx)
+                    elif output_data.startswith("image"):
+                        self._log_image_output(output, cell_idx, output_data_idx, output_data)
+
+    def _log_stream_output(self, cell_idx, output_idx, output):
+        mlflow.log_text("".join(output.text), f"cell_{cell_idx}_output_{output_idx}.txt")
+
+    def _log_html_output(self, output, cell_idx, output_idx):
+        if "text/html" in output.data:
+            html_content = output.data["text/html"]
+            if isinstance(html_content, list):
+                html_content = "".join(html_content)
+            mlflow.log_text(html_content, f"cell_{cell_idx}_output_{output_idx}.html")
+
+    def _log_pdf_output(self, output, cell_idx, output_idx):
+        pdf_data = base64.b64decode(output.data["application/pdf"].split(",")[1])
+        with open(f"cell_{cell_idx}_output_{output_idx}.pdf", "wb") as pdf_file:
+            pdf_file.write(pdf_data)
+        mlflow.log_artifact(f"cell_{cell_idx}_output_{output_idx}.pdf")
+
+    def _log_image_output(self, output, cell_idx, output_idx, mime_type):
+        image_data_str = output.data[mime_type]
+        if "," in image_data_str:
+            image_data_base64 = image_data_str.split(",")[1]
+        else:
+            image_data_base64 = image_data_str
+
+        try:
+            image_data = base64.b64decode(image_data_base64)
+            image_extension = mime_type.split("/")[1]
+            filename = f"cell_{cell_idx}_output_{output_idx}.{image_extension}"
+            with open(filename, "wb") as image_file:
+                image_file.write(image_data)
+            mlflow.log_artifact(filename)
+            os.remove(filename)
+        except Exception as e:
+            print(f"Error logging image output in cell {cell_idx}, output {output_idx}: {e}")
+
+    def _log_markdown_output(self, cell, cell_idx):
+        mlflow.log_text(cell.source, f"cell_{cell_idx}_output_0.md")
 
     def supported_features(cls) -> Dict[JobFeature, bool]:
         return {

--- a/jupyter_scheduler/executors.py
+++ b/jupyter_scheduler/executors.py
@@ -144,6 +144,17 @@ class DefaultExecutionManager(ExecutionManager):
                 ep.preprocess(nb, {"metadata": {"path": staging_dir}})
                 if job.parameters:
                     mlflow.log_params(job.parameters)
+
+                for index, cell in enumerate(nb.cells):
+                    if "tags" in cell.metadata and "mlflow_log" in cell.metadata["tags"]:
+                        mlflow.log_text(cell.source, f"source_cell_{index}.txt")
+                        if cell.cell_type == "code" and cell.outputs:
+                            for output in cell.outputs:
+                                if "text/plain" in output.data:
+                                    mlflow.log_text(
+                                        output.data["text/plain"], f"output_cell_{cell.cell_id}.txt"
+                                    )
+
             except CellExecutionError as e:
                 raise e
             finally:

--- a/jupyter_scheduler/executors.py
+++ b/jupyter_scheduler/executors.py
@@ -145,14 +145,14 @@ class DefaultExecutionManager(ExecutionManager):
                 if job.parameters:
                     mlflow.log_params(job.parameters)
 
-                for index, cell in enumerate(nb.cells):
+                for idx, cell in enumerate(nb.cells):
                     if "tags" in cell.metadata and "mlflow_log" in cell.metadata["tags"]:
-                        mlflow.log_text(cell.source, f"source_cell_{index}.txt")
+                        mlflow.log_text(cell.source, f"source_cell_{idx}.txt")
                         if cell.cell_type == "code" and cell.outputs:
                             for output in cell.outputs:
                                 if "text/plain" in output.data:
                                     mlflow.log_text(
-                                        output.data["text/plain"], f"output_cell_{cell.cell_id}.txt"
+                                        output.data["text/plain"], f"output_cell_{idx}.txt"
                                     )
 
             except CellExecutionError as e:

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -86,6 +86,9 @@ class CreateJob(BaseModel):
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
     compute_type: Optional[str] = None
     package_input_folder: Optional[bool] = None
+    mlflow_logging: Optional[bool] = None
+    mlflow_experiment_id: Optional[str] = None
+    mlflow_run_id: Optional[str] = None
 
     @root_validator
     def compute_input_filename(cls, values) -> Dict:
@@ -148,6 +151,9 @@ class DescribeJob(BaseModel):
     downloaded: bool = False
     package_input_folder: Optional[bool] = None
     packaged_files: Optional[List[str]] = []
+    mlflow_logging: Optional[bool] = None
+    mlflow_experiment_id: Optional[str] = None
+    mlflow_run_id: Optional[str] = None
 
     class Config:
         orm_mode = True
@@ -213,6 +219,8 @@ class CreateJobDefinition(BaseModel):
     schedule: Optional[str] = None
     timezone: Optional[str] = None
     package_input_folder: Optional[bool] = None
+    mlflow_logging: Optional[bool] = None
+    mlflow_experiment_id: Optional[str] = None
 
     @root_validator
     def compute_input_filename(cls, values) -> Dict:
@@ -240,6 +248,8 @@ class DescribeJobDefinition(BaseModel):
     active: bool
     package_input_folder: Optional[bool] = None
     packaged_files: Optional[List[str]] = []
+    mlflow_logging: Optional[bool] = None
+    mlflow_experiment_id: Optional[str] = None
 
     class Config:
         orm_mode = True

--- a/jupyter_scheduler/orm.py
+++ b/jupyter_scheduler/orm.py
@@ -89,6 +89,8 @@ class CommonColumns:
     # Any default values specified for new columns will be ignored during the migration process.
     package_input_folder = Column(Boolean)
     packaged_files = Column(JsonType, default=[])
+    mlflow_logging = Column(Boolean)
+    mlflow_experiment_id = Column(String(256), nullable=True)
 
 
 class Job(CommonColumns, Base):
@@ -105,6 +107,7 @@ class Job(CommonColumns, Base):
     idempotency_token = Column(String(256))
     # All new columns added to this table must be nullable to ensure compatibility during database migrations.
     # Any default values specified for new columns will be ignored during the migration process.
+    mlflow_run_id = Column(String(256), nullable=True)
 
 
 class JobDefinition(CommonColumns, Base):

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -513,7 +513,7 @@ class Scheduler(BaseScheduler):
                 mlflow.log_artifact(input_file_path, "input")
 
             mlflow_run = mlflow_client.create_run(
-                experiment_id=experiment_id, run_name=model.input_filename
+                experiment_id=experiment_id, run_name=f"{model.input_filename}-{uuid4()}"
             )
             model.mlflow_run_id = mlflow_run.info.run_id
 

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -507,12 +507,12 @@ class Scheduler(BaseScheduler):
             if model.job_definition_id and model.mlflow_experiment_id:
                 experiment_id = model.mlflow_experiment_id
             else:
-                experiment_id = mlflow_client.create_experiment(f"{model.name}-{uuid4()}")
+                experiment_id = mlflow_client.create_experiment(f"{model.input_filename}-{uuid4()}")
                 model.mlflow_experiment_id = experiment_id
                 input_file_path = os.path.join(self.root_dir, model.input_uri)
                 mlflow.log_artifact(input_file_path, "input")
 
-            mlflow_run = mlflow_client.create_run(experiment_id=experiment_id, run_name=model.name)
+            mlflow_run = mlflow_client.create_run(experiment_id=experiment_id, run_name=model.input_filename)
             model.mlflow_run_id = mlflow_run.info.run_id
 
             job = Job(**model.dict(exclude_none=True, exclude={"input_uri"}))
@@ -663,7 +663,7 @@ class Scheduler(BaseScheduler):
                 raise InputUriError(model.input_uri)
 
             mlflow_client = mlflow.MlflowClient()
-            experiment_id = mlflow_client.create_experiment(f"{model.name}-{uuid4()}")
+            experiment_id = mlflow_client.create_experiment(f"{model.input_filename}-{uuid4()}")
             model.mlflow_experiment_id = experiment_id
             input_file_path = os.path.join(self.root_dir, model.input_uri)
             mlflow.log_artifact(input_file_path, "input")

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -512,7 +512,9 @@ class Scheduler(BaseScheduler):
                 input_file_path = os.path.join(self.root_dir, model.input_uri)
                 mlflow.log_artifact(input_file_path, "input")
 
-            mlflow_run = mlflow_client.create_run(experiment_id=experiment_id, run_name=model.input_filename)
+            mlflow_run = mlflow_client.create_run(
+                experiment_id=experiment_id, run_name=model.input_filename
+            )
             model.mlflow_run_id = mlflow_run.info.run_id
 
             job = Job(**model.dict(exclude_none=True, exclude={"input_uri"}))

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -4,8 +4,11 @@ import random
 import shutil
 from typing import Dict, List, Optional, Type, Union
 import subprocess
+from typing import Dict, Optional, Type, Union
+from uuid import uuid4
 
 import fsspec
+import mlflow
 import psutil
 from jupyter_core.paths import jupyter_data_dir
 from jupyter_server.transutils import _i18n
@@ -45,6 +48,10 @@ from jupyter_scheduler.utils import (
     create_output_directory,
     create_output_filename,
 )
+
+MLFLOW_SERVER_HOST = "127.0.0.1"
+MLFLOW_SERVER_PORT = "5000"
+MLFLOW_SERVER_URI = f"http://{MLFLOW_SERVER_HOST}:{MLFLOW_SERVER_PORT}"
 
 
 class BaseScheduler(LoggingConfigurable):
@@ -405,16 +412,13 @@ class Scheduler(BaseScheduler):
             [
                 "mlflow",
                 "server",
-                "--backend-store-uri",
-                "./mlruns",
-                "--default-artifact-root",
-                "./mlartifacts",
                 "--host",
-                "0.0.0.0",
+                MLFLOW_SERVER_HOST,
                 "--port",
-                "5000",
+                MLFLOW_SERVER_PORT,
             ]
         )
+        mlflow.set_tracking_uri(MLFLOW_SERVER_URI)
 
     def __init__(
         self,
@@ -480,6 +484,19 @@ class Scheduler(BaseScheduler):
 
             if not model.output_formats:
                 model.output_formats = []
+
+            mlflow_client = mlflow.MlflowClient()
+
+            if model.job_definition_id and model.mlflow_experiment_id:
+                experiment_id = model.mlflow_experiment_id
+            else:
+                experiment_id = mlflow_client.create_experiment(f"{model.name}-{uuid4()}")
+                model.mlflow_experiment_id = experiment_id
+                input_file_path = os.path.join(self.root_dir, model.input_uri)
+                mlflow.log_artifact(input_file_path, "input")
+
+            mlflow_run = mlflow_client.create_run(experiment_id=experiment_id, run_name=model.name)
+            model.mlflow_run_id = mlflow_run.info.run_id
 
             job = Job(**model.dict(exclude_none=True, exclude={"input_uri"}))
 
@@ -627,6 +644,12 @@ class Scheduler(BaseScheduler):
         with self.db_session() as session:
             if not self.file_exists(model.input_uri):
                 raise InputUriError(model.input_uri)
+
+            mlflow_client = mlflow.MlflowClient()
+            experiment_id = mlflow_client.create_experiment(f"{model.name}-{uuid4()}")
+            model.mlflow_experiment_id = experiment_id
+            input_file_path = os.path.join(self.root_dir, model.input_uri)
+            mlflow.log_artifact(input_file_path, "input")
 
             job_definition = JobDefinition(**model.dict(exclude_none=True, exclude={"input_uri"}))
             session.add(job_definition)

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -3,6 +3,7 @@ import os
 import random
 import shutil
 from typing import Dict, List, Optional, Type, Union
+import subprocess
 
 import fsspec
 import psutil
@@ -399,6 +400,22 @@ class Scheduler(BaseScheduler):
 
     task_runner = Instance(allow_none=True, klass="jupyter_scheduler.task_runner.BaseTaskRunner")
 
+    def start_mlflow_server(self):
+        subprocess.Popen(
+            [
+                "mlflow",
+                "server",
+                "--backend-store-uri",
+                "./mlruns",
+                "--default-artifact-root",
+                "./mlartifacts",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "5000",
+            ]
+        )
+
     def __init__(
         self,
         root_dir: str,
@@ -413,6 +430,8 @@ class Scheduler(BaseScheduler):
         self.db_url = db_url
         if self.task_runner_class:
             self.task_runner = self.task_runner_class(scheduler=self, config=config)
+
+        self.start_mlflow_server()
 
     @property
     def db_session(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
     "croniter~=1.4",
     "pytz==2023.3",
     "fsspec==2023.6.0",
-    "psutil~=5.9"
+    "psutil~=5.9",
+    "mlflow"
 ]
 
 [project.optional-dependencies]

--- a/src/components/mlflow-checkbox.tsx
+++ b/src/components/mlflow-checkbox.tsx
@@ -2,15 +2,13 @@ import React, { ChangeEvent } from 'react';
 
 import { Checkbox, FormControlLabel, FormGroup } from '@mui/material';
 
-export type MLFlowCheckboxProps = {
+export function MLFlowLoggingControl(props: {
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-};
-
-export function MLFlowCheckbox(props: MLFlowCheckboxProps): JSX.Element {
+}): JSX.Element {
   return (
     <FormGroup>
       <FormControlLabel
-        control={<Checkbox onChange={props.onChange} value={'mlflowLogging'} />}
+        control={<Checkbox onChange={props.onChange} name={'mlflowLogging'} />}
         label="Log with MLFlow"
       />
     </FormGroup>

--- a/src/components/mlflow-checkbox.tsx
+++ b/src/components/mlflow-checkbox.tsx
@@ -1,0 +1,18 @@
+import React, { ChangeEvent } from 'react';
+
+import { Checkbox, FormControlLabel, FormGroup } from '@mui/material';
+
+export type MLFlowCheckboxProps = {
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function MLFlowCheckbox(props: MLFlowCheckboxProps): JSX.Element {
+  return (
+    <FormGroup>
+      <FormControlLabel
+        control={<Checkbox onChange={props.onChange} value={'mlflowLogging'} />}
+        label="Log with MLFlow"
+      />
+    </FormGroup>
+  );
+}

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -364,6 +364,8 @@ export namespace Scheduler {
     schedule?: string;
     timezone?: string;
     package_input_folder?: boolean;
+    mlflow_logging?: boolean;
+    mlflow_experiment_id?: string;
   }
 
   export interface IUpdateJobDefinition {
@@ -391,6 +393,8 @@ export namespace Scheduler {
     update_time: number;
     active: boolean;
     package_input_folder?: boolean;
+    mlflow_logging: boolean;
+    mlflow_experiment_id?: string;
   }
 
   export interface IEmailNotifications {
@@ -418,6 +422,9 @@ export namespace Scheduler {
     output_formats?: string[];
     compute_type?: string;
     package_input_folder?: boolean;
+    mlflow_logging?: boolean;
+    mlflow_experiment_id?: string;
+    mlflow_run_id?: string;
   }
 
   export interface ICreateJobFromDefinition {
@@ -467,6 +474,9 @@ export namespace Scheduler {
     end_time?: number;
     downloaded: boolean;
     package_input_folder?: boolean;
+    mlflow_logging?: boolean;
+    mlflow_experiment_id?: string;
+    mlflow_run_id?: string;
   }
 
   export interface ICreateJobResponse {

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -43,6 +43,7 @@ import {
 import { Box, Stack } from '@mui/system';
 import { getErrorMessage } from '../util/errors';
 import { PackageInputFolderControl } from '../components/input-folder-checkbox';
+import { MLFlowCheckbox } from '../components/mlflow-checkbox';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -511,6 +512,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             onChange={handleInputChange}
             inputFile={props.model.inputFile}
           />
+          <MLFlowCheckbox onChange={handleInputChange} />
           <OutputFormatPicker
             label={trans.__('Output formats')}
             name="outputFormat"

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -176,7 +176,6 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const target = event.target;
-
     const parameterNameIdx = parameterNameMatch(target.name);
     const parameterValueIdx = parameterValueMatch(target.name);
     const newParams = props.model.parameters || [];
@@ -323,7 +322,10 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       idempotency_token: props.model.idempotencyToken,
       tags: props.model.tags,
       runtime_environment_parameters: props.model.runtimeEnvironmentParameters,
-      package_input_folder: props.model.packageInputFolder
+      package_input_folder: props.model.packageInputFolder,
+      mlflow_logging: props.model.mlflowLogging,
+      mlflow_experiment_id: props.model.mlflowExperimentId,
+      mlflow_run_id: props.model.mlflowRunId
     };
 
     if (props.model.parameters !== undefined) {
@@ -372,7 +374,9 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
       runtime_environment_parameters: props.model.runtimeEnvironmentParameters,
       schedule: props.model.schedule,
       timezone: props.model.timezone,
-      package_input_folder: props.model.packageInputFolder
+      package_input_folder: props.model.packageInputFolder,
+      mlflow_logging: props.model.mlflowLogging,
+      mlflow_experiment_id: props.model.mlflowExperimentId
     };
 
     if (props.model.parameters !== undefined) {

--- a/src/mainviews/create-job.tsx
+++ b/src/mainviews/create-job.tsx
@@ -43,7 +43,7 @@ import {
 import { Box, Stack } from '@mui/system';
 import { getErrorMessage } from '../util/errors';
 import { PackageInputFolderControl } from '../components/input-folder-checkbox';
-import { MLFlowCheckbox } from '../components/mlflow-checkbox';
+import { MLFlowLoggingControl } from '../components/mlflow-checkbox';
 
 export interface ICreateJobProps {
   model: ICreateJobModel;
@@ -512,7 +512,7 @@ export function CreateJob(props: ICreateJobProps): JSX.Element {
             onChange={handleInputChange}
             inputFile={props.model.inputFile}
           />
-          <MLFlowCheckbox onChange={handleInputChange} />
+          <MLFlowLoggingControl onChange={handleInputChange} />
           <OutputFormatPicker
             label={trans.__('Output formats')}
             name="outputFormat"

--- a/src/mainviews/detail-view/job-definition.tsx
+++ b/src/mainviews/detail-view/job-definition.tsx
@@ -32,6 +32,7 @@ import { Scheduler as SchedulerTokens } from '../../tokens';
 
 import { timestampLocalize } from './job-detail';
 import { getErrorMessage } from '../../util/errors';
+import { OpenInNew } from '@mui/icons-material';
 
 export interface IJobDefinitionProps {
   app: JupyterFrontEnd;
@@ -175,6 +176,18 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
       >
         {trans.__('Edit Job Definition')}
       </Button>
+      {model.mlflowLogging === true && (
+        <Button
+          variant="outlined"
+          onClick={() => {
+            const mlFlowUrl = `http://127.0.0.1:5000/#/experiments/${props.model?.mlflowExperimentId}`;
+            window.open(mlFlowUrl);
+          }}
+          endIcon={<OpenInNew />}
+        >
+          {trans.__('Open in MLFlow')}
+        </Button>
+      )}
       <ConfirmDialogDeleteButton
         handleDelete={async () => {
           log('job-definition-detail.delete');
@@ -229,6 +242,16 @@ export function JobDefinition(props: IJobDefinitionProps): JSX.Element {
       {
         value: model.timezone ?? '',
         label: trans.__('Time zone')
+      }
+    ],
+    [
+      {
+        value: model.mlflowLogging ? trans.__('Yes') : trans.__('No'),
+        label: trans.__('MLFlow Logging')
+      },
+      {
+        value: props.model.mlflowExperimentId,
+        label: trans.__('MLFLow Experiment Id')
       }
     ],
     [

--- a/src/mainviews/detail-view/job-detail.tsx
+++ b/src/mainviews/detail-view/job-detail.tsx
@@ -39,6 +39,11 @@ import {
   LabeledValue
 } from '../../components/labeled-value';
 import { getErrorMessage } from '../../util/errors';
+import { OpenInNew } from '@mui/icons-material';
+
+const MLFLOW_SERVER_HOST = '127.0.0.1';
+const MLFLOW_SERVER_PORT = '5000';
+const MLFLOW_SERVER_URI = `http://${MLFLOW_SERVER_HOST}:${MLFLOW_SERVER_PORT}`;
 
 export interface IJobDetailProps {
   app: JupyterFrontEnd;
@@ -167,6 +172,18 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
             {trans.__('Download Job Files')}
           </Button>
         )}
+      {props.model?.mlflowLogging === true && (
+        <Button
+          variant="outlined"
+          onClick={() => {
+            const mlFlowUrl = `${MLFLOW_SERVER_URI}/#/experiments/${props.model?.mlflowExperimentId}/runs/${props.model?.mlflowRunId}`;
+            window.open(mlFlowUrl);
+          }}
+          endIcon={<OpenInNew />}
+        >
+          {trans.__('Open in MLFlow')}
+        </Button>
+      )}
       {props.model !== null && props.model.status === 'IN_PROGRESS' && (
         <ConfirmDialogStopButton
           handleStop={handleStopJob}
@@ -250,6 +267,23 @@ export function JobDetail(props: IJobDetailProps): JSX.Element {
         value: timestampLocalize(props.model.endTime ?? ''),
         label: trans.__('End time')
       },
+      {
+        value: props.model.mlflowLogging ? trans.__('Yes') : trans.__('No'),
+        label: trans.__('MLFlow Logging')
+      }
+    ],
+    [
+      {
+        value: props.model.mlflowExperimentId,
+        label: trans.__('MLFLow Experiment Id')
+      },
+      {
+        value: props.model.mlflowRunId,
+
+        label: trans.__('MLFlow Run Id')
+      }
+    ],
+    [
       {
         value: props.model.packageInputFolder
           ? trans.__('Yes')

--- a/src/mainviews/list-jobs.tsx
+++ b/src/mainviews/list-jobs.tsx
@@ -226,7 +226,7 @@ function ListJobDefinitionsTable(props: ListJobDefinitionsTableProps) {
     },
     {
       sortField: 'input_filename',
-      name: trans.__('Input filename')
+      name: trans.__('Input file')
     },
     {
       sortField: 'create_time',

--- a/src/model.ts
+++ b/src/model.ts
@@ -100,6 +100,9 @@ export interface ICreateJobModel
   // Is the create button disabled due to a submission in progress?
   createInProgress?: boolean;
   packageInputFolder?: boolean;
+  mlflowLogging?: boolean;
+  mlflowExperimentId?: string;
+  mlflowRunId?: string;
 }
 
 export const defaultScheduleFields: ModelWithScheduleFields = {
@@ -312,6 +315,9 @@ export interface IJobDetailModel {
   job_files: Scheduler.IJobFile[];
   downloaded: boolean;
   packageInputFolder?: boolean;
+  mlflowLogging?: boolean;
+  mlflowExperimentId?: string;
+  mlflowRunId?: string;
 }
 
 export interface IJobDefinitionModel {
@@ -339,6 +345,8 @@ export interface IJobDefinitionModel {
   endTime?: number;
   outputPrefix?: string;
   packageInputFolder?: boolean;
+  mlflowLogging?: boolean;
+  mlflowExperimentId?: string;
 }
 
 const convertParameters = (parameters: {
@@ -388,7 +396,10 @@ export function convertDescribeJobtoJobDetail(
     startTime: describeJob.start_time,
     endTime: describeJob.end_time,
     downloaded: describeJob.downloaded,
-    packageInputFolder: describeJob.package_input_folder
+    packageInputFolder: describeJob.package_input_folder,
+    mlflowLogging: describeJob.mlflow_logging,
+    mlflowExperimentId: describeJob.mlflow_experiment_id,
+    mlflowRunId: describeJob.mlflow_run_id
   };
 }
 
@@ -417,7 +428,9 @@ export function convertDescribeDefinitiontoDefinition(
     updateTime: describeDefinition.update_time,
     schedule: describeDefinition.schedule,
     timezone: describeDefinition.timezone,
-    packageInputFolder: describeDefinition.package_input_folder
+    packageInputFolder: describeDefinition.package_input_folder,
+    mlflowLogging: describeDefinition.mlflow_logging,
+    mlflowExperimentId: describeDefinition.mlflow_experiment_id
   };
 }
 


### PR DESCRIPTION
Prototype of MLFlow - Scheduler integration:
* Add an option to "Log with MLFlow" during job / job definition creation. When activated, input notebooks "Run now" / single jobs are logged as single experiment with a single run, "Scheduled notebooks" / job definitions are logged as an experiment with a run for every job
* Modify models, scheduler, and executors logic to accommodate such logging
* Add "Open in MLFlow" button to detail view that opens a run (for a job) or experiment (for a job definition) in MLFLow Tracker UI where logged artifacts (input notebook, outputs) can be previewed
* Notebook cells tagged with `mlflow_log` (can be done via metadata editor) are logged as separate artifacts of the appropriate format (image, pdf, text, html, markdown) when notebook is ran with MLFlow logging enabled. `mlflow_log` tag logs both input (cell content) and output (result of running the cell), `mlflow_log_input` tag logs input only, `mlflow_log_output` tag logs output only. Note that MLFlow UI can only preview image, pdf, text, and html files.

To install and use, clone this PR/[andrii-i:mlflow](https://github.com/andrii-i/jupyter-scheduler/tree/mlflow) branch and follow the [development install steps](https://jupyter-scheduler.readthedocs.io/en/latest/contributors/index.html#development-install) form the jupyter-scheduler readthedocs.

Beyond the scope of this prototype:
* MLFlow could be used to replace existing Job files management functionality of the Scheduler
* Possibility to make MLFlow be able to run notebooks: MLFlow has [python_function abstraction](https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html?highlight=python_function) that tells it how to run [models](https://mlflow.org/docs/latest/traditional-ml/creating-custom-pyfunc/part1-named-flavors.html) (essentially, bundles of files). This could be potentially leveraged to package notebooks and dependencies as models and run them directly in MLFlow via python_function abstraction.

![Screenshot 2024-02-27 at 10 09 15 AM copy](https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/e974209c-ae8d-452d-8eaf-5743fb44e35b)
![Screenshot 2024-02-27 at 10 09 32 AM copy](https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/6d1221b7-faff-4d6b-80c7-6abc206eab97)
![Screenshot 2024-03-05 at 10 50 51 AM](https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/b3ac8e87-9da9-4b56-8f87-270b5dd36a0d)
<img width="1262" alt="Screenshot 2024-03-05 at 11 02 28 AM" src="https://github.com/jupyter-server/jupyter-scheduler/assets/26686070/64873cf9-4114-44b1-9084-9a9b7594853b">

