### PR TITLE
Bump RTD Node.js to 22 and pyupgrade to v3.21.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         files: \.py$
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    nodejs: "18"
+    nodejs: "22"
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
## Problem

Two infrastructure checks fail on any PR to `2.x`:

- Read the Docs: the build runs `pip install .[docs]`, whose isolated build environment resolves `jupyterlab~=4.0` (from `build-system.requires`) to the current 4.x release, and its labextension builder now requires Node.js `^20.19.0 || >=22.12.0`. `.readthedocs.yml` pins `nodejs: "18"`, so the build fails with "Please upgrade Node.js". Previous successful build was before the requirement was raised.
- pre-commit.ci: builds hook environments on Python 3.14 where pyupgrade v3.15.1 crashes (`TypeError: cannot use a bytes pattern on a string-like object` in `tokenize.cookie_re`). Fixed by updating pyupgrade to latest version which vendors `cookie_re`.

## Changes

`.readthedocs.yml`: `nodejs: "18"` to `"22"`. `.pre-commit-config.yaml`: pyupgrade `v3.15.1` to `v3.21.2`.