### PR TITLE
Migrate from pydantic v1 to v2 API

### DIFF
--- a/jupyter_scheduler/backend_registry.py
+++ b/jupyter_scheduler/backend_registry.py
@@ -1,10 +1,11 @@
 import logging
 from typing import Any, Dict, List, Optional, Type
 
+from pydantic import BaseModel
+
 from jupyter_scheduler.backends import BackendConfig, DescribeBackendResponse
 from jupyter_scheduler.environments import EnvironmentManager
 from jupyter_scheduler.orm import create_tables
-from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/jupyter_scheduler/backend_registry.py
+++ b/jupyter_scheduler/backend_registry.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Type
 from jupyter_scheduler.backends import BackendConfig, DescribeBackendResponse
 from jupyter_scheduler.environments import EnvironmentManager
 from jupyter_scheduler.orm import create_tables
-from jupyter_scheduler.pydantic_v1 import BaseModel
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/jupyter_scheduler/backends.py
+++ b/jupyter_scheduler/backends.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from jupyter_scheduler.base_backend import BaseBackend
 from jupyter_scheduler.models import OutputFormat
-from jupyter_scheduler.pydantic_v1 import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 JUPYTER_SERVER_NB_BACKEND_ID = "jupyter_server_nb"
 JUPYTER_SERVER_PY_BACKEND_ID = "jupyter_server_py"
@@ -37,8 +37,7 @@ class DescribeBackendResponse(BaseModel):
     file_extensions: List[str]
     output_formats: List[OutputFormat]
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class JupyterServerNotebookBackend(BaseBackend):

--- a/jupyter_scheduler/backends.py
+++ b/jupyter_scheduler/backends.py
@@ -1,8 +1,9 @@
 from typing import Any, Dict, List, Optional
 
+from pydantic import BaseModel, ConfigDict, Field
+
 from jupyter_scheduler.base_backend import BaseBackend
 from jupyter_scheduler.models import OutputFormat
-from pydantic import BaseModel, ConfigDict, Field
 
 JUPYTER_SERVER_NB_BACKEND_ID = "jupyter_server_nb"
 JUPYTER_SERVER_PY_BACKEND_ID = "jupyter_server_py"

--- a/jupyter_scheduler/executors.py
+++ b/jupyter_scheduler/executors.py
@@ -40,7 +40,7 @@ class ExecutionManager(ABC):
         if self._model is None:
             with self.db_session() as session:
                 job = session.query(Job).filter(Job.job_id == self.job_id).first()
-                self._model = DescribeJob.from_orm(job)
+                self._model = DescribeJob.model_validate(job)
         return self._model
 
     @property

--- a/jupyter_scheduler/handlers.py
+++ b/jupyter_scheduler/handlers.py
@@ -31,7 +31,7 @@ from jupyter_scheduler.models import (
     UpdateJob,
     UpdateJobDefinition,
 )
-from jupyter_scheduler.pydantic_v1 import ValidationError
+from pydantic import ValidationError
 from jupyter_scheduler.scheduler import BaseScheduler
 
 logger = logging.getLogger(__name__)
@@ -124,7 +124,7 @@ class JobDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
                     500, f"Unexpected error while getting job definition details: {e}"
                 ) from e
             else:
-                self.finish(job_definition.json())
+                self.finish(job_definition.model_dump_json())
         else:
             create_time = self.get_query_argument("create_time", None)
             sort_by = compute_sort_model(self.get_query_arguments("sort_by"))
@@ -153,7 +153,7 @@ class JobDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
                     500, f"Unexpected error while getting job definition list: {e}"
                 ) from e
             else:
-                self.finish(list_response.json(exclude_none=True))
+                self.finish(list_response.model_dump_json(exclude_none=True))
 
     @authenticated
     async def post(self):
@@ -238,7 +238,7 @@ class JobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
                 self.log.exception(e)
                 raise HTTPError(500, f"Unexpected error while getting job details: {e}") from e
             else:
-                self.finish(job.json())
+                self.finish(job.model_dump_json())
         else:
             status = self.get_query_argument("status", None)
             start_time = self.get_query_argument("start_time", None)
