### PR TITLE
Add database schema update and database migration logic

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 from jupyter_scheduler.orm import Base
 from jupyter_scheduler.scheduler import Scheduler

--- a/jupyter_scheduler/orm.py
+++ b/jupyter_scheduler/orm.py
@@ -1,5 +1,4 @@
 import json
-import os
 from sqlite3 import OperationalError
 from uuid import uuid4
 
@@ -92,6 +91,7 @@ class CommonColumns:
 
 class Job(CommonColumns, Base):
     __tablename__ = "jobs"
+    __table_args__ = {"extend_existing": True}
     job_id = Column(String(36), primary_key=True, default=generate_uuid)
     job_definition_id = Column(String(36))
     status = Column(String(64), default=Status.STOPPED)
@@ -105,6 +105,7 @@ class Job(CommonColumns, Base):
 
 class JobDefinition(CommonColumns, Base):
     __tablename__ = "job_definitions"
+    __table_args__ = {"extend_existing": True}
     job_definition_id = Column(String(36), primary_key=True, default=generate_uuid)
     schedule = Column(String(256))
     timezone = Column(String(36))

--- a/jupyter_scheduler/orm.py
+++ b/jupyter_scheduler/orm.py
@@ -124,6 +124,8 @@ def update_db_schema(engine, Base):
                 columns_db_names = {col["name"] for col in columns_db}
 
                 for column_model_name, column_model in model.c.items():
+                    if column_model_name in columns_db_names:
+                        continue
                     if column_model_name not in columns_db_names:
                         column_type = str(column_model.type.compile(dialect=engine.dialect))
                         nullable = "NULL" if column_model.nullable else "NOT NULL"

--- a/jupyter_scheduler/orm.py
+++ b/jupyter_scheduler/orm.py
@@ -85,6 +85,8 @@ class CommonColumns:
     output_filename_template = Column(String(256))
     update_time = Column(Integer, default=get_utc_timestamp, onupdate=get_utc_timestamp)
     create_time = Column(Integer, default=get_utc_timestamp)
+    # All new columns added to this table must be nullable to ensure compatibility during database migrations.
+    # Any default values specified for new columns will be ignored during the migration process.
     package_input_folder = Column(Boolean)
     packaged_files = Column(JsonType, default=[])
 
@@ -101,6 +103,8 @@ class Job(CommonColumns, Base):
     url = Column(String(256), default=generate_jobs_url)
     pid = Column(Integer)
     idempotency_token = Column(String(256))
+    # All new columns added to this table must be nullable to ensure compatibility during database migrations.
+    # Any default values specified for new columns will be ignored during the migration process.
 
 
 class JobDefinition(CommonColumns, Base):
@@ -112,6 +116,8 @@ class JobDefinition(CommonColumns, Base):
     url = Column(String(256), default=generate_job_definitions_url)
     create_time = Column(Integer, default=get_utc_timestamp)
     active = Column(Boolean, default=True)
+    # All new columns added to this table must be nullable to ensure compatibility during database migrations.
+    # Any default values specified for new columns will be ignored during the migration process.
 
 
 def update_db_schema(engine, Base):
@@ -128,9 +134,8 @@ def update_db_schema(engine, Base):
                         continue
                     if column_model_name not in columns_db_names:
                         column_type = str(column_model.type.compile(dialect=engine.dialect))
-                        nullable = "NULL" if column_model.nullable else "NOT NULL"
                         alter_statement = text(
-                            f"ALTER TABLE {table_name} ADD COLUMN {column_model_name} {column_type} {nullable}"
+                            f"ALTER TABLE {table_name} ADD COLUMN {column_model_name} {column_type} NULL"
                         )
                         connection.execute(alter_statement)
 

--- a/jupyter_scheduler/tests/test_orm.py
+++ b/jupyter_scheduler/tests/test_orm.py
@@ -1,6 +1,7 @@
+from typing import Type
 import pytest
