### PR TITLE
Bump psutil to v7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "croniter~=1.4",
     "pytz>=2023.3,<=2024.2",
     "fsspec>=2023.6.0,<=2025.3.2,!=2025.3.1",
-    "psutil~=5.9"
+    "psutil~=7.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
<!--
Thanks for contributing to Jupyter Scheduler!
Please fill out the following items to submit a pull request.
Please refer to our contributor's guide for more information on installation and usage:
https://jupyter-scheduler.readthedocs.io/en/latest/contributors/index.html
-->

## References

#588 

## Code changes

Modified the following line to `"psutil~=7.0"`
https://github.com/jupyter-server/jupyter-scheduler/blob/576fecfac22844656408ef5b8e9b3b150fe6cfd1/pyproject.toml#L40

## User-facing changes

No visual impact.

## Backwards-incompatible changes

None. `psutil v7.0` should be compatible with `python >=3.7`.