@@ -295,7 +295,7 @@ class JobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
                 self.log.exception(e)
                 raise HTTPError(500, f"Unexpected error while getting jobs list: {e}") from e
             else:
-                self.finish(list_jobs_response.json(exclude_none=True))
+                self.finish(list_jobs_response.model_dump_json(exclude_none=True))
 
     @authenticated
     async def post(self):
@@ -456,7 +456,7 @@ class RuntimeEnvironmentsHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHan
 
         response = []
         for environment in environments:
-            env = environment.dict()
+            env = environment.model_dump()
             formats = env["output_formats"]
             env["output_formats"] = [{"id": f, "label": output_formats[f]} for f in formats]
             response.append(env)
@@ -522,7 +522,7 @@ class BackendsHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
                 raise HTTPError(500, "Backend registry not initialized")
 
             backends = registry.describe_backends()
-            self.finish(json.dumps([b.dict() for b in backends]))
+            self.finish(json.dumps([b.model_dump() for b in backends]))
         except SchedulerError as e:
             self.log.exception(e)
             raise HTTPError(500, f"Unexpected error while listing backends: {e}") from e

--- a/jupyter_scheduler/handlers.py
+++ b/jupyter_scheduler/handlers.py
@@ -6,6 +6,7 @@ from typing import Optional
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.extension.handler import ExtensionHandlerMixin
 from jupyter_server.utils import ensure_async
+from pydantic import ValidationError
 from tornado.web import HTTPError, authenticated
 
 from jupyter_scheduler.backend_registry import BackendInstance, BackendRegistry
@@ -31,7 +32,6 @@ from jupyter_scheduler.models import (
     UpdateJob,
     UpdateJobDefinition,
 )
-from pydantic import ValidationError
 from jupyter_scheduler.scheduler import BaseScheduler
 
 logger = logging.getLogger(__name__)

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, model_validator
 def _coerce_str(v):
     return str(v) if v is not None else v
 
+
 CoercedStr = Annotated[str, BeforeValidator(_coerce_str)]
 
 Tags = List[str]
@@ -105,7 +106,7 @@ class CreateJob(BaseModel):
     package_input_folder: Optional[bool] = None
     backend_id: Optional[str] = None
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def compute_input_filename(cls, values) -> Dict:
         if not values.get("input_filename") and values.get("input_uri"):
@@ -236,7 +237,7 @@ class CreateJobDefinition(BaseModel):
     package_input_folder: Optional[bool] = None
     backend_id: Optional[str] = None
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def compute_input_filename(cls, values) -> Dict:
         if not values.get("input_filename") and "input_uri" in values and values.get("input_uri"):

--- a/jupyter_scheduler/models.py
+++ b/jupyter_scheduler/models.py
@@ -1,8 +1,14 @@
 import os
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Annotated, Dict, List, Optional, Union
 
-from jupyter_scheduler.pydantic_v1 import BaseModel, root_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, model_validator
+
+
+def _coerce_str(v):
+    return str(v) if v is not None else v
+
+CoercedStr = Annotated[str, BeforeValidator(_coerce_str)]
 
 Tags = List[str]
 EnvironmentParameterValues = Union[int, float, bool, str]
@@ -33,23 +39,23 @@ class RuntimeEnvironment(BaseModel):
     description: str
     file_extensions: List[str]  # Supported input file types
     output_formats: List[str]  # Supported output formats
-    metadata: Optional[Dict[str, str]]  # Optional metadata
-    compute_types: Optional[List[str]]
-    default_compute_type: Optional[str]  # Should be a member of the compute_types list
-    utc_only: Optional[bool]
+    metadata: Optional[Dict[str, str]] = None  # Optional metadata
+    compute_types: Optional[List[str]] = None
+    default_compute_type: Optional[str] = None  # Should be a member of the compute_types list
+    utc_only: Optional[bool] = None
 
     def __str__(self):
-        return self.json()
+        return self.model_dump_json()
 
 
 class EmailNotifications(BaseModel):
