### PR TITLE
Remove psutil version ceiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "croniter~=1.4",
     "pytz>=2023.3,<=2024.2",
     "fsspec>=2025.3.2",
-    "psutil~=5.9"
+    "psutil>=5.9"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #588

## Problem

`psutil~=5.9` caps psutil below 6.0. psutil builds for Python 3.13 start at 6.0.0 (conda-forge has no py313 builds of any 5.9.x release), so environments on Python 3.13 cannot resolve `jupyter-scheduler`, and the ceiling also blocks co-installation with anything that requires `psutil>=6`.

## Changes

`psutil>=5.9` in `pyproject.toml`. psutil is used in one place, `Scheduler.stop_job` (`Process()`, `children(recursive=True)`, `pid`, `kill()`), stable API across psutil 5 through 7.

## Testing

Full test suite passes with psutil 7.2.2 (latest) on Python 3.12. Verified `stop_job` finds and kills the job's child process on psutil 7.2.2 with Python 3.13.7, and the extension builds, loads, and serves scheduler API requests in JupyterLab on the same versions.
