### PR TITLE
Updated copyright template

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,10 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import time
+
 project = "jupyter_scheduler"
-copyright = "2022, Project Jupyter"
+copyright = f"2022–{time.localtime().tm_year}, Project Jupyter"
 author = "Project Jupyter"
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Made the template of the form `2022–<Current year>`

Recompiled the documentation to confirm this change is working: 
![image](https://github.com/user-attachments/assets/943385cc-a1ec-477d-a6f8-ea2e8e2ecade)
