### PR TITLE
Add OpenAPI API specification

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -487,7 +487,7 @@ components:
           type: string
         direction:
           type: string
-        enum: [asc, desc]
+          enum: [asc, desc]
     DescribeJob:
       type: object
       properties:
@@ -575,8 +575,8 @@ components:
           type: object
         tags:
           type: array
-        items:
-          type: string
+          items:
+            type: string
         name:
           type: string
         output_filename_template:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -88,12 +88,6 @@ paths:
                 properties:
                   job_id:
                     type: string
-        '400':
-          description: Invalid request data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         '500':
           description: Server error
           content:
@@ -141,18 +135,6 @@ paths:
       responses:
         '204':
           description: Successfully updated the job.
-        '400':
-          description: Invalid request data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '404':
-          description: Job not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         '500':
           description: Server error
           content:
@@ -170,12 +152,6 @@ paths:
       responses:
         '204':
           description: Successfully deleted the job.
-        '404':
-          description: Job not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         '500':
           description: Server error
           content:
@@ -261,12 +237,6 @@ paths:
                 properties:
                   job_definition_id:
                     type: string
-        '400':
-          description: Invalid request data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         '500':
           description: Server error
           content:
@@ -315,18 +285,6 @@ paths:
       responses:
         '204':
           description: Successfully updated the job definition.
-        '400':
-          description: Invalid request data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '404':
-          description: Job definition not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         '500':
           description: Server error
           content:
@@ -345,12 +303,6 @@ paths:
       responses:
         '204':
           description: Successfully deleted the job definition.
-        '404':
-          description: Job definition not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         '500':
           description: Server error
           content:
@@ -384,12 +336,6 @@ paths:
                 properties:
                   job_id:
                     type: string
-        '400':
-          description: Invalid input data
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
         '500':
           description: Server error
           content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,777 @@
