### PR TITLE
Relax fsspec and pytz version pins allowing latest versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dependencies = [
     "pydantic>=1.10,<3",
     "sqlalchemy>=2.0,<3",
     "croniter~=1.4",
-    "pytz==2023.3",
-    "fsspec==2023.6.0",
+    "pytz>=2023.3,<=2024.2",
+    "fsspec>=2023.6.0,<=2024.10.0",
     "psutil~=5.9"
 ]
 


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Scheduler!
Please fill out the following items to submit a pull request.
Please refer to our contributor's guide for more information on installation and usage:
https://jupyter-scheduler.readthedocs.io/en/latest/contributors/index.html
-->

## References

- Fixes #555
- Fixes #540 

<!-- Note the issue numbers this pull request addresses (should be at least one, see the contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Relax fsspec and pytz version pins allowing latest versions 

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

No UI changes, users are able to install different versions of `fsspec` and `pytz` within the pinned versions range instead of only one pinned version. As a result Jupyter Scheduler can be installed in the same environment as packages that depend on new versions of `fsspec` and `pytz` such as `s3fs`.


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

## Testing

On top of automated pytest tests that cover [file copying](https://github.com/jupyter-server/jupyter-scheduler/blob/main/jupyter_scheduler/tests/test_scheduler.py) and [download](https://github.com/jupyter-server/jupyter-scheduler/blob/main/jupyter_scheduler/tests/test_job_files_manager.py) (`fsspec`) I have manually tested main user flows: creating a job, job definition with different schedules, with and without inclusion of input folder.