-    on_start: Optional[List[str]]
-    on_success: Optional[List[str]]
-    on_failure: Optional[List[str]]
+    on_start: Optional[List[str]] = None
+    on_success: Optional[List[str]] = None
+    on_failure: Optional[List[str]] = None
     no_alert_for_skipped_runs: bool = True
 
     def __str__(self) -> str:
-        return self.json()
+        return self.model_dump_json()
 
 
 class Status(str, Enum):
@@ -85,13 +91,13 @@ class CreateJob(BaseModel):
     """Defines the model for creating a new job"""
 
     input_uri: str
-    input_filename: str = None
+    input_filename: Optional[str] = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]] = None
     output_formats: Optional[List[str]] = None
     idempotency_token: Optional[str] = None
     job_definition_id: Optional[str] = None
-    parameters: Optional[Dict[str, str]] = None
+    parameters: Optional[Dict[str, Union[str, int, float, bool]]] = None
     tags: Optional[Tags] = None
     name: str
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
@@ -99,9 +105,10 @@ class CreateJob(BaseModel):
     package_input_folder: Optional[bool] = None
     backend_id: Optional[str] = None
 
-    @root_validator
+    @model_validator(mode='before')
+    @classmethod
     def compute_input_filename(cls, values) -> Dict:
-        if not values["input_filename"] and values["input_uri"]:
+        if not values.get("input_filename") and values.get("input_uri"):
             values["input_filename"] = os.path.basename(values["input_uri"])
 
         return values
@@ -137,13 +144,13 @@ class JobFile(BaseModel):
 
 
 class DescribeJob(BaseModel):
-    input_filename: str = None
+    input_filename: Optional[str] = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]] = None
     output_formats: Optional[List[str]] = None
     idempotency_token: Optional[str] = None
     job_definition_id: Optional[str] = None
-    parameters: Optional[Dict[str, str]] = None
+    parameters: Optional[Dict[str, Union[str, int, float, bool]]] = None
     tags: Optional[Tags] = None
     name: str
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
@@ -162,8 +169,7 @@ class DescribeJob(BaseModel):
     packaged_files: Optional[List[str]] = []
     backend_id: Optional[str] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class SortDirection(Enum):
@@ -216,11 +222,11 @@ class DeleteJob(BaseModel):
 
 class CreateJobDefinition(BaseModel):
     input_uri: str
-    input_filename: str = None
+    input_filename: Optional[str] = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]] = None
     output_formats: Optional[List[str]] = None
-    parameters: Optional[Dict[str, str]] = None
+    parameters: Optional[Dict[str, Union[str, int, float, bool]]] = None
     tags: Optional[Tags] = None
     name: str
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
@@ -230,20 +236,21 @@ class CreateJobDefinition(BaseModel):
     package_input_folder: Optional[bool] = None
     backend_id: Optional[str] = None
 
-    @root_validator
+    @model_validator(mode='before')
+    @classmethod
     def compute_input_filename(cls, values) -> Dict:
-        if not values["input_filename"] and "input_uri" in values and values["input_uri"]:
+        if not values.get("input_filename") and "input_uri" in values and values.get("input_uri"):
             values["input_filename"] = os.path.basename(values["input_uri"])
 
         return values
 
 
 class DescribeJobDefinition(BaseModel):
-    input_filename: str = None
+    input_filename: Optional[str] = None
     runtime_environment_name: str
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]] = None
     output_formats: Optional[List[str]] = None
-    parameters: Optional[Dict[str, str]] = None
+    parameters: Optional[Dict[str, Union[str, int, float, bool]]] = None
     tags: Optional[Tags] = None
     name: str
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
@@ -258,15 +265,14 @@ class DescribeJobDefinition(BaseModel):
     packaged_files: Optional[List[str]] = []
     backend_id: Optional[str] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UpdateJobDefinition(BaseModel):
-    runtime_environment_name: Optional[str]
-    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    runtime_environment_name: Optional[str] = None
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]] = None
     output_formats: Optional[List[str]] = None
-    parameters: Optional[Dict[str, str]] = None
+    parameters: Optional[Dict[str, Union[str, int, float, bool]]] = None
     tags: Optional[Tags] = None
     name: Optional[str] = None
     url: Optional[str] = None
