### PR TITLE
Add support for Python 3.13 version and remove support for Python  3.7 and 3.8 versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.10.0"
 description = "A JupyterLab extension for running notebook jobs"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
     { name = "Project Jupyter" },
 ]
@@ -22,12 +22,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "jupyter_server>=1.6,<3",


### PR DESCRIPTION
Adding support for Python 3.13 version and removing support for Python  3.7 and 3.8 versions

## References

Resolves #551 

## Code changes

Following modifications made to the **project config** in the **pyproject.toml** file:
1. Added support for Python 3.13 in the _classifiers_ config.
2. Removed support for Python 3.7 and 3.8 in the _classifiers_ config.
3. Upgraded the minimum required python version _(requires-python)_ to 3.9. 

## User-facing changes

None. 

## Backwards-incompatible changes

None Anticipated. Awaiting results from CLI tests for further evaluation. 