+openapi: 3.0.0
+info:
+  title: Jupyter Scheduler API
+  version: 2.7.1
+  description: API for Jupyter Scheduler, a JupyterLab extension for running notebook jobs.
+servers:
+  - url: /scheduler
+paths:
+  /jobs:
+    get:
+      summary: List all jobs
+      parameters:
+        - name: job_definition_id
+          in: query
+          schema:
+            type: string
+          required: false
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/Status'
+          required: false
+        - name: name
+          in: query
+          schema:
+            type: string
+          required: false
+        - name: tags
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          required: false
+        - name: start_time
+          in: query
+          schema:
+            type: integer
+          required: false
+        - name: sort_by
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortField'
+          description: Specifies the sorting criteria, defaults to 'create_time' in descending order if not provided
+          required: false
+        - name: max_items
+          in: query
+          schema:
+            type: integer
+            default: 1000
+          required: false
+        - name: next_token
+          in: query
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: Successfully retrieved the list of jobs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListJobsResponse'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      summary: Create a new job
+      requestBody:
+        description: Payload to create a new job
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateJob'
+      responses:
+        '200':
+          description: Successfully created the job.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job_id:
+                    type: string
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+  /jobs/{job_id}:
+    get:
+      summary: Get details of a specific job
+      parameters:
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully retrieved job details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DescribeJob'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    patch:
+      summary: Update a specific job
+      parameters:
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Data for updating the job
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateJob'
+      responses:
+        '204':
+          description: Successfully updated the job.
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Job not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      summary: Delete a specific job
+      parameters:
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successfully deleted the job.
+        '404':
+          description: Job not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+  /job_definitions:
+    get:
+      summary: List all job definitions
+      parameters:
+        - name: job_definition_id
+          in: query
+          schema:
+            type: string
+          required: false
+        - name: name
+          in: query
+          schema:
+            type: string
+          required: false
+        - name: tags
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          required: false
+        - name: create_time
+          in: query
+          schema:
+            type: integer
+          required: false
+        - name: sort_by
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortField'
+          description: Specifies the sorting criteria, defaults to 'create_time' in descending order if not provided
+          required: false
+        - name: max_items
+          in: query
+          schema:
+            type: integer
+            default: 1000
+          required: false
+        - name: next_token
+          in: query
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: Successfully retrieved the list of job definitions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListJobDefinitionsResponse'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+    post:
+      summary: Create a new job definition
+      requestBody:
+        description: Payload to create a new job definition
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateJobDefinition'
+      responses:
+        '200':
+          description: Successfully created the job definition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job_definition_id:
+                    type: string
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+  /job_definitions/{job_definition_id}:
+    get:
+      summary: Get details of a specific job definition
+      parameters:
+        - name: job_definition_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully retrieved job definition details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DescribeJobDefinition'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+    patch:
+      summary: Update a specific job definition
+      parameters:
+        - name: job_definition_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Data for updating the job definition
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateJobDefinition'
+      responses:
+        '204':
+          description: Successfully updated the job definition.
+        '400':
+          description: Invalid request data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Job definition not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+    delete:
+      summary: Delete a specific job definition
+      parameters:
+        - name: job_definition_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Successfully deleted the job definition.
+        '404':
+          description: Job definition not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+  /jobs/{job_id}/download_files:
+    get:
+      summary: Download job files
+      parameters:
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: redownload
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '204':
+          description: Files successfully downloaded or copied.
+        '500':
+          description: Error downloading files
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+  /jobs/count:
+    get:
+      summary: Count jobs based on status
+      parameters:
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/Status'
+      responses:
+        '200':
+          description: Successfully counted jobs.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+  /runtime_environments:
+    get:
+      summary: List available runtime environments
+      responses:
+        '200':
+          description: Successfully listed runtime environments.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RuntimeEnvironment'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+  /config:
+    get:
+      summary: Get configuration details
+      responses:
+        '200':
+          description: Successfully retrieved configuration details.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  supported_features:
+                    type: array
+                    items:
+                      type: string
+                  manage_environments_command:
+                    type: string
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+  /batch/jobs:
+    delete:
+      summary: Batch delete jobs
+      parameters:
+        - name: job_id
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '204':
+          description: Successfully deleted the specified jobs.
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        message:
+          type: string
+    Status:
+      type: string
+      enum: [CREATED, QUEUED, IN_PROGRESS, COMPLETED, FAILED, STOPPING, STOPPED]
+    SortField:
+      type: object
+      properties:
+        name:
+          type: string
+        direction:
+          type: string
+        enum: [asc, desc]
+    DescribeJob:
+      type: object
+      properties:
+        job_id:
+          type: string
+        input_filename:
+          type: string
+        runtime_environment_name:
+          type: string
+        runtime_environment_parameters:
+          type: object
+          additionalProperties:
+            type: string
+        output_formats:
+          type: array
+          items:
+            type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+        output_filename_template:
+          type: string
+        compute_type:
+          type: string
+        job_files:
+          type: array
+          items:
+            $ref: '#/components/schemas/JobFile'
+        create_time:
+          type: integer
+        update_time:
+          type: integer
+        start_time:
+          type: integer
+        end_time:
+          type: integer
+        status:
+          $ref: '#/components/schemas/Status'
+        status_message:
+          type: string
+        downloaded:
+          type: boolean
+        package_input_folder:
+          type: boolean
+        packaged_files:
+          type: array
+          items:
+            type: string
+    ListJobsResponse:
+      type: object
+      properties:
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DescribeJob'
+        total_count:
+          type: integer
+        next_token:
+          type: string
+    CreateJob:
+      type: object
+      properties:
+        input_uri:
+          type: string
+        input_filename:
+          type: string
+        runtime_environment_name:
+          type: string
+        runtime_environment_parameters:
+          type: object
+        additionalProperties:
+            type: string
+        output_formats:
+          type: array
+          items:
+            type: string
+        parameters:
+          type: object
+        additionalProperties:
+            type: string
+        tags:
+          type: array
+        items:
+            type: string
+        name:
+          type: string
+        output_filename_template:
+          type: string
+        compute_type:
+          type: string
+        package_input_folder:
+          type: boolean
+    UpdateJob:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/Status'
+        name:
+          type: string
+        compute_type:
+          type: string
+    DescribeJobDefinition:
+      type: object
+      properties:
+        job_definition_id:
+          type: string
+        input_filename:
+          type: string
+        runtime_environment_name:
+          type: string
+        runtime_environment_parameters:
+          type: object
+          additionalProperties:
+            type: string
+        output_formats:
+          type: array
+          items:
+            type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+        output_filename_template:
+          type: string
+        active:
+          type: boolean
+        create_time:
+          type: integer
+        update_time:
+          type: integer
+    ListJobDefinitionsResponse:
+      type: object
+      properties:
+        job_definitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/DescribeJobDefinition'
+        total_count:
+          type: integer
+        next_token:
+          type: string
+    CreateJobDefinition:
+      type: object
+      properties:
+        input_uri:
+          type: string
+        input_filename:
+          type: string
+        runtime_environment_name:
+          type: string
+        runtime_environment_parameters:
+          type: object
+          additionalProperties:
+            type: string
+        output_formats:
+          type: array
+          items:
+            type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+        output_filename_template:
+          type: string
+        active:
+          type: boolean
+        schedule:
+          type: string
+        timezone:
+          type: string
+        compute_type:
+          type: string
+        package_input_folder:
+          type: boolean
+    UpdateJobDefinition:
+      type: object
+      properties:
+        runtime_environment_name:
+          type: string
+        runtime_environment_parameters:
+          type: object
+          additionalProperties:
+            type: string
+        output_formats:
+          type: array
+          items:
+            type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+        name:
+          type: string
+        url:
+          type: string
+        schedule:
+          type: string
+        timezone:
+          type: string
+        output_filename_template:
+          type: string
+        active:
+          type: boolean
+        compute_type:
+          type: string
+        input_uri:
+          type: string
+    CreateJobFromDefinition:
+      type: object
+      properties:
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+    JobFile:
+      type: object
+      properties:
+        display_name:
+          type: string
+        file_format:
+          type: string
+        file_path:
+          type: string
+    RuntimeEnvironment:
+      type: object
+      properties:
+        name:
+          type: string
+        label:
+          type: string
+        description:
+          type: string
+        file_extensions:
+          type: array
+          items:
+            type: string
+        output_formats:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        compute_types:
+          type: array
+          items:
+            type: string
+        default_compute_type:
+          type: string
+        utc_only:
+          type: boolean

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5,6 +5,9 @@ info:
   description: API for Jupyter Scheduler, a JupyterLab extension for running notebook jobs.
 servers:
   - url: /scheduler