-from sqlalchemy import Column, Integer, String, create_engine, inspect
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import Column, Integer, String, inspect
+from sqlalchemy.orm import DeclarativeMeta, sessionmaker
 
 from jupyter_scheduler.orm import (
     create_session,
@@ -11,7 +12,7 @@ from jupyter_scheduler.orm import (
 
 
 @pytest.fixture
-def initial_db(jp_scheduler_db_url):
+def initial_db(jp_scheduler_db_url) -> tuple[Type[DeclarativeMeta], sessionmaker, str]:
     TestBase = declarative_base()
 
     class InitialJob(TestBase):
@@ -36,7 +37,7 @@ def initial_db(jp_scheduler_db_url):
 
 
 @pytest.fixture
-def updated_job_model(initial_db):
+def updated_job_model(initial_db) -> Type[DeclarativeMeta]:
     Base = initial_db[0]
 
     class UpdatedJob(Base):
@@ -45,7 +46,7 @@ def updated_job_model(initial_db):
         job_id = Column(String(36), primary_key=True, default=generate_uuid)
         runtime_environment_name = Column(String(256), nullable=False)
         input_filename = Column(String(256), nullable=False)
-        new_column = Column("new_column", Integer, default=0)
+        new_column = Column("new_column", Integer)
 
     return UpdatedJob
 

--- a/jupyter_scheduler/tests/test_orm.py
+++ b/jupyter_scheduler/tests/test_orm.py
@@ -1,0 +1,65 @@
+import pytest
+from sqlalchemy import Column, Integer, String, create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+from jupyter_scheduler.orm import (
+    create_tables,
+    declarative_base,
+    create_session,
+    generate_uuid,
+)
+
+
+@pytest.fixture
+def initial_db(jp_scheduler_db_url):
+    TestBase = declarative_base()
+
+    class InitialJob(TestBase):
+        __tablename__ = "jobs"
+        job_id = Column(String(36), primary_key=True, default=generate_uuid)
+        runtime_environment_name = Column(String(256), nullable=False)
+        input_filename = Column(String(256), nullable=False)
+
+    initial_job = InitialJob(runtime_environment_name="abc", input_filename="abc")
+
+    create_tables(db_url=jp_scheduler_db_url, Base=TestBase)
+
+    Session = create_session(jp_scheduler_db_url)
+    session = Session()
+
+    session.add(initial_job)
+    session.commit()
+    job_id = initial_job.job_id
+    session.close()
+
+    yield TestBase, Session, job_id
+
+
+def updated_job_model(Base):
+    class UpdatedJob(Base):
+        __tablename__ = "jobs"
+        __table_args__ = {"extend_existing": True}
+        job_id = Column(String(36), primary_key=True, default=generate_uuid)
+        runtime_environment_name = Column(String(256), nullable=False)
+        input_filename = Column(String(256), nullable=False)
+        new_column = Column("new_column", Integer, default=0)
+
+    return UpdatedJob
+
+
+def test_create_tables_with_new_column(jp_scheduler_db_url, initial_db):
+    Base, Session, initial_job_id = initial_db
+
+    session = Session()
+    initial_columns = {col["name"] for col in inspect(session.bind).get_columns("jobs")}
+    assert "new_column" not in initial_columns
+    session.close()
+
+    JobModel = updated_job_model(Base)
+    create_tables(db_url=jp_scheduler_db_url, Base=Base)
+
+    session = Session()
+    updated_columns = {col["name"] for col in inspect(session.bind).get_columns("jobs")}
+    assert "new_column" in updated_columns
+
+    job1 = session.query(JobModel).filter(JobModel.job_id == initial_job_id).one()
+    assert job1 is not None

--- a/jupyter_scheduler/tests/test_orm.py
+++ b/jupyter_scheduler/tests/test_orm.py
@@ -16,13 +16,13 @@ from jupyter_scheduler.orm import (
 def initial_db(jp_scheduler_db_url) -> tuple[Type[DeclarativeMeta], sessionmaker, str]:
     TestBase = declarative_base()
 
-    class InitialJob(TestBase):
+    class MockInitialJob(TestBase):
         __tablename__ = "jobs"
         job_id = Column(String(36), primary_key=True, default=generate_uuid)
         runtime_environment_name = Column(String(256), nullable=False)
         input_filename = Column(String(256), nullable=False)
 
-    initial_job = InitialJob(runtime_environment_name="abc", input_filename="input.ipynb")
+    initial_job = MockInitialJob(runtime_environment_name="abc", input_filename="input.ipynb")
 
     create_tables(db_url=jp_scheduler_db_url, Base=TestBase)
 
@@ -39,9 +39,9 @@ def initial_db(jp_scheduler_db_url) -> tuple[Type[DeclarativeMeta], sessionmaker
 
 @pytest.fixture
 def updated_job_model(initial_db) -> Type[DeclarativeMeta]:
-    Base = initial_db[0]
+    TestBase = initial_db[0]
 
-    class UpdatedJob(Base):
+    class MockUpdatedJob(TestBase):
         __tablename__ = "jobs"
         __table_args__ = {"extend_existing": True}
         job_id = Column(String(36), primary_key=True, default=generate_uuid)
@@ -49,11 +49,11 @@ def updated_job_model(initial_db) -> Type[DeclarativeMeta]:
         input_filename = Column(String(256), nullable=False)
         new_column = Column("new_column", Integer)
 
-    return UpdatedJob
+    return MockUpdatedJob
 
 
 def test_create_tables_with_new_column(jp_scheduler_db_url, initial_db, updated_job_model):
-    Base, Session, initial_job_id = initial_db
+    TestBase, Session, initial_job_id = initial_db
 
     session = Session()
     initial_columns = {col["name"] for col in inspect(session.bind).get_columns("jobs")}
@@ -61,7 +61,7 @@ def test_create_tables_with_new_column(jp_scheduler_db_url, initial_db, updated_
     session.close()
 
     JobModel = updated_job_model
-    create_tables(db_url=jp_scheduler_db_url, Base=Base)
+    create_tables(db_url=jp_scheduler_db_url, Base=TestBase)
 
     session = Session()
     updated_columns = {col["name"] for col in inspect(session.bind).get_columns("jobs")}

--- a/jupyter_scheduler/tests/test_orm.py
+++ b/jupyter_scheduler/tests/test_orm.py
@@ -1,4 +1,5 @@
 from typing import Type
+
 import pytest
 from sqlalchemy import Column, Integer, String, inspect
 from sqlalchemy.orm import DeclarativeMeta, sessionmaker

--- a/jupyter_scheduler/tests/test_orm.py
+++ b/jupyter_scheduler/tests/test_orm.py
@@ -1,10 +1,11 @@
 import pytest
 from sqlalchemy import Column, Integer, String, create_engine, inspect
 from sqlalchemy.orm import sessionmaker
+
 from jupyter_scheduler.orm import (
+    create_session,
     create_tables,
     declarative_base,
-    create_session,
     generate_uuid,
 )
 

--- a/jupyter_scheduler/tests/test_orm.py
+++ b/jupyter_scheduler/tests/test_orm.py
@@ -34,7 +34,7 @@ def initial_db(jp_scheduler_db_url) -> tuple[Type[DeclarativeMeta], sessionmaker
     job_id = initial_job.job_id
     session.close()
 
-    return TestBase, Session, job_id
+    return (TestBase, Session, job_id)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add database schema update and database migration logic, test cases. 

With this PR, if database schema is extended between versions, schema is automatically updated and relevant tables are altered accordingly preventing errors. 

Fixes #519.