@@ -284,17 +290,17 @@ class ListJobDefinitionsQuery(BaseModel):
     tags: Optional[Tags] = None
     sort_by: List[SortField] = [DEFAULT_SORT]
     max_items: Optional[int] = DEFAULT_MAX_ITEMS
-    next_token: Optional[str] = None
+    next_token: Optional[CoercedStr] = None
 
 
 class ListJobDefinitionsResponse(BaseModel):
     job_definitions: List[DescribeJobDefinition] = []
     total_count: int = 0
-    next_token: Optional[str] = None
+    next_token: Optional[CoercedStr] = None
 
 
 class CreateJobFromDefinition(BaseModel):
-    parameters: Optional[Dict[str, str]] = None
+    parameters: Optional[Dict[str, Union[str, int, float, bool]]] = None
 
 
 class JobFeature(str, Enum):

--- a/jupyter_scheduler/orm.py
+++ b/jupyter_scheduler/orm.py
@@ -54,7 +54,7 @@ class EmailNotificationType(types.TypeDecorator):
             return None
 
         if isinstance(value, EmailNotifications):
-            return json.dumps(value.dict(exclude_none=True))
+            return json.dumps(value.model_dump(exclude_none=True))
         else:
             return value
 

--- a/jupyter_scheduler/pydantic_v1/__init__.py
+++ b/jupyter_scheduler/pydantic_v1/__init__.py
@@ -1,6 +1,0 @@
-# expose Pydantic v1 API, regardless of Pydantic version in current env
-
-try:
-    from pydantic.v1 import *
-except ImportError:
-    from pydantic import *

--- a/jupyter_scheduler/pydantic_v1/dataclasses.py
+++ b/jupyter_scheduler/pydantic_v1/dataclasses.py
@@ -1,4 +1,0 @@
-try:
-    from pydantic.v1.dataclasses import *
-except ImportError:
-    from pydantic.dataclasses import *

--- a/jupyter_scheduler/pydantic_v1/main.py
+++ b/jupyter_scheduler/pydantic_v1/main.py
@@ -1,4 +1,0 @@
-try:
-    from pydantic.v1.main import *
-except ImportError:
-    from pydantic.main import *

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -487,13 +487,13 @@ class Scheduler(BaseScheduler):
             job = Job(
                 job_id=full_job_id,
                 backend_id=self.backend_id,
-                **model.dict(exclude_none=True, exclude={"input_uri", "backend_id"}),
+                **model.model_dump(exclude_none=True, exclude={"input_uri", "backend_id"}),
             )
 
             session.add(job)
             session.commit()
 
-            staging_paths = self.get_staging_paths(DescribeJob.from_orm(job))
+            staging_paths = self.get_staging_paths(DescribeJob.model_validate(job))
             if model.package_input_folder:
                 copied_files = self.copy_input_folder(model.input_uri, staging_paths["input"])
                 input_notebook_filename = os.path.basename(model.input_uri)
@@ -531,7 +531,7 @@ class Scheduler(BaseScheduler):
 
     def update_job(self, job_id: str, model: UpdateJob):
         with self.db_session() as session:
-            session.query(Job).filter(Job.job_id == job_id).update(model.dict(exclude_none=True))
+            session.query(Job).filter(Job.job_id == job_id).update(model.model_dump(exclude_none=True))
             session.commit()
 
     def list_jobs(self, query: ListJobsQuery) -> ListJobsResponse:
@@ -566,7 +566,7 @@ class Scheduler(BaseScheduler):
 
         jobs_list = []
         for job in jobs:
-            model = DescribeJob.from_orm(job)
+            model = DescribeJob.model_validate(job)
             self.add_job_files(model=model)
             jobs_list.append(model)
 
@@ -589,7 +589,7 @@ class Scheduler(BaseScheduler):
         with self.db_session() as session:
             job_record = session.query(Job).filter(Job.job_id == job_id).one()
 
-        model = DescribeJob.from_orm(job_record)
+        model = DescribeJob.model_validate(job_record)
         if job_files:
             self.add_job_files(model=model)
 