+security:
+  - JupyterServerAuthHeader: []
+  - JupyterServerAuthToken: []
 paths:
   /jobs:
     get:
@@ -457,6 +460,18 @@ paths:
                 $ref: '#/components/schemas/Error'
 
 components:
+  securitySchemes:
+    JupyterServerAuthHeader:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: "Authentication managed by the Jupyter Server using a token provided in the Authorization header. See Jupyter Server documentation for more details."
+    JupyterServerAuthToken:
+      type: apiKey
+      in: query
+      name: token
+      description: "Authentication managed by the Jupyter Server using a token provided as a query parameter. See Jupyter Server documentation for more details."
+
   schemas:
     Error:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -101,7 +101,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-
   /jobs/{job_id}:
     get:
       summary: Get details of a specific job
@@ -184,7 +183,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-
   /job_definitions:
     get:
       summary: List all job definitions
@@ -244,7 +242,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-
     post:
       summary: Create a new job definition
       requestBody:
@@ -277,7 +274,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-
   /job_definitions/{job_definition_id}:
     get:
       summary: Get details of a specific job definition
@@ -300,7 +296,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
 
     patch:
       summary: Update a specific job definition
@@ -339,7 +334,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-
     delete:
       summary: Delete a specific job definition
       parameters:
@@ -364,7 +358,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-
   /jobs/{job_id}/download_files:
     get:
       summary: Download job files
@@ -388,7 +381,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
 
   /jobs/count:
     get:
@@ -415,7 +407,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-
   /runtime_environments:
     get:
       summary: List available runtime environments
@@ -434,7 +425,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
 
   /config:
     get:
@@ -460,7 +450,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-
   /batch/jobs:
     delete:
       summary: Batch delete jobs
@@ -480,7 +469,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
 
 components:
   schemas:
@@ -578,19 +566,17 @@ components:
         runtime_environment_parameters:
           type: object
         additionalProperties:
-            type: string
+          type: string
         output_formats:
           type: array
           items:
             type: string
         parameters:
           type: object
-        additionalProperties:
-            type: string
         tags:
           type: array
         items:
-            type: string
+          type: string
         name:
           type: string
         output_filename_template:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -358,6 +358,46 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /job_definitions/{job_definition_id}/jobs:
+    post:
+      summary: Create a job from a job definition
+      parameters:
+        - name: job_definition_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Parameters needed to create a job from this job definition
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateJobFromDefinition'
+      responses:
+        '200':
+          description: Successfully created the job from the job definition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job_id:
+                    type: string
+        '400':
+          description: Invalid input data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+
   /jobs/{job_id}/download_files:
     get:
       summary: Download job files


### PR DESCRIPTION
Adds OpenAPI specification of the current Jupyter Scheduler (v2.7.1) API contract. Documentation addition, does not change extension logic. 

This formalizes an API contract and allows users and automated tools use the specification as a reference. For example, here's a human-friendly API specification generated by Swagger.io based on the specification: https://app.swaggerhub.com/apis/andrii-i/jupyter-scheduler/2.7.1-oas3. Future PRs should add a CI step building and publishing this human-readable API specification as a part of documentation.