### PR TITLE
bump fsspec to >= 2026.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "sqlalchemy>=2.0,<3",
     "croniter~=1.4",
     "pytz>=2023.3,<=2024.2",
-    "fsspec>=2023.6.0,<=2025.3.2,!=2025.3.1",
+    "fsspec>=2026.2.0",
     "psutil~=5.9"
 ]
 


### PR DESCRIPTION
## Problem

Downstream consumers cannot upgrade to newer versions of `fsspec` (>= 2026.2.0) because `jupyter-scheduler` pins `fsspec>=2023.6.0,<=2025.3.2,!=2025.3.1`.

## Proposed solution

Remove the upper bound on `fsspec` and set the minimum to `>=2026.2.0`.

## Code changes

Changed `fsspec>=2026.2.0`

## Testing

On top of CI, verified manually that notebook job creation, execution, and output file download work correctly with `fsspec 2026.2.0`.

## User-facing changes

None.

## Backwards-incompatible changes

The minimum required `fsspec` version is now `2026.2.0` (previously `2023.6.0`). Environments with older fsspec versions will need to upgrade.