@@ -601,7 +601,7 @@ class Scheduler(BaseScheduler):
             if Status(job_record.status) == Status.IN_PROGRESS:
                 self.stop_job(job_id)
 
-            staging_paths = self.get_staging_paths(DescribeJob.from_orm(job_record))
+            staging_paths = self.get_staging_paths(DescribeJob.model_validate(job_record))
             if staging_paths:
                 path = os.path.dirname(next(iter(staging_paths.values())))
                 if os.path.exists(path):
@@ -613,7 +613,7 @@ class Scheduler(BaseScheduler):
     def stop_job(self, job_id):
         with self.db_session() as session:
             job_record = session.query(Job).filter(Job.job_id == job_id).one()
-            job = DescribeJob.from_orm(job_record)
+            job = DescribeJob.model_validate(job_record)
             process_id = job_record.pid
             if process_id and job.status == Status.IN_PROGRESS:
                 session.query(Job).filter(Job.job_id == job_id).update({"status": Status.STOPPING})
@@ -635,7 +635,7 @@ class Scheduler(BaseScheduler):
             if not self.file_exists(model.input_uri):
                 raise InputUriError(model.input_uri)
 
-            job_definition = JobDefinition(**model.dict(exclude_none=True, exclude={"input_uri"}))
+            job_definition = JobDefinition(**model.model_dump(exclude_none=True, exclude={"input_uri"}))
             session.add(job_definition)
             session.commit()
 
@@ -643,7 +643,7 @@ class Scheduler(BaseScheduler):
             job_definition_id = job_definition.job_definition_id
             job_definition_schedule = job_definition.schedule
 
-            staging_paths = self.get_staging_paths(DescribeJobDefinition.from_orm(job_definition))
+            staging_paths = self.get_staging_paths(DescribeJobDefinition.model_validate(job_definition))
             if model.package_input_folder:
                 copied_files = self.copy_input_folder(model.input_uri, staging_paths["input"])
                 input_notebook_filename = os.path.basename(model.input_uri)
@@ -665,7 +665,7 @@ class Scheduler(BaseScheduler):
                 JobDefinition.job_definition_id == job_definition_id
             )
 
-            describe_job_definition = DescribeJobDefinition.from_orm(filtered_query.one())
+            describe_job_definition = DescribeJobDefinition.model_validate(filtered_query.one())
 
             if (
                 (
@@ -682,7 +682,7 @@ class Scheduler(BaseScheduler):
             ):
                 return
 
-            updates = model.dict(exclude_none=True, exclude={"input_uri"})
+            updates = model.model_dump(exclude_none=True, exclude={"input_uri"})
 
             if model.input_uri:
                 new_input_filename = os.path.basename(model.input_uri)
@@ -733,7 +733,7 @@ class Scheduler(BaseScheduler):
                 .one()
             )
 
-        return DescribeJobDefinition.from_orm(job_definition)
+        return DescribeJobDefinition.model_validate(job_definition)
 
     def list_job_definitions(self, query: ListJobDefinitionsQuery) -> ListJobDefinitionsResponse:
         with self.db_session() as session:
