### PR TITLE
Update to SQLAlchemy 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ details.
 > Starting with v2.7.0, Jupyter Scheduler requires SQLAlchemy 2.x instead of SQLAlchemy 1.x.
 
 > [!IMPORTANT]
-> JupyterLab 3 reached its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+> JupyterLab 3 reached its end of maintenance date on May 15, 2024. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ details.
 - JupyterLab 3.x (for Jupyter Scheduler 1.x)
 
 > [!IMPORTANT]
+> Starting with v2.7.0, Jupyter Scheduler requires SQLAlchemy 2.x instead of SQLAlchemy 1.x.
+
+> [!IMPORTANT]
 > JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ details.
 > Starting with v2.7.0, Jupyter Scheduler requires SQLAlchemy 2.x instead of SQLAlchemy 1.x.
 
 > [!IMPORTANT]
-> JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+> JupyterLab 3 reached its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 
 ## Install
 

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -33,7 +33,7 @@ Starting with v2.7.0, Jupyter Scheduler requires SQLAlchemy 2.x instead of SQLAl
 
 :::{attention}
 :name: jupyter-lab-3-end-of-maintenance
-JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+JupyterLab 3 reached its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 :::
 
 ## Use

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -27,6 +27,11 @@ and checking that both the `jupyter_scheduler` server extension and the
 `@jupyterlab/scheduler` prebuilt lab extension are enabled.
 
 :::{attention}
+:name: sqlalchemy-2.x-requirement
+Starting with v2.7.0, Jupyter Scheduler requires SQLAlchemy 2.x instead of SQLAlchemy 1.x.
+:::
+
+:::{attention}
 :name: jupyter-lab-3-end-of-maintenance
 JupyterLab 3 will reach its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 :::

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -33,7 +33,7 @@ Starting with v2.7.0, Jupyter Scheduler requires SQLAlchemy 2.x instead of SQLAl
 
 :::{attention}
 :name: jupyter-lab-3-end-of-maintenance
-JupyterLab 3 reached its end of maintenance date on May 15, 2024, anywhere on Earth. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
+JupyterLab 3 reached its end of maintenance date on May 15, 2024. As a result, we will not backport new features to the v1 branch supporting JupyterLab 3 after this date. Fixes for critical issues will still be backported until December 31, 2024. If you are still using JupyterLab 3, we strongly encourage you to **upgrade to JupyterLab 4 as soon as possible**. For more information, see [JupyterLab 3 end of maintenance](https://blog.jupyter.org/jupyterlab-3-end-of-maintenance-879778927db2) on the Jupyter Blog.
 :::
 
 ## Use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "traitlets~=5.0",
     "nbconvert~=7.0",
     "pydantic>=1.10,<3",
-    "sqlalchemy~=1.0",
+    "sqlalchemy>=2.0,<3",
     "croniter~=1.4",
     "pytz==2023.3",
     "fsspec==2023.6.0",


### PR DESCRIPTION
Jupyter Scheduler uses subset of SQLAlchemy functionality supported in both SQLAlchemy 1.x and 2.x.

Updating to SQLAlchemy 2.x would allow people who want to use Jupyter Scheduler and other packages that depend on SQLAlchemy 2.x in the same environment (for example, [pandas](https://github.com/pandas-dev/pandas/blob/986074b4901511a4e87a99854fc62f8c24bdbb71/requirements-dev.txt#L45)) to do so.

For reference: [SQLAlchemy 2.0 - Major Migration Guide ](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#the-1-4-2-0-migration-path).

Fixes #478.
Will also fix a SQLAlchemy 1.x depreciation warning failing CI in #520: https://github.com/jupyter-server/jupyter-scheduler/actions/runs/9179340732/job/25241262049?pr=520#step:6:463