### PR TITLE
Clarify support lifecycle after JupyterLab 3 end of maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ details.
 - JupyterLab >= 3.0
 
 > [!IMPORTANT]
-> JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. To help us make this transition, fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+> JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ details.
 
 ## Requirements
 
-- JupyterLab >= 3.0
+- JupyterLab >= 4.0
 
 > [!IMPORTANT]
 > JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ details.
 
 - JupyterLab >= 3.0
 
+> [!IMPORTANT]
+> JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. To help us make this transition, fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+
 ## Install
 
 To install the extension, execute:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ details.
 
 ## Requirements
 
-- JupyterLab >= 4.0
+- JupyterLab 4.x (for newer Jupyter Scheduler versions)
+- JupyterLab 3.x (for Jupyter Scheduler 1.x)
 
 > [!IMPORTANT]
 > JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ author = "Project Jupyter"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = ["myst_parser"]
+myst_enable_extensions = ["colon_fence"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -26,6 +26,11 @@ jupyter labextension list
 and checking that both the `jupyter_scheduler` server extension and the
 `@jupyterlab/scheduler` prebuilt lab extension are enabled.
 
+:::{important}
+:name: jupyter-lab-3-end-of-maintenance
+JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see `JupyterLab 3 end of maintenance <https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2>`\_ on the Jupyter Blog.
+:::
+
 ## Use
 
 Jupyter Scheduler runs Jupyter notebooks in the background, either once or on a schedule. You can create _jobs_ (single run of an individual notebook) and _job definitions_ (scheduled recurring notebook jobs). When the scheduler runs your notebook, it makes a copy of the input file. The scheduler uses unique names for the input and output files so that rerunning the same notebook produces new files every time.

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -26,9 +26,9 @@ jupyter labextension list
 and checking that both the `jupyter_scheduler` server extension and the
 `@jupyterlab/scheduler` prebuilt lab extension are enabled.
 
-:::{important}
+:::{attention}
 :name: jupyter-lab-3-end-of-maintenance
-JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see `JupyterLab 3 end of maintenance <https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2>`\_ on the Jupyter Blog.
+JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 :::
 
 ## Use


### PR DESCRIPTION
Modifies README.md and Users section, Installation subsection of readthedocs to clarify support lifecycle after JupyterLab 3 end of maintenance. Readthedocs section can be previewed [here](https://jupyter-scheduler--508.org.readthedocs.build/en/508/users/index.html#installation).

> JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024.
 
Fixes #485.