@@ -767,7 +767,7 @@ class Scheduler(BaseScheduler):
 
         list_response = ListJobDefinitionsResponse(
             job_definitions=[
-                DescribeJobDefinition.from_orm(definition) for definition in definitions or []
+                DescribeJobDefinition.model_validate(definition) for definition in definitions or []
             ],
             next_token=next_token,
             total_count=total,
@@ -780,8 +780,8 @@ class Scheduler(BaseScheduler):
         definition = self.get_job_definition(job_definition_id)
         if definition:
             input_uri = self.get_staging_paths(definition)["input"]
-            attributes = definition.dict(exclude={"schedule", "timezone"}, exclude_none=True)
-            attributes = {**attributes, **model.dict(exclude_none=True), "input_uri": input_uri}
+            attributes = definition.model_dump(exclude={"schedule", "timezone"}, exclude_none=True)
+            attributes = {**attributes, **model.model_dump(exclude_none=True), "input_uri": input_uri}
             job_id = self.create_job(CreateJob(**attributes))
 
         return job_id

--- a/jupyter_scheduler/scheduler.py
+++ b/jupyter_scheduler/scheduler.py
@@ -531,7 +531,9 @@ class Scheduler(BaseScheduler):
 
     def update_job(self, job_id: str, model: UpdateJob):
         with self.db_session() as session:
-            session.query(Job).filter(Job.job_id == job_id).update(model.model_dump(exclude_none=True))
+            session.query(Job).filter(Job.job_id == job_id).update(
+                model.model_dump(exclude_none=True)
+            )
             session.commit()
 
     def list_jobs(self, query: ListJobsQuery) -> ListJobsResponse:
@@ -635,7 +637,9 @@ class Scheduler(BaseScheduler):
             if not self.file_exists(model.input_uri):
                 raise InputUriError(model.input_uri)
 
-            job_definition = JobDefinition(**model.model_dump(exclude_none=True, exclude={"input_uri"}))
+            job_definition = JobDefinition(
+                **model.model_dump(exclude_none=True, exclude={"input_uri"})
+            )
             session.add(job_definition)
             session.commit()
 
@@ -643,7 +647,9 @@ class Scheduler(BaseScheduler):
             job_definition_id = job_definition.job_definition_id
             job_definition_schedule = job_definition.schedule
 
-            staging_paths = self.get_staging_paths(DescribeJobDefinition.model_validate(job_definition))
+            staging_paths = self.get_staging_paths(
+                DescribeJobDefinition.model_validate(job_definition)
+            )
             if model.package_input_folder:
                 copied_files = self.copy_input_folder(model.input_uri, staging_paths["input"])
                 input_notebook_filename = os.path.basename(model.input_uri)
@@ -781,7 +787,11 @@ class Scheduler(BaseScheduler):
         if definition:
             input_uri = self.get_staging_paths(definition)["input"]
             attributes = definition.model_dump(exclude={"schedule", "timezone"}, exclude_none=True)
-            attributes = {**attributes, **model.model_dump(exclude_none=True), "input_uri": input_uri}
+            attributes = {
+                **attributes,
+                **model.model_dump(exclude_none=True),
+                "input_uri": input_uri,
+            }
             job_id = self.create_job(CreateJob(**attributes))
 
         return job_id

--- a/jupyter_scheduler/task_runner.py
+++ b/jupyter_scheduler/task_runner.py
@@ -12,7 +12,7 @@ from traitlets.config import LoggingConfigurable
 
 from jupyter_scheduler.models import CreateJob, UpdateJobDefinition
 from jupyter_scheduler.orm import JobDefinition, declarative_base
-from jupyter_scheduler.pydantic_v1 import BaseModel
+from pydantic import BaseModel, ConfigDict
 from jupyter_scheduler.utils import (
     compute_next_run_time,
     get_localized_timestamp,
@@ -38,8 +38,7 @@ class DescribeJobDefinitionCache(BaseModel):
     timezone: Optional[str] = None
     schedule: str
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UpdateJobDefinitionCache(BaseModel):
@@ -105,7 +104,7 @@ class Cache:
     def load(self, models: List[DescribeJobDefinitionCache]):
         with self.session() as session:
             for model in models:
-                session.add(JobDefinitionCache(**model.dict()))
+                session.add(JobDefinitionCache(**model.model_dump()))
             session.commit()
 
     def get(self, job_definition_id: str) -> DescribeJobDefinitionCache:
@@ -117,20 +116,20 @@ class Cache:
             )
 
         if definition:
-            return DescribeJobDefinitionCache.from_orm(definition)
+            return DescribeJobDefinitionCache.model_validate(definition)
         else:
             return None
 
     def put(self, model: DescribeJobDefinitionCache):
         with self.session() as session:
-            session.add(JobDefinitionCache(**model.dict()))
+            session.add(JobDefinitionCache(**model.model_dump()))
             session.commit()
 
     def update(self, job_definition_id: str, model: UpdateJobDefinitionCache):
         with self.session() as session:
             session.query(JobDefinitionCache).filter(
                 JobDefinitionCache.job_definition_id == job_definition_id
-            ).update(model.dict(exclude_none=True))
+            ).update(model.model_dump(exclude_none=True))
             session.commit()
 
     def delete(self, job_definition_id: str):
