### PR TITLE
Check for and remove "RTC" drive prefix when returning selected file path added by the jupyter-collaboration 

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -161,7 +161,10 @@ function getSelectedFilePath(
  * Checks if path contains "RTC" drive prefix potentially added by jupyter-collaboration
  * and returns a local path removing "RTC" prefix if needed
  */
-function getLocalPath(path: string, contents: Contents.IManager): string {
+export function getLocalPath(
+  path: string,
+  contents: Contents.IManager
+): string {
   if (contents.driveName(path) === 'RTC') {
     return contents.localPath(path);
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -143,11 +143,19 @@ function getSelectedFileBaseName(widget: FileBrowser | null): string | null {
 }
 
 // Get the file name, with all parent directories, of the currently selected file.
-function getSelectedFilePath(widget: FileBrowser | null): string | null {
+function getSelectedFilePath(
+  widget: FileBrowser | null,
+  app: JupyterFrontEnd<JupyterFrontEnd.IShell, 'desktop' | 'mobile'>
+): string | null {
   const selectedItem = getSelectedItem(widget);
   if (selectedItem === null) {
     return null;
   }
+
+  if (app.serviceManager.contents.driveName(selectedItem.path) === 'RTC') {
+    return app.serviceManager.contents.localPath(selectedItem.path);
+  }
+
   return selectedItem.path;
 }
 
@@ -260,7 +268,8 @@ function activatePlugin(
     execute: async () => {
       eventLogger('file-browser.create-job');
       const widget = fileBrowserTracker.currentWidget;
-      const filePath = getSelectedFilePath(widget) ?? '';
+      const filePath = getSelectedFilePath(widget, app) ?? '';
+      console.log(filePath);
 
       // Update the job form inside the notebook jobs widget
       const newCreateModel = emptyCreateJobModel();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -142,7 +142,10 @@ function getSelectedFileBaseName(widget: FileBrowser | null): string | null {
   return parts.join('.');
 }
 
-// Get the file name, with all parent directories, of the currently selected file.
+/**
+ * Get the file name of the currently selected file with all parent directories, check
+ * for and remove "RTC" drive prefix potentially added by jupyter-collaboration.
+ */
 function getSelectedFilePath(
   widget: FileBrowser | null,
   contents: Contents.IManager
@@ -151,12 +154,18 @@ function getSelectedFilePath(
   if (selectedItem === null) {
     return null;
   }
+  return getLocalPath(selectedItem.path, contents);
+}
 
-  if (contents.driveName(selectedItem.path) === 'RTC') {
-    return contents.localPath(selectedItem.path);
+/**
+ * Checks if path contains "RTC" drive prefix potentially added by jupyter-collaboration
+ * and returns a local path removing "RTC" prefix if needed
+ */
+function getLocalPath(path: string, contents: Contents.IManager): string {
+  if (contents.driveName(path) === 'RTC') {
+    return contents.localPath(path);
   }
-
-  return selectedItem.path;
+  return path;
 }
 
 // Get the containing directory of the file at a particular path.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -145,15 +145,15 @@ function getSelectedFileBaseName(widget: FileBrowser | null): string | null {
 // Get the file name, with all parent directories, of the currently selected file.
 function getSelectedFilePath(
   widget: FileBrowser | null,
-  app: JupyterFrontEnd<JupyterFrontEnd.IShell, 'desktop' | 'mobile'>
+  contents: Contents.IManager
 ): string | null {
   const selectedItem = getSelectedItem(widget);
   if (selectedItem === null) {
     return null;
   }
 
-  if (app.serviceManager.contents.driveName(selectedItem.path) === 'RTC') {
-    return app.serviceManager.contents.localPath(selectedItem.path);
+  if (contents.driveName(selectedItem.path) === 'RTC') {
+    return contents.localPath(selectedItem.path);
   }
 
   return selectedItem.path;
@@ -268,8 +268,8 @@ function activatePlugin(
     execute: async () => {
       eventLogger('file-browser.create-job');
       const widget = fileBrowserTracker.currentWidget;
-      const filePath = getSelectedFilePath(widget, app) ?? '';
-      console.log(filePath);
+      const filePath =
+        getSelectedFilePath(widget, app.serviceManager.contents) ?? '';
 
       // Update the job form inside the notebook jobs widget
       const newCreateModel = emptyCreateJobModel();


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Scheduler!
Please fill out the following items to submit a pull request.
Please refer to our contributor's guide for more information on installation and usage:
https://jupyter-scheduler.readthedocs.io/en/latest/contributors/index.html
-->

## References

<!-- Note the issue numbers this pull request addresses (should be at least one, see the contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->
- Fixes #429 
- JupyterLab reference PR fixing inability to create files in custom drives (everytime a file path is being handled, it should be assumed there can be a drive prefix in the file name) https://github.com/jupyterlab/jupyterlab/pull/15291/files#diff-a05e6e7e60f1adc4ea4f416f51df2d1e0277a12b5c84dea329859c9ccd6aef96R412-R427
- JupyterLab work in progress PR that would remove the need for special handling of drive prefixes (won't be in JupyterLab 4.3, JupyterLab 4.4 earliest) https://github.com/jupyterlab/jupyterlab/pull/16556

## Code changes

`getSelectedFilePath` helper function now uses `serviceManager.contents` API to check if there is an added “RTC” drive name in the file path and return local path without it.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Jupyter Scheduler now works when `jupyter-collaboration` is installed.

## Backwards-incompatible changes

None
