### PR TITLE
Emit telemetry event on "Run job with input folder" checkbox click

### DIFF
--- a/src/components/input-folder-checkbox.tsx
+++ b/src/components/input-folder-checkbox.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react';
-import { useTranslator } from '../hooks';
+import { useEventLogger, useTranslator } from '../hooks';
 
 import {
   Checkbox,
@@ -13,6 +13,7 @@ export function PackageInputFolderControl(props: {
   inputFile: string;
 }): JSX.Element {
   const trans = useTranslator('jupyterlab');
+  const log = useEventLogger();
   const inputFilePath = props.inputFile.split('/');
   inputFilePath.pop();
 
@@ -33,7 +34,14 @@ export function PackageInputFolderControl(props: {
     <FormGroup>
       <FormControlLabel
         control={
-          <Checkbox onChange={props.onChange} name={'packageInputFolder'} />
+          <Checkbox
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+              const checkboxEvent = event.target.checked ? 'check' : 'uncheck';
+              log(`create-job.options.package_input_folder.${checkboxEvent}`);
+              props.onChange(event);
+            }}
+            name={'packageInputFolder'}
+          />
         }
         label={trans.__('Run job with input folder')}
         aria-describedby="jp-package-input-folder-helper-text"

--- a/src/components/input-folder-checkbox.tsx
+++ b/src/components/input-folder-checkbox.tsx
@@ -35,7 +35,7 @@ export function PackageInputFolderControl(props: {
       <FormControlLabel
         control={
           <Checkbox
-            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            onChange={event => {
               const checkboxEvent = event.target.checked ? 'check' : 'uncheck';
               log(`create-job.options.package_input_folder.${checkboxEvent}`);
               props.onChange(event);


### PR DESCRIPTION
Emit `create-job.options.package_input_folder.{check/uncheck}` on "Run job with input folder" checkbox click. Metric name is proposed because it is semantically in line with metrics already being emitted: [1](https://github.com/jupyter-server/jupyter-scheduler/blob/dbeb34fd357cc5f9bfad28cb1233e7041d25e24c/src/mainviews/create-job.tsx#L341), [2](https://github.com/jupyter-server/jupyter-scheduler/blob/dbeb34fd357cc5f9bfad28cb1233e7041d25e24c/src/mainviews/create-job.tsx#L598), [3](https://github.com/jupyter-server/jupyter-scheduler/blob/dbeb34fd357cc5f9bfad28cb1233e7041d25e24c/src/mainviews/create-job.tsx#L548-L552).

Note that by default [LogContext is empty](https://github.com/jupyter-server/jupyter-scheduler/blob/dbeb34fd357cc5f9bfad28cb1233e7041d25e24c/src/context.ts#L5-L9) so telemetry goes nowhere (Jupyter Scheduler operator needs to overwrite it with a custom logging function to actually use telemetry). So this PR is in line what we are already doing and does not expose Jupyter Scheduler users to anything.