@@ -285,7 +284,7 @@ class TaskRunner(BaseTaskRunner):
             input_uri = self.scheduler.get_staging_paths(definition)["input"]
             self.scheduler.create_job(
                 CreateJob(
-                    **definition.dict(exclude={"schedule", "timezone"}, exclude_none=True),
+                    **definition.model_dump(exclude={"schedule", "timezone"}, exclude_none=True),
                     input_uri=input_uri,
                 )
             )

--- a/jupyter_scheduler/task_runner.py
+++ b/jupyter_scheduler/task_runner.py
@@ -6,13 +6,13 @@ from typing import List, Optional
 
 import traitlets
 from jupyter_server.transutils import _i18n
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy import Boolean, Column, Integer, String, create_engine
 from sqlalchemy.orm import sessionmaker
 from traitlets.config import LoggingConfigurable
 
 from jupyter_scheduler.models import CreateJob, UpdateJobDefinition
 from jupyter_scheduler.orm import JobDefinition, declarative_base
-from pydantic import BaseModel, ConfigDict
 from jupyter_scheduler.utils import (
     compute_next_run_time,
     get_localized_timestamp,

--- a/jupyter_scheduler/tests/test_scheduler.py
+++ b/jupyter_scheduler/tests/test_scheduler.py
@@ -182,13 +182,13 @@ def load_job_definitions(jp_scheduler_db):
 )
 def test_list_job_definitions(jp_scheduler, load_job_definitions, list_query, expected_response):
     list_response = jp_scheduler.list_job_definitions(ListJobDefinitionsQuery(**list_query))
-    response = list_response.dict(exclude_none=True)
+    response = list_response.model_dump(exclude_none=True)
     assert expected_response == response
 
 
 def test_get_job_definition(jp_scheduler, load_job_definitions):
     definition = jp_scheduler.get_job_definition(job_definition_1["job_definition_id"])
-    assert job_definition_1 == definition.dict(exclude_none=True)
+    assert job_definition_1 == definition.model_dump(exclude_none=True)
 
 
 def test_pause_jobs(jp_scheduler, load_job_definitions, jp_scheduler_db):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jupyter_server>=1.6,<3",
     "traitlets~=5.0",
     "nbconvert~=7.0",
-    "pydantic>=1.10,<3",
+    "pydantic>=2.0,<3",
     "sqlalchemy>=2.0,<3",
     "croniter~=1.4",
     "pytz>=2023.3,<=2024.2",


### PR DESCRIPTION
## Motivation

The `pydantic_v1` compatibility shim imports from `pydantic.v1`, which is deprecated and will be removed in a future pydantic release. On Python 3.14+, the v1 compat layer already throws `ConfigError` on import, making `jupyter-scheduler` incompatible with newer Python versions.

This PR removes the shim entirely and migrates all code to native pydantic v2 API.

## Changes

### Removed
- `jupyter_scheduler/pydantic_v1/` — the entire v1 compatibility shim (3 files)

### Updated (9 files)
- `@root_validator` → `@model_validator(mode='before')` (2 instances)
- `class Config: orm_mode=True` → `model_config=ConfigDict(from_attributes=True)` (4 instances)
- `.dict()` → `.model_dump()`, `.json()` → `.model_dump_json()` (30+ instances)
- `.from_orm()` → `.model_validate()` (11 instances)
- `Optional[X]` fields now have explicit `= None` defaults (required by pydantic v2)
- Added `CoercedStr` type for backward-compatible int-to-str coercion
- Broadened `parameters` dict value type to accept int/float/bool
- `pydantic>=1.10,<3` → `pydantic>=2.0,<3`

## Testing
- 126 tests collected, 124 passed on Python 3.14.0 + pydantic 2.12.5
- 2 failures are pre-existing Windows path separator issues (unrelated to this PR)