### PR TITLE
[1.2.x] Ignore check-wheel-contents W002 duplciate files error during release process as it is done in main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ docs = [
 [project.urls]
 Homepage = "https://github.com/jupyter-server/jupyter-scheduler"
 
+[tool.check-wheel-contents]
+ignore = ["W002"]
+
 [tool.hatch.build]
 artifacts = ["jupyter_scheduler/labextension"]
 


### PR DESCRIPTION
Ports https://github.com/jupyter-server/jupyter-scheduler/pull/488 to 1.2.x