### PR TITLE
Relax SQLAlchemy version requirements to allow for both SQLAlchemy 1.x and 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "traitlets~=5.0",
     "nbconvert~=7.0",
     "pydantic>=1.10,<3",
-    "sqlalchemy~=1.0",
+    "sqlalchemy>=1.0,<3",
     "croniter~=1.4",
     "pytz==2023.3",
     "fsspec==2023.6.0",


### PR DESCRIPTION
Jupyter Scheduler uses subset of SQLAlchemy functionality common between SQLAlchemy 1.x and 2.x. 

Relaxing SQLAlchemy version requirements to allow for both SQLAlchemy 1.x and 2.x would allow people who want to use Jupyter Scheduler and other packages that depend on SQLAlchemy 2.x (for example, [pandas](https://github.com/pandas-dev/pandas/blob/986074b4901511a4e87a99854fc62f8c24bdbb71/requirements-dev.txt#L45)) to do so. 

Fixes #478.

