### PR TITLE
Add `_update_last_activity` to the extension app

### DIFF
--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -96,11 +96,17 @@ class BaseScheduler(LoggingConfigurable):
     )
 
     def __init__(
-        self, root_dir: str, environments_manager: Type[EnvironmentManager], config=None, **kwargs
+        self,
+        root_dir: str,
+        environments_manager: Type[EnvironmentManager],
+        config=None,
+        update_last_activity=None,
+        **kwargs
     ):
         super().__init__(config=config, **kwargs)
         self.root_dir = root_dir
         self.environments_manager = environments_manager
+        self.update_last_activity = update_last_activity
 
     def create_job(self, model: CreateJob) -> str:
         """Creates a new job record, may trigger execution of the job.
@@ -405,10 +411,15 @@ class Scheduler(BaseScheduler):
         environments_manager: Type[EnvironmentManager],
         db_url: str,
         config=None,
+        update_last_activity=None,
         **kwargs,
     ):
         super().__init__(
-            root_dir=root_dir, environments_manager=environments_manager, config=config, **kwargs
+            root_dir=root_dir,
+            environments_manager=environments_manager,
+            config=config,
+            update_last_activity=update_last_activity,
+            **kwargs
         )
         self.db_url = db_url
         if self.task_runner_class:
@@ -438,6 +449,7 @@ class Scheduler(BaseScheduler):
         )
 
     def create_job(self, model: CreateJob) -> str:
+        self.update_last_activity()
         if not model.job_definition_id and not self.file_exists(model.input_uri):
             raise InputUriError(model.input_uri)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Scheduler!
Please fill out the following items to submit a pull request.
Please refer to our contributor's guide for more information on installation and usage:
https://jupyter-scheduler.readthedocs.io/en/latest/contributors/index.html
-->

## References

This addresses #563 

## Code changes

Added `_update_last_activity` to the extension app to update the `last_activity_times` [look up in the web application](https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/serverapp.py#L461-L463). Pass this method down to the scheduler so that it can be used to update the `last_activity` whenever a job is created. May want to add it elsewhere in the future, but this is a good start.

I tested it by using docker

```
FROM quay.io/jupyter/minimal-notebook:latest

ENV JUPYTER_TOKEN=token

USER root
RUN apt update -y && apt install -y gcc npm

COPY . .

RUN pip install .

EXPOSE 8888
```

I scheduled a job that ran every minute and traveled to `http://localhost:8888/api/status`, which shows something like

```
{
  "connections": 0,
  "kernels": 0,
  "last_activity": "2025-04-13T19:04:50.087961Z",
  "started": "2025-04-13T19:04:40.605374Z"
}
```

Before the change, the `last_activity` would not update with when a job is run. After the change, it is updated whenever a job is run.

