### PR TITLE
Remove `fsspec` version ceiling, set to `>=2025.3.2`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - uses: actions/download-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "sqlalchemy>=2.0,<3",
     "croniter~=1.4",
     "pytz>=2023.3,<=2024.2",
-    "fsspec>=2023.6.0,<=2025.3.2,!=2025.3.1",
+    "fsspec>=2026.2.0",
     "psutil~=5.9"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.11.0"
 description = "A JupyterLab extension for running jobs"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Project Jupyter" },
 ]
@@ -22,7 +22,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.11.0"
 description = "A JupyterLab extension for running jobs"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 authors = [
     { name = "Project Jupyter" },
 ]
@@ -22,6 +22,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -35,7 +36,7 @@ dependencies = [
     "sqlalchemy>=2.0,<3",
     "croniter~=1.4",
     "pytz>=2023.3,<=2024.2",
-    "fsspec>=2026.2.0",
+    "fsspec>=2025.3.2",
     "psutil~=5.9"
 ]
 


### PR DESCRIPTION
## Problem

Downstream consumers cannot upgrade to newer versions of `fsspec` (>= 2026.2.0) because `jupyter-scheduler` pins `fsspec>=2023.6.0,<=2025.3.2,!=2025.3.1`.

## Proposed solution

Remove the upper bound on `fsspec` and set the minimum to `>=2025.3.2`.

This would allow existing users to upgrade jupyter-scheduler without being forced to change their environment, while also unblocking users that need fsspec 2026.2.0.

## Code changes

Changed `fsspec>=2025.3.2`.

## Testing

On top of CI, verified manually that notebook job creation, execution, and output file download work correctly with `fsspec 2026.2.0`.

## User-facing changes

None.

## Backwards-incompatible changes

The minimum required `fsspec` version is now `2025.3.2` (previously `2023.6.0`). Environments with older `fsspec` versions will need to upgrade.
